### PR TITLE
Use Ilford Spring Cloud BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>2.3.0.BUILD-SNAPSHOT</version>
+		<version>3.0.0.BUILD-SNAPSHOT</version>
 		<relativePath/><!-- lookup parent from repository -->
 	</parent>
 
@@ -50,17 +50,11 @@
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<spring-cloud-commons.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-commons.version>
-		<spring-cloud-bus.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-bus.version>
+		<spring-cloud.version>2020.0.0-SNAPSHOT</spring-cloud.version>
 		<spring-cloud-sleuth.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
-		<spring-cloud-stream.version>Ivyland.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<zipkin-gcp.version>0.16.0</zipkin-gcp.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>
-		<spring-javaformat-checkstyle.version>0.0.21</spring-javaformat-checkstyle.version>
-		<puppycrawl-tools-checkstyle.version>8.32</puppycrawl-tools-checkstyle.version>
-		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
-		<spring-cloud-build-tools.version>3.0.0-SNAPSHOT</spring-cloud-build-tools.version>
 	</properties>
 
 	<dependencyManagement>
@@ -74,14 +68,7 @@
 				<scope>import</scope>
 			</dependency>
 
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-commons-dependencies</artifactId>
-				<version>${spring-cloud-commons.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-
+			<!-- TODO: remove after upgrading to latest Sleuth -->
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-sleuth-dependencies</artifactId>
@@ -92,24 +79,10 @@
 
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-dependencies</artifactId>
-				<version>${spring-cloud-stream.version}</version>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-config-dependencies</artifactId>
-				<version>${spring-cloud-commons.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-bus</artifactId>
-				<version>${spring-cloud-bus.version}</version>
 			</dependency>
 
 			<dependency>
@@ -189,13 +162,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<dependencies>
-					<dependency>
-						<groupId>org.springframework.cloud</groupId>
-						<artifactId>spring-cloud-build-tools</artifactId>
-						<version>${spring-cloud-build-tools.version}</version>
-					</dependency>
-				</dependencies>
 				<executions>
 					<execution>
 						<id>checkstyle-validation</id>

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -57,7 +57,6 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
 import org.springframework.cloud.sleuth.autoconfig.SleuthProperties;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
-import org.springframework.cloud.sleuth.log.SleuthLogAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
@@ -86,7 +85,6 @@ public class StackdriverTraceAutoConfigurationTests {
 					StackdriverTraceAutoConfiguration.class,
 					GcpContextAutoConfiguration.class,
 					TraceAutoConfiguration.class,
-					SleuthLogAutoConfiguration.class,
 					RefreshAutoConfiguration.class))
 			.withUserConfiguration(StackdriverTraceAutoConfigurationTests.MockConfiguration.class)
 			.withPropertyValues("spring.cloud.gcp.project-id=proj",

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -20,6 +20,12 @@
 
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
+
+		<!-- Checkstyle version settings. Keep in sync with ../pom.xml -->
+		<spring-cloud-build-tools.version>3.0.0-SNAPSHOT</spring-cloud-build-tools.version>
+		<puppycrawl-tools-checkstyle.version>8.32</puppycrawl-tools-checkstyle.version>
+		<spring-javaformat-checkstyle.version>0.0.9</spring-javaformat-checkstyle.version>
+		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
 	</properties>
 
 	<modules>
@@ -62,6 +68,24 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-checkstyle-plugin</artifactId>
+						<version>${maven-checkstyle-plugin.version}</version>
+						<dependencies>
+							<dependency>
+								<groupId>com.puppycrawl.tools</groupId>
+								<artifactId>checkstyle</artifactId>
+								<version>${puppycrawl-tools-checkstyle.version}</version>
+							</dependency>
+							<dependency>
+								<groupId>io.spring.javaformat</groupId>
+								<artifactId>spring-javaformat-checkstyle</artifactId>
+								<version>0.0.9</version>
+							</dependency>
+							<dependency>
+								<groupId>org.springframework.cloud</groupId>
+								<artifactId>spring-cloud-build-tools</artifactId>
+								<version>${spring-cloud-build-tools.version}</version>
+							</dependency>
+						</dependencies>
 						<executions>
 							<execution>
 								<id>checkstyle-validation</id>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.5.BUILD-SNAPSHOT</version>
+		<version>2.3.0.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 
@@ -20,9 +20,6 @@
 
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
-		<spring-cloud-build-tools.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-build-tools.version>
-		<puppycrawl-tools-checkstyle.version>8.18</puppycrawl-tools-checkstyle.version>
-		<maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
 	</properties>
 
 	<modules>
@@ -65,24 +62,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-checkstyle-plugin</artifactId>
-						<version>${maven-checkstyle-plugin.version}</version>
-						<dependencies>
-							<dependency>
-								<groupId>com.puppycrawl.tools</groupId>
-								<artifactId>checkstyle</artifactId>
-								<version>${puppycrawl-tools-checkstyle.version}</version>
-							</dependency>
-							<dependency>
-								<groupId>io.spring.javaformat</groupId>
-								<artifactId>spring-javaformat-checkstyle</artifactId>
-								<version>0.0.9</version>
-							</dependency>
-							<dependency>
-								<groupId>org.springframework.cloud</groupId>
-								<artifactId>spring-cloud-build-tools</artifactId>
-								<version>${spring-cloud-build-tools.version}</version>
-							</dependency>
-						</dependencies>
 						<executions>
 							<execution>
 								<id>checkstyle-validation</id>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/java/com/example/CloudSqlJpaSampleApplicationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/java/com/example/CloudSqlJpaSampleApplicationTests.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.boot.test.system.OutputCaptureRule;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,7 +60,7 @@ public class CloudSqlJpaSampleApplicationTests {
 	 * Used to check exception messages and types.
 	 */
 	@Rule
-	public OutputCapture outputCapture = new OutputCapture();
+	public OutputCaptureRule outputCapture = new OutputCaptureRule();
 
 	@Test
 	public void basicTest() throws Exception {


### PR DESCRIPTION
This PR upgrades the project to Ilford.
Since Spring Cloud GCP is no longer included in the Spring Cloud BOM for Ilford, we can actually use the Spring BOM ourselves in our parent POM.

The version of Sleuth is being overwritten to the old one because the new one causes our integration tests to fail.