### PR TITLE
tests: Renames and enables all integration tests

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 
 jobs:
   unitTests:
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -21,6 +24,7 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Unit Tests
+      continue-on-error: true
       run: |
         ./mvnw \
           --fail-at-end \
@@ -29,12 +33,33 @@ jobs:
           --show-version \
           --define maven.javadoc.skip=true \
           test
+    - name: Archive logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: Test logs - ${{ matrix.it}}
+        path: "**/target/surefire-reports/*"
 
   integrationTests:
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp'
-    needs: unitTests
+    if: |
+      github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' &&
+       (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        it:
+          - bigquery
+          - config
+          - datastore
+          - firestore
+          - logging
+          - kotlin
+          # - pubsub # currently not working
+          # - pubsub-emulator # not sure if this actually does anything?
+          - secretmanager
+          - spanner
+          - storage
+          - trace
+          - vision
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
@@ -53,7 +78,13 @@ jobs:
           project_id: spring-cloud-gcp-ci
           service_account_key: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY }}
           export_default_credentials: true
+      - name: install pubsub-emulator
+        if: ${{ matrix.it }} == 'pubsub-emulator'
+        run: |
+          gcloud components install pubsub-emulator && \
+            gcloud components update
       - name: Integration Tests
+        continue-on-error: true
         run: |
           ./mvnw \
             --batch-mode \
@@ -62,5 +93,10 @@ jobs:
             --define test="**/*IntegrationTest*" \
             --define failIfNoTests=false \
             --define maven.javadoc.skip=true \
-            --define it.storage=true \
+            --define it.${{ matrix.it }}=true \
             test
+      - name: Archive logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: Test logs - ${{ matrix.it}}
+          path: "**/target/surefire-reports/*"

--- a/docs/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java
+++ b/docs/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java
@@ -58,7 +58,7 @@ import static org.awaitility.Awaitility.await;
  *
  * @author Dmitry Solomakha
  */
-public class PubSubTemplateDocumentationTests {
+public class PubSubTemplateDocumentationIntegrationTests {
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withPropertyValues("spring.cloud.gcp.pubsub.subscriber.max-ack-extension-period=0")

--- a/docs/src/test/java/org/springframework/cloud/gcp/sample/firestore/FirestoreDocumentationIntegrationTests.java
+++ b/docs/src/test/java/org/springframework/cloud/gcp/sample/firestore/FirestoreDocumentationIntegrationTests.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
  *
  * @since 1.2
  */
-public class FirestoreDocumentationTests {
+public class FirestoreDocumentationIntegrationTests {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(GcpContextAutoConfiguration.class,
 					GcpFirestoreAutoConfiguration.class));

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
@@ -26,6 +26,7 @@ import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.EntityQuery;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.StructuredQuery;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
@@ -44,6 +45,8 @@ import org.springframework.data.annotation.Id;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -56,6 +59,14 @@ import static org.mockito.Mockito.mock;
  * @since 1.2
  */
 public class GcpDatastoreEmulatorIntegrationTests {
+
+	@BeforeClass
+	public static void checkToRun() {
+		assumeThat(
+				"Google Cloud Datastore integration tests are disabled. "
+						+ "Please use '-Dit.datastore=true' to enable them. ",
+				System.getProperty("it.datastore"), is("true"));
+	}
 
 	@Test
 	public void testDatastoreEmulatorConfiguration() {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationIntegrationTests.java
@@ -35,7 +35,7 @@ import static org.junit.Assume.assumeThat;
  *
  * @author Daniel Zou
  */
-public class GcpFirestoreEmulatorAutoConfigurationTests {
+public class GcpFirestoreEmulatorAutoConfigurationIntegrationTests {
 
 	ApplicationContextRunner contextRunner =
 			new ApplicationContextRunner()

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/spanner/GcpSpannerEmulatorAutoConfigurationIntegrationTests.java
@@ -31,7 +31,7 @@ import static org.junit.Assume.assumeThat;
 /**
  * @author Eddú Meléndez
  */
-public class GcpSpannerEmulatorAutoConfigurationTests {
+public class GcpSpannerEmulatorAutoConfigurationIntegrationTests {
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(GcpSpannerEmulatorAutoConfiguration.class,

--- a/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/src/test/kotlin/com/example/RegistrationKotlinSampleApplicationIntegrationTests.kt
+++ b/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/src/test/kotlin/com/example/RegistrationKotlinSampleApplicationIntegrationTests.kt
@@ -53,7 +53,7 @@ import java.util.concurrent.TimeUnit
 			"spring.test.mockmvc.print=none"
 		]
 )
-class RegistrationKotlinSampleApplicationTests {
+class RegistrationKotlinSampleApplicationIntegrationTests {
 
 	private val REGISTER_USER_URL = "/registerPerson?firstName=Bob&lastName=Blob&email=bob@bob.com"
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/org/springframework/cloud/gcp/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
@@ -34,7 +34,7 @@ import org.springframework.cloud.stream.binder.Spy;
  * @author Elena Felder
  * @author Artem Bilan
  */
-public class PubSubMessageChannelBinderEmulatorTests extends
+public class PubSubMessageChannelBinderEmulatorIntegrationTests extends
 		AbstractBinderTests<PubSubTestBinder, ExtendedConsumerProperties<PubSubConsumerProperties>,
 				ExtendedProducerProperties<PubSubProducerProperties>> {
 

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -126,6 +126,9 @@
 								<gcs-read-bucket>gcp-storage-bucket-sample-input</gcs-read-bucket>
 								<gcs-write-bucket>gcp-storage-bucket-sample-output</gcs-write-bucket>
 								<gcs-local-directory>/tmp/gcp_integration_tests/integration_storage_sample</gcs-local-directory>
+								<spring.cloud.gcp.sql.instance-connection-name>spring-cloud-gcp-ci:us-central1:testmysql</spring.cloud.gcp.sql.instance-connection-name>
+								<spring.cloud.gcp.sql.database-name>code_samples_test_db</spring.cloud.gcp.sql.database-name>
+								<spring.datasource.password>test</spring.datasource.password>
 							</systemPropertyVariables>
 						</configuration>
 					</plugin>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-bigquery-sample/src/test/java/com/example/BigQuerySampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-bigquery-sample/src/test/java/com/example/BigQuerySampleApplicationIntegrationTests.java
@@ -55,7 +55,7 @@ import static org.junit.Assume.assumeThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = BigQuerySampleApplication.class, properties = "spring.cloud.gcp.bigquery.datasetName=test_dataset")
-public class BigQuerySampleApplicationTests {
+public class BigQuerySampleApplicationIntegrationTests {
 
 	private static final String DATASET_NAME = "test_dataset";
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/src/test/java/com/example/ConfigSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/src/test/java/com/example/ConfigSampleApplicationIntegrationTests.java
@@ -40,7 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { Application.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-public class ConfigSampleApplicationTests {
+public class ConfigSampleApplicationIntegrationTests {
 	@Autowired
 	private MockMvc mvc;
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/src/test/java/com/example/DatastoreBookshelfExampleIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/src/test/java/com/example/DatastoreBookshelfExampleIntegrationTests.java
@@ -50,7 +50,7 @@ import static org.junit.Assume.assumeThat;
 @SpringBootTest(classes = DatastoreBookshelfExample.class,
 		properties = { InteractiveShellApplicationRunner.SPRING_SHELL_INTERACTIVE_ENABLED + "="
 				+ false }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class DatastoreBookshelfExampleTests {
+public class DatastoreBookshelfExampleIntegrationTests {
 
 	@Autowired
 	private Shell shell;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/test/java/com/example/DatastoreSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/test/java/com/example/DatastoreSampleApplicationIntegrationTests.java
@@ -64,7 +64,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(classes = {
 		DatastoreRepositoryExample.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class DatastoreSampleApplicationTests {
+public class DatastoreSampleApplicationIntegrationTests {
 
 	private static PrintStream systemOut;
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/FirestoreSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/FirestoreSampleApplicationIntegrationTests.java
@@ -45,7 +45,7 @@ import static org.junit.Assume.assumeThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = FirestoreSampleApplication.class)
 @TestPropertySource("classpath:application-test.properties")
-public class FirestoreSampleApplicationTests {
+public class FirestoreSampleApplicationIntegrationTests {
 
 	@Autowired
 	FirestoreTemplate firestoreTemplate;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/java/com/example/CloudSqlJpaSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/test/java/com/example/CloudSqlJpaSampleApplicationIntegrationTests.java
@@ -44,7 +44,7 @@ import static org.junit.Assume.assumeThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {DemoApplication.class})
-public class CloudSqlJpaSampleApplicationTests {
+public class CloudSqlJpaSampleApplicationIntegrationTests {
 	@BeforeClass
 	public static void checkToRun() {
 		assumeThat(

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/java/com/example/MultipleDataModuleIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/java/com/example/MultipleDataModuleIntegrationTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assume.assumeThat;
 @RunWith(SpringRunner.class)
 @TestPropertySource("classpath:application-test.properties")
 @EnableAutoConfiguration
-public class MultipleDataModuleTest {
+public class MultipleDataModuleIntegrationTest {
 
 	// The Spanner Repo
 	@Autowired

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/java/com/example/MultipleNamespaceDatastoreIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/java/com/example/MultipleNamespaceDatastoreIntegrationTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assume.assumeThat;
 @RunWith(SpringRunner.class)
 @TestPropertySource("classpath:application-test.properties")
 @EnableAutoConfiguration
-public class MultipleNamespaceDatastoreTest {
+public class MultipleNamespaceDatastoreIntegrationTest {
 
 	@Autowired
 	PersonRepository datastorePersonRepository;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerRepositoryIntegrationTests.java
@@ -61,7 +61,7 @@ import static org.junit.Assume.assumeThat;
 @ActiveProfiles("test")
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { SpannerExampleDriver.class })
-public class SpannerRepositoryTests {
+public class SpannerRepositoryIntegrationTests {
 	@LocalServerPort
 	private int port;
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerRepositoryMultiDatabaseIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerRepositoryMultiDatabaseIntegrationTests.java
@@ -47,7 +47,7 @@ import static org.junit.Assume.assumeThat;
 @RunWith(SpringRunner.class)
 @TestPropertySource("classpath:application-test.properties")
 @EnableAutoConfiguration
-public class SpannerRepositoryMultiDatabaseTests {
+public class SpannerRepositoryMultiDatabaseIntegrationTests {
 	@Autowired
 	private TraderRepository traderRepository;
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerTemplateIntegrationTests.java
@@ -47,7 +47,7 @@ import static org.junit.Assume.assumeThat;
 @ActiveProfiles("test")
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(classes = { SpannerExampleDriver.class })
-public class SpannerTemplateTests {
+public class SpannerTemplateIntegrationTests {
 	@Autowired
 	private SpannerOperations spannerOperations;
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/src/test/java/com/example/ReceiverIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/src/test/java/com/example/ReceiverIntegrationTest.java
@@ -42,14 +42,15 @@ import static org.junit.Assume.assumeThat;
  * Tests for the receiver application.
  *
  * @author Dmitry Solomakha
+ * @author Elena Felder
  *
- * @since 1.2
+ * @since 1.1
  */
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @DirtiesContext
-public class PollingReceiverTest {
+public class ReceiverIntegrationTest {
 	private static PrintStream systemOut;
 
 	private static ByteArrayOutputStream baos;
@@ -78,7 +79,7 @@ public class PollingReceiverTest {
 	@Test
 	public void testSample() throws Exception {
 		String message = "test message " + UUID.randomUUID();
-		String expectedString = "Message arrived by Synchronous Pull! Payload: " + message;
+		String expectedString = "Message arrived! Payload: " + message;
 
 		this.pubSubTemplate.publish("exampleTopic", message);
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationIntegrationTests.java
@@ -56,7 +56,7 @@ import static org.junit.Assume.assumeThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { Application.class })
-public class LoggingSampleApplicationTests {
+public class LoggingSampleApplicationIntegrationTests {
 
 	private static final String LOG_FILTER_FORMAT = "trace:%s";
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/src/test/java/com/example/ReactiveReceiverApplicationIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/src/test/java/com/example/ReactiveReceiverApplicationIntegrationTest.java
@@ -52,7 +52,7 @@ import static org.junit.Assume.assumeThat;
 @SpringBootTest(
 	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 	classes = ReactiveReceiverApplication.class)
-public class ReactiveReceiverApplicationTest {
+public class ReactiveReceiverApplicationIntegrationTest {
 
 	@LocalServerPort
 	private int port;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubSampleApplicationIntegrationTests.java
@@ -64,7 +64,7 @@ import static org.junit.Assume.assumeThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { PubSubApplication.class })
-public class PubSubSampleApplicationTests {
+public class PubSubSampleApplicationIntegrationTests {
 
 	/** Output capture for validating that message was received. */
 	@Rule

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleIntegrationTests.java
@@ -39,7 +39,7 @@ import static org.junit.Assume.assumeThat;
 		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		classes = SecretManagerApplication.class,
 		properties = {"spring.cloud.gcp.secretmanager.enabled=true"})
-public class SecretManagerSampleTests {
+public class SecretManagerSampleIntegrationTests {
 
 	@Autowired
 	private TestRestTemplate testRestTemplate;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/src/test/java/com/example/SqlPostgresSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/src/test/java/com/example/SqlPostgresSampleApplicationIntegrationTests.java
@@ -51,7 +51,7 @@ import static org.junit.Assume.assumeThat;
 		"spring.datasource.continue-on-error=true",
 		"spring.datasource.initialization-mode=always"
 })
-public class SqlPostgresSampleApplicationTests {
+public class SqlPostgresSampleApplicationIntegrationTests {
 
 	@Autowired
 	private TestRestTemplate testRestTemplate;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/src/test/java/com/example/GcsSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/src/test/java/com/example/GcsSampleApplicationIntegrationTests.java
@@ -52,7 +52,7 @@ import static org.junit.Assume.assumeThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { GcsApplication.class })
-public class GcsSampleApplicationTests {
+public class GcsSampleApplicationIntegrationTests {
 
 	@Autowired
 	private Storage storage;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
@@ -65,7 +65,7 @@ import static org.junit.Assume.assumeThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { Application.class })
-public class TraceSampleApplicationTests {
+public class TraceSampleApplicationIntegrationTests {
 
 	@LocalServerPort
 	private int port;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/test/java/com/example/VisionApiSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/test/java/com/example/VisionApiSampleApplicationIntegrationTests.java
@@ -45,7 +45,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
-public class VisionApiSampleApplicationTests {
+public class VisionApiSampleApplicationIntegrationTests {
 
 	private static final String LABEL_IMAGE_URL = "/extractLabels?imageUrl=classpath:static/boston-terrier.jpg";
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-ocr-demo/src/test/java/VisionOcrSampleIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-ocr-demo/src/test/java/VisionOcrSampleIntegrationTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assume.assumeThat;
 		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		classes = Application.class,
 		properties = "application.ocr-bucket=vision-integration-test-bucket")
-public class VisionOcrSampleTest {
+public class VisionOcrSampleIntegrationTest {
 
 	@Autowired
 	private TestRestTemplate testRestTemplate;


### PR DESCRIPTION
Adds log archiving (not sure if this really that helpful, TBH) and deduplicates GHA runs for push & pull_request events.

The bulk of this PR finds tests that require `-Dit.something` and ensures they have the required `IntegrationTest` in their name.

Still to go: pubsub and pubsub-emulator.