### PR TITLE
tests: Enable pubsub integration tests

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -24,11 +24,11 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Unit Tests
-      continue-on-error: true
       run: |
         ./mvnw \
           --fail-at-end \
           --batch-mode \
+          --threads 1.5C \
           --activate-profiles full-checkstyle \
           --show-version \
           --define maven.javadoc.skip=true \
@@ -53,7 +53,7 @@ jobs:
           - firestore
           - logging
           - kotlin
-          # - pubsub # currently not working
+          - pubsub
           # - pubsub-emulator # not sure if this actually does anything?
           - secretmanager
           - spanner
@@ -79,15 +79,25 @@ jobs:
           service_account_key: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY }}
           export_default_credentials: true
       - name: install pubsub-emulator
-        if: ${{ matrix.it }} == 'pubsub-emulator'
+        if: ${{ matrix.it == 'pubsub-emulator' }}
         run: |
           gcloud components install pubsub-emulator && \
             gcloud components update
-      - name: Integration Tests
-        continue-on-error: true
+      # Some integration tests (pubsub) fork their own mvn instance, which needs these
+      # libraries to be installed to the local repo.
+      - name: Mvn install
         run: |
           ./mvnw \
             --batch-mode \
+            --threads 1.5C \
+            --define skipTests=true \
+            --define maven.javadoc.skip=true \
+            install
+      - name: Integration Tests
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --fail-at-end \
             --activate-profiles spring-cloud-gcp-ci-it \
             --show-version \
             --define test="**/*IntegrationTest*" \

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--DaltSnapshotDeploymentRepository=repo.spring.io::default::https://repo.spring.io/libs-snapshot-local -P spring -T 1.5C
+-DaltSnapshotDeploymentRepository=repo.spring.io::default::https://repo.spring.io/libs-snapshot-local -P spring

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/test/java/com/example/PubSubBinderSampleAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-binder-sample/src/test/java/com/example/PubSubBinderSampleAppIntegrationTest.java
@@ -53,7 +53,7 @@ import static org.junit.Assume.assumeThat;
 		"spring.cloud.stream.bindings.output.destination=my-topic",
 		"spring.cloud.stream.bindings.input.group=my-group"})
 @DirtiesContext
-public class SampleAppIntegrationTest {
+public class PubSubBinderSampleAppIntegrationTest {
 
 	@Autowired
 	private TestRestTemplate restTemplate;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubSampleApplicationIntegrationTests.java
@@ -18,6 +18,7 @@ package com.example;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -72,19 +73,19 @@ public class PubSubSampleApplicationIntegrationTests {
 
 	private static final int PUBSUB_CLIENT_TIMEOUT_SECONDS = 60;
 
-	private static final String SAMPLE_TEST_TOPIC = "pubsub-sample-test-exampleTopic";
+	private static final String SAMPLE_TEST_TOPIC = "pubsub-sample-test-exampleTopic-" + UUID.randomUUID();
 
-	private static final String SAMPLE_TEST_TOPIC2 = "pubsub-sample-test-exampleTopic2";
+	private static final String SAMPLE_TEST_TOPIC2 = "pubsub-sample-test-exampleTopic2-" + UUID.randomUUID();
 
-	private static final String SAMPLE_TEST_TOPIC_DELETE = "pubsub-sample-test-topicdelete";
+	private static final String SAMPLE_TEST_TOPIC_DELETE = "pubsub-sample-test-topicdelete-" + UUID.randomUUID();
 
-	private static final String SAMPLE_TEST_SUBSCRIPTION1 = "pubsub-sample-test-exampleSubscription1";
+	private static final String SAMPLE_TEST_SUBSCRIPTION1 = "pubsub-sample-test-exampleSubscription1-" + UUID.randomUUID();
 
-	private static final String SAMPLE_TEST_SUBSCRIPTION2 = "pubsub-sample-test-exampleSubscription2";
+	private static final String SAMPLE_TEST_SUBSCRIPTION2 = "pubsub-sample-test-exampleSubscription2-" + UUID.randomUUID();
 
-	private static final String SAMPLE_TEST_SUBSCRIPTION3 = "pubsub-sample-test-exampleSubscription3";
+	private static final String SAMPLE_TEST_SUBSCRIPTION3 = "pubsub-sample-test-exampleSubscription3-" + UUID.randomUUID();
 
-	private static final String SAMPLE_TEST_SUBSCRIPTION_DELETE = "pubsub-sample-test-subdelete";
+	private static final String SAMPLE_TEST_SUBSCRIPTION_DELETE = "pubsub-sample-test-subdelete-" + UUID.randomUUID();
 
 	private static TopicAdminClient topicAdminClient;
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/PubSubStreamBinderSampleAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/PubSubStreamBinderSampleAppIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assume.assumeThat;
  *
  * @author Elena Felder
  */
-public class SampleAppIntegrationTest {
+public class PubSubStreamBinderSampleAppIntegrationTest {
 
 	/** Captures output to check that Sink application processed the message. */
 	@Rule


### PR DESCRIPTION
It appears that the PubSub integration tests are the reason we can't run everything in parallel. We may be able to sink some effort into making them more thread safe (removing external dependencies, maybe removing some of the standard out redirects?, marking everything as `@DirtiesContext`). 

A few more runs with this enabled may show how much time we could save by fixing pubsub and re-enabling parallel builds (which in turn test in parallel). Without Pubsub, unit + integration tests can run as fast as [4min 24sec](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/126264301) 