### PR TITLE
actions: Redirect stdout to file and always save it

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -34,6 +34,7 @@ jobs:
           --define maven.javadoc.skip=true \
           test
     - name: Archive logs
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: Test logs - ${{ matrix.it}}
@@ -41,8 +42,7 @@ jobs:
 
   integrationTests:
     if: |
-      github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' &&
-       (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
+      github.event_name == 'push' && github.repository == 'GoogleCloudPlatform/spring-cloud-gcp'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -100,12 +100,14 @@ jobs:
             --fail-at-end \
             --activate-profiles spring-cloud-gcp-ci-it \
             --show-version \
+            --define maven.test.redirectTestOutputToFile=true \
             --define test="**/*IntegrationTest*" \
             --define failIfNoTests=false \
             --define maven.javadoc.skip=true \
             --define it.${{ matrix.it }}=true \
             test
       - name: Archive logs
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: Test logs - ${{ matrix.it}}


### PR DESCRIPTION
Two changes here:

1. Found the `always()` function that ensures the logs are actually saved, even if the job (or step) fails

2. The copious amount of Maven occasionally causes the GitHub Javascript to slow to a crawl - and most of it zooms by too fast to be useful. Found the Maven option to redirect all test stdout to files that are then archived afterward for viewing.

