### PR TITLE
actions: Fail-fast to false

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -36,6 +36,7 @@ jobs:
           test
     - name: Archive logs
       if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v2
       with:
         name: Test logs - ${{ matrix.it}}
@@ -116,6 +117,7 @@ jobs:
             test
       - name: Archive logs
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: Test logs - ${{ matrix.it}}


### PR DESCRIPTION
As discussed yesterday: This allows all matrix jobs to continue should one of them fail. This should help prevent shared resources from getting into a wonky state as the result of a mid-test cancellation.

Reference: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast