### PR TITLE
tests: Removes various unnecessary network calls

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/core/GcpContextAutoConfigurationTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gcp.autoconfigure.core;
 
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -26,8 +28,10 @@ import org.springframework.cloud.gcp.core.DefaultGcpEnvironmentProvider;
 import org.springframework.cloud.gcp.core.DefaultGcpProjectIdProvider;
 import org.springframework.cloud.gcp.core.GcpEnvironmentProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
+import org.springframework.context.annotation.Bean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for the top-level context auto-configuration.
@@ -39,7 +43,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class GcpContextAutoConfigurationTests {
 
 	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(GcpContextAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(GcpContextAutoConfiguration.class))
+			.withUserConfiguration(TestConfiguration.class);
 
 	@Test
 	public void testGetProjectIdProvider_withGcpProperties() {
@@ -91,5 +96,13 @@ public class GcpContextAutoConfigurationTests {
 		return context -> assertThat(context
 				.getBeansOfType(GcpProjectIdProvider.class).size())
 						.isEqualTo(count);
+	}
+
+	private static class TestConfiguration {
+
+		@Bean
+		public CredentialsProvider googleCredentials() {
+			return () -> mock(Credentials.class);
+		}
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/logging/StackdriverLoggingAutoConfigurationTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.gcp.autoconfigure.logging;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
 import org.junit.Test;
+import zipkin2.reporter.Reporter;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.mock;
 public class StackdriverLoggingAutoConfigurationTests {
 
 	private WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+			.withUserConfiguration(TestConfiguration.class)
 			.withConfiguration(
 					AutoConfigurations.of(
 							StackdriverLoggingAutoConfiguration.class,
@@ -62,6 +64,7 @@ public class StackdriverLoggingAutoConfigurationTests {
 				AutoConfigurations.of(
 						StackdriverLoggingAutoConfiguration.class,
 						GcpContextAutoConfiguration.class))
+				.withUserConfiguration(TestConfiguration.class)
 				.run((context) -> assertThat(context
 						.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class).size())
 								.isEqualTo(0));
@@ -73,6 +76,7 @@ public class StackdriverLoggingAutoConfigurationTests {
 				AutoConfigurations.of(
 						StackdriverLoggingAutoConfiguration.class,
 						GcpContextAutoConfiguration.class))
+				.withUserConfiguration(TestConfiguration.class)
 				.run((context) -> assertThat(context
 						.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class).size())
 								.isEqualTo(0));
@@ -90,20 +94,22 @@ public class StackdriverLoggingAutoConfigurationTests {
 		this.contextRunner
 				.withConfiguration(AutoConfigurations.of(StackdriverTraceAutoConfiguration.class,
 						TraceAutoConfiguration.class))
-				.withUserConfiguration(Configuration.class)
 				.withPropertyValues("spring.cloud.gcp.project-id=pop-1")
 				.run((context) -> assertThat(context
 						.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class).size())
 								.isEqualTo(0));
 	}
 
-	private static class Configuration {
+	private static class TestConfiguration {
 
 		@Bean
 		public CredentialsProvider googleCredentials() {
 			return () -> mock(Credentials.class);
 		}
 
+		@Bean
+		public Reporter stackdriverReporter() {
+			return r -> { };
+		}
 	}
-
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfigurationTests.java
@@ -24,6 +24,7 @@ import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.auth.Credentials;
 import com.google.cloud.pubsub.v1.TopicAdminSettings;
 import org.assertj.core.data.Offset;
 import org.junit.Test;
@@ -32,8 +33,10 @@ import org.threeten.bp.Duration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.gcp.autoconfigure.core.GcpContextAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for the Pub/Sub emulator config.
@@ -82,7 +85,8 @@ public class GcpPubSubEmulatorAutoConfigurationTests {
 					"spring.cloud.gcp.pubsub.publisher.batching.enabled=true")
 			.withConfiguration(AutoConfigurations.of(GcpPubSubEmulatorAutoConfiguration.class,
 					GcpContextAutoConfiguration.class,
-					GcpPubSubAutoConfiguration.class));
+					GcpPubSubAutoConfiguration.class))
+			.withUserConfiguration(TestConfiguration.class);
 
 	@Test
 	public void testEmulatorConfig() {
@@ -171,5 +175,12 @@ public class GcpPubSubEmulatorAutoConfigurationTests {
 			assertThat(settings.getDelayThreshold()).isEqualTo(Duration.ofSeconds(23));
 			assertThat(settings.getIsEnabled()).isTrue();
 		});
+	}
+
+	private static class TestConfiguration {
+		@Bean
+		public CredentialsProvider googleCredentials() {
+			return () -> mock(Credentials.class);
+		}
 	}
 }


### PR DESCRIPTION
Using the handy [maven-build-scanner](https://github.com/intuit/maven-build-scanner) I was able to identify the `spring-cloud-gcp-autoconfigure` as the bottleneck in our unit test build. Not only is it the bottleneck, it also is the source of a number of stacktrace outputs (that, in general, [look like bugs](https://github.com/spring-cloud/spring-cloud-gcp/issues/1892) and should try to be avoided).

This PR copies over the mocked `googleCredentials()` method in various places to return a mock Credential, therefore preventing a network call to the (absent) Metadata server. With no failing network call, there is also no errant stack traces. 

But wait, there's _MORE!!_

Removing these network calls _also_ shaves the bottleneck `test` phase from 34s --> 17s. Here's what the build scan now looks like (test with `-T 3` since GHActions is run with 3 threads):

![SaY5fKrjjKZ](https://user-images.githubusercontent.com/13141550/84311449-52419b80-ab31-11ea-98e0-d20dfbf804ac.png)
