### PR TITLE
tests: Use failsafe plugin, fix maven missing-version warnings

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -27,6 +27,7 @@ jobs:
       run: |
         ./mvnw \
           --batch-mode \
+          --show-version \
           --threads 1.5C \
           --define maven.test.skip=true \
           --define maven.javadoc.skip=true \
@@ -35,12 +36,10 @@ jobs:
     - name: Unit Tests
       run: |
         ./mvnw \
-          --fail-at-end \
           --batch-mode \
+          --fail-at-end \
           --threads 1.5C \
           --activate-profiles full-checkstyle \
-          --show-version \
-          --define maven.javadoc.skip=true \
           test
     - name: Archive logs
       if: always()
@@ -114,18 +113,15 @@ jobs:
         run: |
           ./mvnw \
             --batch-mode \
-            --fail-at-end \
             --activate-profiles spring-cloud-gcp-ci-it \
-            --show-version \
-            --define test="**/*IntegrationTest*" \
-            --define failIfNoTests=false \
             --define maven.javadoc.skip=true \
+            --define skip.surefire.tests=true \
             --define it.${{ matrix.it }}=true \
-            test
+            verify
       - name: Archive logs
         if: always()
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: Test logs - ${{ matrix.it}}
-          path: "**/target/surefire-reports/*"
+          path: "**/target/failsafe-reports/*"

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -87,6 +87,7 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<configuration>
 					<skip>true</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,11 @@
 		<zipkin-gcp.version>0.17.0</zipkin-gcp.version>
 		<app-engine-maven-plugin.version>1.3.2</app-engine-maven-plugin.version>
 		<kotlin.version>1.3.31</kotlin.version>
-        <errorprone.version>2.3.4</errorprone.version>
+		<errorprone.version>2.3.4</errorprone.version>
+		<skip.surefire.tests>false</skip.surefire.tests>
+		<skip.failsafe.tests>false</skip.failsafe.tests>
+		<integration-test.pattern>**/*IntegrationTest*</integration-test.pattern>
+		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 	</properties>
 
 	<dependencyManagement>
@@ -152,9 +156,30 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
+					<version>${maven-surefire-plugin.version}</version>
 					<configuration>
 						<argLine>-Xms512m -Xmx512m</argLine>
+						<skip>${skip.surefire.tests}</skip>
+						<excludes>
+							<exclude>${integration-test.pattern}</exclude>
+						</excludes>
 					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-failsafe-plugin</artifactId>
+					<version>${maven-failsafe-plugin.version}</version>
+					<configuration>
+						<skip>${skip.failsafe.tests}</skip>
+						<includes>
+							<include>${integration-test.pattern}</include>
+						</includes>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>${maven-deploy-plugin.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -213,6 +238,10 @@
 						<link>https://googleapis.dev/java/google-cloud-clients/latest/</link>
 					</links>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-cloud-gcp-data-firestore/pom.xml
+++ b/spring-cloud-gcp-data-firestore/pom.xml
@@ -16,11 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-core</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-firestore</artifactId>
         </dependency>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -25,6 +25,10 @@
 		<spring-cloud-build-tools.version>3.0.0-SNAPSHOT</spring-cloud-build-tools.version>
 		<puppycrawl-tools-checkstyle.version>8.32</puppycrawl-tools-checkstyle.version>
 		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+		<skip.surefire.tests>false</skip.surefire.tests>
+		<skip.failsafe.tests>false</skip.failsafe.tests>
+		<integration-test.pattern>**/*IntegrationTest*</integration-test.pattern>
+		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 	</properties>
 
 	<modules>
@@ -120,7 +124,7 @@
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
+						<artifactId>maven-failsafe-plugin</artifactId>
 						<configuration>
 							<systemPropertyVariables>
 								<gcs-resource-test-bucket>gcp-storage-resource-bucket-sample</gcs-resource-test-bucket>
@@ -139,12 +143,49 @@
 	</profiles>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>${maven-surefire-plugin.version}</version>
+					<configuration>
+						<argLine>-Xms512m -Xmx512m</argLine>
+						<skip>${skip.surefire.tests}</skip>
+						<excludes>
+							<exclude>${integration-test.pattern}</exclude>
+						</excludes>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-failsafe-plugin</artifactId>
+					<version>${maven-failsafe-plugin.version}</version>
+					<configuration>
+						<skip>${skip.failsafe.tests}</skip>
+						<includes>
+							<include>${integration-test.pattern}</include>
+						</includes>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>${maven-deploy-plugin.version}</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+
 		<plugins>
 			<plugin>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<configuration>
 					<skip>true</skip>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationIntegrationTests.java
@@ -97,7 +97,7 @@ public class LoggingSampleApplicationIntegrationTests {
 
 		String logFilter = String.format(LOG_FILTER_FORMAT, traceHeader);
 
-		await().atMost(60, TimeUnit.SECONDS)
+		await().atMost(120, TimeUnit.SECONDS)
 				.pollInterval(2, TimeUnit.SECONDS)
 				.untilAsserted(() -> {
 					Page<LogEntry> logEntryPage = this.logClient.listLogEntries(


### PR DESCRIPTION
A few things in this PR:

1. `./mvnw test` now only runs unit tests
1. `./mvnw verify` now runs both unit tests and integration tests. The `-Dit.whatever` flags still guard the test from actually running.
    1. Two new options, `skip.surefire.tests` and `skip.failsafe.tests`, were added to control unit/integration tests independently. For the CI job(s), we're running only one or the other. (Context: it appears the documented `-DskipTests` and `-DskipITs` don't mesh well together, so I found this option suggested somewhere on stackoverflow, and it works nicely. `-DskipTests` still works to skip _all_ tests). 
1. Fixed some warnings maven kept complaining about 
    1. Added an explicit version for the `maven-deploy-plugin` 
    1. Removed duplicate dependency listing
1. Extended the logging integration test timeout (I was seeing semi-consistent failures here both on GHA and locally)