### PR TITLE
Fix build for the Ilford version upgrade

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -101,7 +101,7 @@ We offer `BUILD-SNAPSHOT` versions that always reflect the latest code changes t
     <repository>
         <id>spring-snapshots</id>
         <name>Spring Snapshots</name>
-        <url>https://repo.spring.io/libs-snapshot</url>
+        <url>https://repo.spring.io/snapshot</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -95,7 +95,7 @@ We offer `BUILD-SNAPSHOT` versions that always reflect the latest code changes t
     <repository>
         <id>spring-snapshots</id>
         <name>Spring Snapshots</name>
-        <url>https://repo.spring.io/libs-snapshot</url>
+        <url>https://repo.spring.io/snapshot</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -257,11 +257,14 @@
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
+					<releases>
+						<enabled>false</enabled>
+					</releases>
 				</repository>
 				<repository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>https://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -290,7 +293,7 @@
 				<pluginRepository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>https://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -301,7 +304,7 @@
 				<pluginRepository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>https://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -250,16 +250,24 @@
 		<profile>
 			<id>spring</id>
 			<repositories>
+<!--				<repository>-->
+<!--					<id>spring-snapshots</id>-->
+<!--					<name>Spring Snapshots</name>-->
+<!--					<url>https://repo.spring.io/libs-snapshot-local</url>-->
+<!--					<snapshots>-->
+<!--						<enabled>true</enabled>-->
+<!--					</snapshots>-->
+<!--					<releases>-->
+<!--						<enabled>false</enabled>-->
+<!--					</releases>-->
+<!--				</repository>-->
 				<repository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>https://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
-					<releases>
-						<enabled>false</enabled>
-					</releases>
 				</repository>
 				<repository>
 					<id>spring-milestones</id>

--- a/pom.xml
+++ b/pom.xml
@@ -250,17 +250,6 @@
 		<profile>
 			<id>spring</id>
 			<repositories>
-<!--				<repository>-->
-<!--					<id>spring-snapshots</id>-->
-<!--					<name>Spring Snapshots</name>-->
-<!--					<url>https://repo.spring.io/libs-snapshot-local</url>-->
-<!--					<snapshots>-->
-<!--						<enabled>true</enabled>-->
-<!--					</snapshots>-->
-<!--					<releases>-->
-<!--						<enabled>false</enabled>-->
-<!--					</releases>-->
-<!--				</repository>-->
 				<repository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>

--- a/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/support/DatastoreRepositoryFactory.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/org/springframework/cloud/gcp/data/datastore/repository/support/DatastoreRepositoryFactory.java
@@ -37,6 +37,7 @@ import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.QueryLookupStrategy.Key;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
+import org.springframework.data.spel.ExpressionDependencies;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.lang.Nullable;
@@ -118,13 +119,13 @@ public class DatastoreRepositoryFactory extends RepositoryFactorySupport
 
 	private QueryMethodEvaluationContextProvider delegateContextProvider(
 			QueryMethodEvaluationContextProvider evaluationContextProvider) {
+
 		return new QueryMethodEvaluationContextProvider() {
 			@Override
 			public <T extends Parameters<?, ?>> EvaluationContext getEvaluationContext(
 					T parameters, Object[] parameterValues) {
 				StandardEvaluationContext evaluationContext = (StandardEvaluationContext)
-						evaluationContextProvider
-						.getEvaluationContext(parameters, parameterValues);
+						evaluationContextProvider.getEvaluationContext(parameters, parameterValues);
 				evaluationContext.setRootObject(
 						DatastoreRepositoryFactory.this.applicationContext);
 				evaluationContext.addPropertyAccessor(new BeanFactoryAccessor());
@@ -132,7 +133,20 @@ public class DatastoreRepositoryFactory extends RepositoryFactorySupport
 						DatastoreRepositoryFactory.this.applicationContext));
 				return evaluationContext;
 			}
+
+			@Override
+			public <T extends Parameters<?, ?>> EvaluationContext getEvaluationContext(
+					T parameters, Object[] parameterValues, ExpressionDependencies expressionDependencies) {
+				StandardEvaluationContext evaluationContext =
+						(StandardEvaluationContext) evaluationContextProvider.getEvaluationContext(
+								parameters, parameterValues, expressionDependencies);
+
+				evaluationContext.setRootObject(DatastoreRepositoryFactory.this.applicationContext);
+				evaluationContext.addPropertyAccessor(new BeanFactoryAccessor());
+				evaluationContext.setBeanResolver(
+						new BeanFactoryResolver(DatastoreRepositoryFactory.this.applicationContext));
+				return evaluationContext;
+			}
 		};
 	}
-
 }

--- a/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryFactory.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/org/springframework/cloud/gcp/data/spanner/repository/support/SpannerRepositoryFactory.java
@@ -37,6 +37,7 @@ import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.QueryLookupStrategy.Key;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
+import org.springframework.data.spel.ExpressionDependencies;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -126,6 +127,20 @@ public class SpannerRepositoryFactory extends RepositoryFactorySupport
 				evaluationContext.addPropertyAccessor(new BeanFactoryAccessor());
 				evaluationContext.setBeanResolver(new BeanFactoryResolver(
 						SpannerRepositoryFactory.this.applicationContext));
+				return evaluationContext;
+			}
+
+			@Override
+			public <T extends Parameters<?, ?>> EvaluationContext getEvaluationContext(
+					T parameters, Object[] parameterValues, ExpressionDependencies expressionDependencies) {
+				StandardEvaluationContext evaluationContext =
+						(StandardEvaluationContext) evaluationContextProvider.getEvaluationContext(
+								parameters, parameterValues, expressionDependencies);
+
+				evaluationContext.setRootObject(SpannerRepositoryFactory.this.applicationContext);
+				evaluationContext.addPropertyAccessor(new BeanFactoryAccessor());
+				evaluationContext.setBeanResolver(
+						new BeanFactoryResolver(SpannerRepositoryFactory.this.applicationContext));
 				return evaluationContext;
 			}
 		};

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -241,7 +241,7 @@
 				<repository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>https://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -252,7 +252,7 @@
 				<repository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>https://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -270,7 +270,7 @@
 				<pluginRepository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>https://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -281,7 +281,7 @@
 				<pluginRepository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>https://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>


### PR DESCRIPTION
Should fix the build for the repo.

The Ilford snapshot of `spring-data-commons` introduces a new method to implement for our spring-data modules.

```
QueryMethodEvaluationContextProvider.getEvaluationContext(T parameters, Object[] parameterValues, ExpressionDependencies expressionDependencies)
```

This adds the method implementation.

Also, `https://repo.spring.io/snapshot` appears to be the snapshot repo we should be relying on; the old repo location was missing some dependencies.