### PR TITLE
Re-enable JUnit 4 tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,17 +134,12 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-		<!--
-				Needed since our tests are JUnit 4 and spring-cloud-build Ilford
-				uses JUnit 5 by default.
-		-->
+		<!-- Needed to run JUnit4 tests while inheriting from spring-cloud-build parent pom -->
 		<dependency>
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,17 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!--
+				Needed since our tests are JUnit 4 and spring-cloud-build Ilford
+				uses JUnit 5 by default.
+		-->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/repository/query/GqlDatastoreQueryTests.java
@@ -158,6 +158,8 @@ public class GqlDatastoreQueryTests {
 		}
 		when(this.evaluationContextProvider.getEvaluationContext(any(), any()))
 				.thenReturn(evaluationContext);
+		when(this.evaluationContextProvider.getEvaluationContext(any(), any(), any()))
+				.thenReturn(evaluationContext);
 
 		GqlDatastoreQuery gqlDatastoreQuery = createQuery(gql, false, false);
 

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -142,6 +142,15 @@
 		</profile>
 	</profiles>
 
+	<dependencies>
+		<!-- Needed for running JUnit 4 tests when depending on Spring Boot Ilford. -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<pluginManagement>
 			<plugins>


### PR DESCRIPTION
Reenable the junit tests by adding the junit4 vintage engine dependency.

Fixes #39.