### PR TITLE
Fix Secret Manager Bootstrap Configuration (#2492)

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.cloud.gcp.core.DefaultCredentialsProvider;
 import org.springframework.cloud.gcp.core.DefaultGcpProjectIdProvider;
 import org.springframework.cloud.gcp.core.GcpProjectIdProvider;
@@ -106,7 +105,7 @@ public class GcpSecretManagerBootstrapConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public PropertySourceLocator secretManagerPropertySourceLocator(
+	public SecretManagerPropertySourceLocator secretManagerPropertySourceLocator(
 			SecretManagerTemplate secretManagerTemplate) {
 		SecretManagerPropertySourceLocator propertySourceLocator =
 				new SecretManagerPropertySourceLocator(secretManagerTemplate, this.gcpProjectIdProvider);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerBootstrapConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/secretmanager/SecretManagerBootstrapConfigurationTests.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -172,6 +173,13 @@ public class SecretManagerBootstrapConfigurationTests {
 		@Bean
 		public static CredentialsProvider googleCredentials() {
 			return () -> mock(Credentials.class);
+		}
+
+		// This is added in here to verify that the Secret Manager property source locator bean
+		// still gets created even if another PropertySourceLocator bean exists in the environment.
+		@Bean
+		public static PropertySourceLocator defaultPropertySourceLocator() {
+			return locatorEnvironment -> null;
 		}
 	}
 }


### PR DESCRIPTION
Fix the Secret Manager bootstrap configuration so that it autoconfigures the SecretManagerPropertySourceLocator bean even if a PropertySourceLocator bean already exists in the environment.

(cherry picked from commit c9614b8299a4c2ffe5484969684562552f6256f4)

deja vu? I'm thinking we can just cherrypick all PRs into this repo in the future. Hopefully doing them 1-by-1 will be less work than doing a large merge all at once in the future.