### PR TITLE
fix(build): Fix compilation error and attempt to fix some flaky tests.

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/org/springframework/cloud/gcp/autoconfigure/pubsub/it/PubSubTemplateIntegrationTests.java
@@ -101,6 +101,7 @@ public class PubSubTemplateIntegrationTests {
 			pubSubTemplate.publish(topicName, "tatatatata", headers).get();
 			PubsubMessage pubsubMessage = pubSubTemplate.pullNext(subscriptionName);
 
+			assertThat(pubsubMessage).isNotNull();
 			assertThat(pubsubMessage.getData()).isEqualTo(ByteString.copyFromUtf8("tatatatata"));
 			assertThat(pubsubMessage.getAttributesCount()).isEqualTo(2);
 			assertThat(pubsubMessage.getAttributesOrThrow("cactuar")).isEqualTo("tonberry");

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/TestDatastoreItemCollections.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/core/convert/TestDatastoreItemCollections.java
@@ -107,7 +107,7 @@ public class TestDatastoreItemCollections {
 	private List<List<Byte>> arraysToLists(Object[] arrays) {
 		List<List<Byte>> result = new ArrayList<>();
 		for (Object e : arrays) {
-			result.add(CollectionUtils.arrayToList(e));
+			result.add((List<Byte>) CollectionUtils.arrayToList(e));
 		}
 		return result;
 	}

--- a/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/org/springframework/cloud/gcp/data/datastore/it/DatastoreIntegrationTests.java
@@ -209,7 +209,7 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		assertThat(this.testEntityRepository
 				.findAll(
 						Example.of(new TestEntity(null, null, null, null, null)),
-						Sort.by(Sort.Direction.ASC, "size")))
+						Sort.by(Sort.Direction.ASC, "id")))
 				.containsExactly(this.testEntityA, this.testEntityB, this.testEntityC, this.testEntityD);
 
 		assertThat(this.testEntityRepository


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/51

This fixes the compilation as well as a flaky datastore test. The pubsub test failed once with an NPE, which prompted the other change. Only the pubsub integration tests are failing now (https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/43).