### PR TITLE
builds(): Build and test every day at 5:30AM

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -1,6 +1,10 @@
 name: Build And Test
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '30 5 * * *' # 05:30 every day
 
 jobs:
   unitTests:


### PR DESCRIPTION
Two big reasons for this:

1.) Since we're based on SNAPSHOTs right now, we don't know what's changing underneath us. If we don't commit for several days (or weeks) it's harder for the first person to narrow down what broke and when it started.

2.) Also since we're based on SNAPSHOTs, new JARs are downloaded on the first go and are cached. This randomly fails sometimes for a human so this warms up the cache a bit before the development day.
