### PR TITLE
fix(tests): Bring Config server in Pubsub integration test up to date

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
@@ -15,7 +15,7 @@
     <name>Spring Cloud GCP Pub/Sub Bus Configuration Management Code Sample</name>
 
     <properties>
-        <spring-cloud-config.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-config.version>
+        <spring-cloud-config.version>3.0.0-SNAPSHOT</spring-cloud-config.version>
     </properties>
 
     <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/pom.xml
@@ -28,6 +28,17 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-bootstrap</artifactId>
+      <version>${spring-cloud-config.version}</version>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/pom.xml
@@ -30,10 +30,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-bootstrap</artifactId>
       <version>${spring-cloud-config.version}</version>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+spring.config.use-legacy-processing=true
+management.endpoints.web.exposure.include=*
+
 # Customize the Pub/Sub Topic to be used as the message bus.
 #spring.cloud.bus.destination=custom-spring-cloud-bus-topic
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-client/src/main/resources/application.properties
@@ -1,6 +1,3 @@
-spring.config.use-legacy-processing=true
-management.endpoints.web.exposure.include=*
-
 # Customize the Pub/Sub Topic to be used as the message bus.
 #spring.cloud.bus.destination=custom-spring-cloud-bus-topic
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-local/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-server-local/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-server.port = 8888
+server.port=8888
 
 spring.profiles.active=native
 spring.cloud.config.server.native.searchLocations=file:/tmp/config/

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/src/test/java/com/example/LocalSampleAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/src/test/java/com/example/LocalSampleAppIntegrationTest.java
@@ -99,7 +99,7 @@ public class LocalSampleAppIntegrationTest {
 		waitForLogMessage(this.configServerOutput, "Refresh for: *");
 		assertConfigServerValue(UPDATED_MESSAGE);
 
-		waitForLogMessage(this.configClientOutput, "Keys refreshed [example.message]");
+		waitForLogMessage(this.configClientOutput, "Keys refreshed");
 		assertConfigClientValue(UPDATED_MESSAGE);
 	}
 


### PR DESCRIPTION
with Spring Boot 2.4

Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/43
Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/53

1.) Upgrades pinned Spring Cloud Config server to the 3.0.0-SNAPSHOT (we've had recent discussions about whether we should be doing this, but since we're being pulled along with the Spring Boot 2.4-SNAPSHOT this needed to be upgraded too)

2.) Adds the `actuator` project to the sample so that I could ping `/actuator/refresh` manually and see the client refresh the value. Not strictly needed but was valuable for debugging.

3.) Added `spring.config.use-legacy-processing=true` to follow what @spencergibb did in his tests in the cloud config repo. I think in theory this shouldn't be necessary but it doesn't work without it right now.