### PR TITLE
Linkage Checker configuration as GitHub Actions

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -139,3 +139,46 @@ jobs:
         with:
           name: Test logs - ${{ matrix.it}}
           path: "**/target/failsafe-reports/*"
+
+  linkageCheck:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: install
+        # install before running Linkage Checker
+        run: |
+          ./mvnw \
+             --batch-mode \
+             --show-version \
+             --threads 1.5C \
+             --define maven.test.skip=true \
+             --define skip.surefire.tests=true \
+             --define skipITs=true \
+             --define maven.javadoc.skip=true \
+             --errors \
+             install
+      - name: run linkage checker
+        run: |
+          ./mvnw \
+            --activate-profiles linkage-check \
+            --batch-mode \
+            --show-version \
+            --threads 1.5C \
+            --define maven.test.skip=true \
+            --define skip.surefire.tests=true \
+            --define skipITs=true \
+            --define maven.javadoc.skip=true \
+            --errors \
+            verify

--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -141,7 +141,12 @@ jobs:
           path: "**/target/failsafe-reports/*"
 
   linkageCheck:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    if: |
+      github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule'
+      )
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -150,7 +155,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -163,9 +168,7 @@ jobs:
              --batch-mode \
              --show-version \
              --threads 1.5C \
-             --define maven.test.skip=true \
-             --define skip.surefire.tests=true \
-             --define skipITs=true \
+             --define skipTests=true \
              --define maven.javadoc.skip=true \
              --errors \
              install
@@ -176,9 +179,7 @@ jobs:
             --batch-mode \
             --show-version \
             --threads 1.5C \
-            --define maven.test.skip=true \
-            --define skip.surefire.tests=true \
-            --define skipITs=true \
+            --define skipTests=true \
             --define maven.javadoc.skip=true \
             --errors \
             verify

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx1024m -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom
+-Xmx2g -XX:CICompilerCount=1 -XX:TieredStopAtLevel=1 -Djava.security.egd=file:/dev/./urandom

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -341,6 +341,46 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>linkage-check</id>
+			<!-- Not running as part of normal build because 'install' task interferes this rule when
+			    running Maven with multi-thread -->
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<version>3.0.0-M3</version>
+						<dependencies>
+							<dependency>
+								<groupId>com.google.cloud.tools</groupId>
+								<artifactId>linkage-checker-enforcer-rules</artifactId>
+								<version>1.5.3</version>
+							</dependency>
+						</dependencies>
+						<executions>
+							<execution>
+								<id>enforce-linkage-checker</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>enforce</goal>
+								</goals>
+								<configuration>
+									<fail>true</fail>
+									<rules>
+										<LinkageCheckerRule
+											implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
+											<dependencySection>DEPENDENCY_MANAGEMENT</dependencySection>
+											<reportOnlyReachable>true</reportOnlyReachable>
+										</LinkageCheckerRule>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
Followup of spring-cloud/spring-cloud-gcp#2489.

- spring-cloud-gcp-dependencies to have the Linkage Checker enforcer plugin in "linkage-check" profile. It's off by default.
- It uses the latest Linkage Checker version 1.5.3, which fixes GoogleCloudPlatform/cloud-opensource-java#1609 and https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1656.
- GitHub Actions on pull requests to run the enforcer plugin
