### PR TITLE
fix(test): Run integration tests as part of nightly build and test

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -55,7 +55,11 @@ jobs:
 
   integrationTests:
     if: |
-      github.event_name == 'push' && github.repository == 'GoogleCloudPlatform/spring-cloud-gcp'
+      github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' &&
+      (
+        github.event_name == 'push' ||
+        github.event == null
+      )
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
I *think* this should work - the [documentation says](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#schedule) scheduled runes do not have an `event` payload.