### PR TITLE
builds(java): Java 14 --> 15

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 14]
+        java: [8, 11, 15]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1


### PR DESCRIPTION
Java 15 was released to GA on [Sept 15, 2020](https://openjdk.java.net/projects/jdk/15/). 