### PR TITLE
fix(build): Revert samples back to 2.4.0-M3 because of missing depend…

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-M3</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
…ency

Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/65