### PR TITLE
(forwardport): Make Pub/Sub integration tests less flaky

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateIntegrationTests.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -44,6 +45,7 @@ import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.awaitility.Awaitility;
 import org.awaitility.Duration;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -99,7 +101,15 @@ public class PubSubTemplateIntegrationTests {
 			headers.put("cactuar", "tonberry");
 			headers.put("fujin", "raijin");
 			pubSubTemplate.publish(topicName, "tatatatata", headers).get();
-			PubsubMessage pubsubMessage = pubSubTemplate.pullNext(subscriptionName);
+
+			// get message
+			AtomicReference<PubsubMessage> pubsubMessageRef = new AtomicReference<>();
+			Awaitility.await().atMost(30, TimeUnit.SECONDS).until(
+					() -> {
+						pubsubMessageRef.set(pubSubTemplate.pullNext(subscriptionName));
+						return pubsubMessageRef.get() != null;
+					});
+			PubsubMessage pubsubMessage = pubsubMessageRef.get();
 
 			assertThat(pubsubMessage).isNotNull();
 			assertThat(pubsubMessage.getData()).isEqualTo(ByteString.copyFromUtf8("tatatatata"));

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/src/test/java/com/example/ReactiveReceiverApplicationIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/src/test/java/com/example/ReactiveReceiverApplicationIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -60,6 +61,9 @@ public class ReactiveReceiverApplicationIntegrationTest {
 	@Autowired
 	private TestRestTemplate testRestTemplate;
 
+	@Autowired
+	private PubSubTemplate pubSubTemplate;
+
 	@BeforeClass
 	public static void prepare() {
 		assumeThat("PUB/SUB-sample integration tests disabled. Use '-Dit.pubsub=true' to enable them.",
@@ -68,6 +72,11 @@ public class ReactiveReceiverApplicationIntegrationTest {
 
 	@Test
 	public void testSample() throws UnsupportedEncodingException {
+		// clear any old messages
+		System.out.println("Cleared " +
+				pubSubTemplate.pullAndAck("exampleSubscription", 1000, true).size() +
+				" old messages");
+
 		String messagePostingUrl = UriComponentsBuilder.newInstance()
 			.scheme("http")
 			.host("localhost")
@@ -92,7 +101,7 @@ public class ReactiveReceiverApplicationIntegrationTest {
 			.retrieve()
 			.bodyToFlux(String.class)
 			.limitRequest(2)
-			.collectList().block(Duration.ofSeconds(10));
+			.collectList().block(Duration.ofSeconds(20));
 
 		assertThat(streamedMessages).containsExactlyInAnyOrder("reactive test msg 0", "reactive test msg 1");
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/src/test/java/com/example/ReactiveReceiverApplicationIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/src/test/java/com/example/ReactiveReceiverApplicationIntegrationTest.java
@@ -20,6 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.time.Duration;
 import java.util.List;
 
+import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;


### PR DESCRIPTION
Porting from 1.2.x: Make Pub/Sub integration tests less flaky (https://github.com/spring-cloud/spring-cloud-gcp/pull/2546)