### PR TITLE
Add javadoc and source modules, which are required to release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
 		<maven-flatten-plugin.version>1.2.5</maven-flatten-plugin.version>
 		<maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
 		<maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
+		<maven-source-plugin.version>3.0.1</maven-source-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
@@ -233,6 +234,15 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>${maven-javadoc-plugin.version}</version>
+					<executions>
+						<execution>
+							<id>aggregate</id>
+							<goals>
+								<goal>aggregate</goal>
+							</goals>
+							<phase>site</phase>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -327,7 +337,18 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>javadoc</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<phase>package</phase>
+					</execution>
+				</executions>
 				<configuration>
+					<!-- https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8212233 -->
+					<source>8</source>
 					<excludePackageNames>
 						com.example,
 						com.example.*,
@@ -344,6 +365,19 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>${maven-source-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<phase>package</phase>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
@@ -371,6 +405,30 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>${maven-javadoc-plugin.version}</version>
+				<reportSets>
+					<reportSet>
+						<id>non-aggregate</id>
+						<reports>
+							<report>javadoc</report>
+						</reports>
+					</reportSet>
+					<reportSet>
+						<id>aggregate</id>
+						<reports>
+							<report>aggregate</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+		</plugins>
+	</reporting>
 
 	<profiles>
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,10 @@
 		<developerConnection>scm:git:ssh://git@github.com/GoogleCloudPlatform/spring-cloud-gcp.git</developerConnection>
 		<tag>HEAD</tag>
 	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues</url>
+	</issueManagement>
 
 	<distributionManagement>
 		<snapshotRepository>
@@ -666,4 +670,33 @@
 		</profile>
 	</profiles>
 
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
+			<comments>
+				Copyright 2015-2020 the original author or authors.
+
+				Licensed under the Apache License, Version 2.0 (the "License");
+				you may not use this file except in compliance with the License.
+				You may obtain a copy of the License at
+
+				https://www.apache.org/licenses/LICENSE-2.0
+
+				Unless required by applicable law or agreed to in writing, software
+				distributed under the License is distributed on an "AS IS" BASIS,
+				WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+				implied.
+
+				See the License for the specific language governing permissions and
+				limitations under the License.
+			</comments>
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<organization>Google</organization>
+			<organizationUrl>http://cloud.google.com</organizationUrl>
+		</developer>
+	</developers>
 </project>


### PR DESCRIPTION
Error from release:

```
[ERROR] Rule failure while trying to close staging repository with ID "comgooglecloud-2391".
[ERROR] 
[ERROR] Nexus Staging Rules Failure Report
[ERROR] ==================================
[ERROR] 
[ERROR] Repository "comgooglecloud-2391" failures
[ERROR]   Rule "javadoc-staging" failures
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-data-spanner/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-data-firestore/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-security-iap/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-storage/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-data-datastore/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-cloudfoundry/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-pubsub/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-autoconfigure/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-core/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-security-firebase/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-pubsub-stream-binder/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-vision/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-secretmanager/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-logging/2.0.0'
[ERROR]     * Missing: no javadoc jar found in folder '/com/google/cloud/spring-cloud-gcp-bigquery/2.0.0'
[ERROR]   Rule "sources-staging" failures
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-data-spanner/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-data-firestore/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-security-iap/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-storage/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-data-datastore/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-cloudfoundry/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-pubsub/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-autoconfigure/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-core/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-security-firebase/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-pubsub-stream-binder/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-vision/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-secretmanager/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-logging/2.0.0'
[ERROR]     * Missing: no sources jar found in folder '/com/google/cloud/spring-cloud-gcp-bigquery/2.0.0'
[ERROR]   Rule "pom-staging" failures
[ERROR]     * Invalid POM: /com/google/cloud/spring-cloud-gcp/2.0.0/spring-cloud-gcp-2.0.0.pom: License information missing, Developer information missing
```