### PR TITLE
Add nexus-staging plugin to samples, but skip it

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -15,7 +15,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-set -eo pipefail
+set -eov pipefail
 
 dir=$(dirname "$0")
 

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -15,7 +15,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-set -eo pipefail
+set -eov pipefail
 
 # Get secrets from keystore and set and environment variables
 setup_environment_secrets() {

--- a/.kokoro/drop.sh
+++ b/.kokoro/drop.sh
@@ -15,7 +15,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-set -eo pipefail
+set -eov pipefail
 
 # STAGING_REPOSITORY_ID must be set
 if [ -z "${STAGING_REPOSITORY_ID}" ]; then

--- a/.kokoro/promote.sh
+++ b/.kokoro/promote.sh
@@ -15,7 +15,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-set -eo pipefail
+set -eov pipefail
 
 # STAGING_REPOSITORY_ID must be set
 if [ -z "${STAGING_REPOSITORY_ID}" ]; then

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -eov pipefail
 
 if [[ -z "${CREDENTIALS}" ]]; then
   CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account

--- a/.kokoro/release_snapshot.sh
+++ b/.kokoro/release_snapshot.sh
@@ -15,7 +15,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-set -eo pipefail
+set -eov pipefail
 
 dir=$(dirname "$0")
 

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -30,6 +30,7 @@
 		<skip.failsafe.tests>false</skip.failsafe.tests>
 		<integration-test.pattern>**/*IntegrationTest*</integration-test.pattern>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+		<nexus-staging-plugin.version>1.6.8</nexus-staging-plugin.version>
 	</properties>
 
 	<modules>
@@ -84,6 +85,22 @@
 								<spring.cloud.gcp.sql.database-name>code_samples_test_db</spring.cloud.gcp.sql.database-name>
 								<spring.datasource.password>test</spring.datasource.password>
 							</systemPropertyVariables>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<version>${nexus-staging-plugin.version}</version>
+						<extensions>true</extensions>
+						<configuration>
+							<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
Step 1 when debugging Korkoro jobs - it's nice to know what exact command it's failed on, but without revealing any secrets. `set -v` shows what command is running without evaluating those variables, like `set -x` would, so things like `${GPG_PASSPHRASE}` should not be exposed.

Step 2: the latest job failed because it could not `nexus-staging:drop` on the code samples (yet another example of not having a strict hierarchy is a PITA):

```
...
[INFO] Spring Cloud GCP Pub/Sub Starter ................... SUCCESS [  0.001 s]
[INFO] Spring Cloud GCP Code Samples ...................... FAILURE [  5.839 s]
[INFO] Spring Cloud GCP Runtime Configuration Code Sample . SKIPPED
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 35.620 s
[INFO] Finished at: 2020-10-12T12:04:15-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] No plugin found for prefix 'nexus-staging' in the current project and in the plugin groups [org.apache.maven.plugins, org.codehaus.mojo] available from the repositories [local (/home/kbuilder/.m2/repository), spring-snapshots (https://repo.spring.io/snapshot), spring-milestones (https://repo.spring.io/milestone), central (https://repo.maven.apache.org/maven2)] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
```