### PR TITLE
Add required configs to plugin that we're trying to skip 

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -101,6 +101,8 @@
 						<extensions>true</extensions>
 						<configuration>
 							<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+							<serverId>ossrh</serverId>
+							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
(*super annoyed*)

From failed logs:

```
[INFO] Spring Cloud GCP Metrics Code Sample 2.0.0-SNAPSHOT  FAILURE [  0.004 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:08 min
[INFO] Finished at: 2020-10-13T05:10:36-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:drop (default-cli) on project spring-cloud-gcp-metrics-sample: Nexus connection problem: Mandatory plugin parameter 'nexusUrl' is missing -> [Help 1]
[ERROR] 
```