### PR TITLE
Be less specific about GHA step versions

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         java: [8, 11, 15]
     steps:
-    - uses: actions/checkout@v2.3.3
-    - uses: actions/setup-java@v1.4.3
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
-    - uses: actions/cache@v2.1.1
+    - uses: actions/cache@v2
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -53,7 +53,7 @@ jobs:
     - name: Archive logs
       if: always()
       continue-on-error: true
-      uses: actions/upload-artifact@v2.2.0
+      uses: actions/upload-artifact@v2
       with:
         name: Test logs - ${{ matrix.it}}
         path: "**/target/surefire-reports/*"
@@ -85,11 +85,11 @@ jobs:
           - trace
           - vision
     steps:
-      - uses: actions/checkout@v2.3.3
-      - uses: actions/setup-java@v1.4.3
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
         with:
           java-version: 8
-      - uses: actions/cache@v2.1.1
+      - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -135,7 +135,7 @@ jobs:
       - name: Archive logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v2.2.0
+        uses: actions/upload-artifact@v2
         with:
           name: Test logs - ${{ matrix.it}}
           path: "**/target/failsafe-reports/*"


### PR DESCRIPTION
Rolls back a bit of https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/69 to be less specific - apparently GH is smart enough to pick up the most recent minor and patch version from just `@vN`