### PR TITLE
chore(pom): Move release-related plugins to release profile, add to GHA CI

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -15,7 +15,7 @@ jobs:
       github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' &&
       (
         github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository
+        github.event.pull_request.head.repo.full_name != 'GoogleCloudPlatform/spring-cloud-gcp'
       )
     runs-on: ubuntu-latest
     strategy:
@@ -139,6 +139,39 @@ jobs:
         with:
           name: Test logs - ${{ matrix.it}}
           path: "**/target/failsafe-reports/*"
+
+  releaseCheck:
+    if: |
+      github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' &&
+      (
+        github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != 'GoogleCloudPlatform/spring-cloud-gcp'
+      )
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: releaseCheck
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --activate-profiles release \
+            -DskipTests \
+            -Dgpg.skip \
+            -Dcheckstyle.skip \
+            clean \
+            package
+
 
   linkageCheck:
     if: |

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -19,7 +19,7 @@ PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceSt
 python3 -m pip install --user gcp-docuploader
 
 # Build the javadocs
-./mvnw clean javadoc:aggregate
+./mvnw clean javadoc:aggregate --activate-profiles release
 
 # Move into generated docs directory
 pushd target/site/apidocs/

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,9 @@
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<maven-failsafe-plugin.version>2.22.1</maven-failsafe-plugin.version>
 		<maven-flatten-plugin.version>1.2.5</maven-flatten-plugin.version>
+		<maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
 		<maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
-		<maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
+		<maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
 		<maven-source-plugin.version>3.0.1</maven-source-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
@@ -237,20 +238,6 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>${maven-javadoc-plugin.version}</version>
-					<executions>
-						<execution>
-							<id>aggregate</id>
-							<goals>
-								<goal>aggregate</goal>
-							</goals>
-							<phase>site</phase>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
 					<version>${maven-checkstyle-plugin.version}</version>
 					<dependencies>
@@ -292,11 +279,6 @@
 							</goals>
 						</execution>
 					</executions>
-				</plugin>
-				<plugin>
-					<groupId>org.codehaus.mojo</groupId>
-					<artifactId>flatten-maven-plugin</artifactId>
-					<version>${maven-flatten-plugin.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -341,99 +323,10 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>javadoc</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-						<phase>package</phase>
-					</execution>
-				</executions>
-				<configuration>
-					<!-- https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8212233 -->
-					<source>8</source>
-					<excludePackageNames>
-						com.example,
-						com.example.*,
-						<!-- Exclude samples and classes in the Firestore Google Client library packages -->
-						com.google.cloud.firestore
-					</excludePackageNames>
-					<links>
-						<link>https://googleapis.dev/java/google-cloud-vision/latest/</link>
-						<link>https://googleapis.dev/java/google-cloud-spanner/latest/</link>
-						<link>https://googleapis.dev/java/google-cloud-clients/latest/</link>
-					</links>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>${maven-source-plugin.version}</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-						<phase>package</phase>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>flatten-maven-plugin</artifactId>
-				<inherited>true</inherited>
-				<executions>
-					<execution>
-						<!-- Tidy up all POMs before they are published -->
-						<id>flatten</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>flatten</goal>
-						</goals>
-						<configuration>
-							<updatePomFile>true</updatePomFile>
-							<flattenMode>oss</flattenMode>
-							<pomElements>
-								<parent>expand</parent>
-								<distributionManagement>remove</distributionManagement>
-								<repositories>remove</repositories>
-							</pomElements>
-						</configuration>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>
-
-	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${maven-javadoc-plugin.version}</version>
-				<reportSets>
-					<reportSet>
-						<id>non-aggregate</id>
-						<reports>
-							<report>javadoc</report>
-						</reports>
-					</reportSet>
-					<reportSet>
-						<id>aggregate</id>
-						<reports>
-							<report>aggregate</report>
-						</reports>
-					</reportSet>
-				</reportSets>
-			</plugin>
-		</plugins>
-	</reporting>
 
 	<profiles>
 		<profile>
@@ -641,11 +534,39 @@
 		<profile>
 			<id>release</id>
 			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-gpg-plugin</artifactId>
+							<version>${maven-gpg-plugin.version}</version>
+						</plugin>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-javadoc-plugin</artifactId>
+							<version>${maven-javadoc-plugin.version}</version>
+						</plugin>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-source-plugin</artifactId>
+							<version>${maven-source-plugin.version}</version>
+						</plugin>
+						<plugin>
+							<groupId>org.codehaus.mojo</groupId>
+							<artifactId>flatten-maven-plugin</artifactId>
+							<version>${maven-flatten-plugin.version}</version>
+						</plugin>
+						<plugin>
+							<groupId>org.sonatype.plugins</groupId>
+							<artifactId>nexus-staging-maven-plugin</artifactId>
+							<version>${nexus-staging-plugin.version}</version>
+						</plugin>
+					</plugins>
+				</pluginManagement>
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -659,13 +580,90 @@
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>${nexus-staging-plugin.version}</version>
 						<extensions>true</extensions>
 						<configuration>
 							<serverId>ossrh</serverId>
 							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
 							<autoReleaseAfterClose>false</autoReleaseAfterClose>
 						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>javadoc</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+								<phase>package</phase>
+							</execution>
+							<execution>
+								<id>aggregate</id>
+								<goals>
+									<goal>aggregate</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<!-- https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8212233 -->
+							<source>8</source>
+							<excludePackageNames>
+								com.example,
+								com.example.*,
+								<!-- Exclude samples and classes in the Firestore Google Client library packages -->
+								com.google.cloud.firestore
+							</excludePackageNames>
+							<links>
+								<link>https://googleapis.dev/java/google-cloud-vision/latest/</link>
+								<link>https://googleapis.dev/java/google-cloud-spanner/latest/</link>
+								<link>https://googleapis.dev/java/google-cloud-clients/latest/</link>
+							</links>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+								<phase>package</phase>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>flatten-maven-plugin</artifactId>
+						<inherited>true</inherited>
+						<executions>
+							<execution>
+								<!-- Tidy up all POMs before they are published -->
+								<id>flatten</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>flatten</goal>
+								</goals>
+								<configuration>
+									<updatePomFile>true</updatePomFile>
+									<flattenMode>oss</flattenMode>
+									<pomElements>
+										<parent>expand</parent>
+										<distributionManagement>remove</distributionManagement>
+										<repositories>remove</repositories>
+									</pomElements>
+								</configuration>
+							</execution>
+							<execution>
+								<id>flatten.clean</id>
+								<phase>clean</phase>
+								<goals>
+									<goal>clean</goal>
+								</goals>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 			</build>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -31,6 +31,8 @@
 		<integration-test.pattern>**/*IntegrationTest*</integration-test.pattern>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<nexus-staging-plugin.version>1.6.8</nexus-staging-plugin.version>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
+		<maven.sources.skip>true</maven.sources.skip>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Added a separate GHActions job to test the `-P release` flow, which generates javadoc and sources Jars, flattens the POM, etc. when preparing for a release. 