### PR TITLE
Make UserAgentHeaderProviderIntegrationTests run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,14 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/core/UserAgentHeaderProviderIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/core/UserAgentHeaderProviderIntegrationTests.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.google.cloud.spring.core;
+package com.google.cloud.spring.autoconfigure.core;
 
 import java.util.regex.Pattern;
 
+import com.google.cloud.spring.core.UserAgentHeaderProvider;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
  */
-public class UserAgentHeaderProviderIT {
+public class UserAgentHeaderProviderIntegrationTests {
 
 	/**
 	 * This test is check if the generated User-Agent header is in the right format.
@@ -39,7 +40,7 @@ public class UserAgentHeaderProviderIT {
 	public void testGetHeaders() {
 		UserAgentHeaderProvider subject = new UserAgentHeaderProvider(this.getClass());
 
-		String versionRegex = "\\d+\\.\\d+\\.\\d+\\.[BUILD-SNAPSHOT|M\\d+|RC\\d+|RELEASE]$";
+		String versionRegex = "\\d+\\.\\d+\\.\\d+(\\-SNAPSHOT)?";
 		assertThat(subject.getHeaders()).containsKey("User-Agent");
 		assertThat(subject.getHeaders().get("User-Agent")).matches(
 				Pattern.compile("Spring/" + versionRegex + " spring-cloud-gcp-core/" + versionRegex));


### PR DESCRIPTION
Fixes the regex and moves the class to another module to make sure
that the `getImplementationVersion()` method works.