### PR TITLE
(Cherrypick) Replace gradle docs with correct syntax

### DIFF
--- a/docs/src/main/asciidoc/bigquery.adoc
+++ b/docs/src/main/asciidoc/bigquery.adoc
@@ -22,7 +22,7 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-bigquery'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-bigquery")
 }
 ----
 

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -113,7 +113,7 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
 }
 ----
 

--- a/docs/src/main/asciidoc/core.adoc
+++ b/docs/src/main/asciidoc/core.adoc
@@ -20,7 +20,7 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter")
 }
 ----
 

--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -22,7 +22,7 @@ Gradle coordinates:
 [source]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-data-datastore'
+    implementation("org.springframework.cloud:spring-cloud-gcp-data-datastore")
 }
 ----
 
@@ -45,7 +45,7 @@ Gradle:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-data-datastore'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-data-datastore")
 }
 ----
 

--- a/docs/src/main/asciidoc/firestore.adoc
+++ b/docs/src/main/asciidoc/firestore.adoc
@@ -23,7 +23,7 @@ Gradle coordinates:
 [source]
 ----
 dependencies {
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-data-firestore'
+  implementation("org.springframework.cloud:spring-cloud-gcp-data-firestore")
 }
 ----
 
@@ -42,7 +42,7 @@ Gradle coordinates:
 [source]
 ----
 dependencies {
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-data-firestore'
+  implementation("org.springframework.cloud:spring-cloud-gcp-starter-data-firestore")
 }
 ----
 
@@ -342,7 +342,7 @@ Gradle coordinates:
 [source]
 ----
 dependencies {
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-firestore'
+  implementation("org.springframework.cloud:spring-cloud-gcp-starter-firestore")
 }
 ----
 

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -15,7 +15,7 @@ Gradle coordinates:
 [source]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-logging'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-logging")
 }
 ----
 

--- a/docs/src/main/asciidoc/metrics.adoc
+++ b/docs/src/main/asciidoc/metrics.adoc
@@ -19,7 +19,7 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-metrics'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-metrics")
 }
 ----
 
@@ -42,7 +42,7 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
 }
 ----
 

--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -19,7 +19,7 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-pubsub'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-pubsub")
 }
 ----
 

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -27,7 +27,7 @@ Gradle coordinates:
 [source]
 ----
 dependencies {
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-secretmanager'
+  implementation("org.springframework.cloud:spring-cloud-gcp-starter-secretmanager")
 }
 ----
 

--- a/docs/src/main/asciidoc/security-iap.adoc
+++ b/docs/src/main/asciidoc/security-iap.adoc
@@ -48,7 +48,7 @@ Starter Gradle coordinates:
 [source]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-security-iap'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-security-iap")
 }
 ----
 

--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -20,7 +20,7 @@ Gradle coordinates:
 [source]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-data-spanner'
+    implementation("org.springframework.cloud:spring-cloud-gcp-data-spanner")
 }
 ----
 
@@ -43,7 +43,7 @@ Gradle:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-data-spanner'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-data-spanner")
 }
 ----
 

--- a/docs/src/main/asciidoc/spring-cloud-bus-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-bus-pubsub.adoc
@@ -24,7 +24,7 @@ Gradle coordinates:
 [source,groovy]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-bus-pubsub'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-bus-pubsub")
 }
 ----
 

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -24,8 +24,8 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-pubsub'
-    compile group: 'org.springframework.integration', name: 'spring-integration-core'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-pubsub")
+    implementation("org.springframework.integration:spring-integration-core")
 }
 ----
 

--- a/docs/src/main/asciidoc/spring-integration-storage.adoc
+++ b/docs/src/main/asciidoc/spring-integration-storage.adoc
@@ -27,8 +27,8 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-storage'
-    compile group: 'org.springframework.integration', name: 'spring-integration-file'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-storage")
+    implementation("org.springframework.integration:spring-integration-file")
 }
 ----
 

--- a/docs/src/main/asciidoc/spring-stream.adoc
+++ b/docs/src/main/asciidoc/spring-stream.adoc
@@ -19,7 +19,7 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-pubsub-stream-binder'
+    implementation("org.springframework.cloud:spring-cloud-gcp-pubsub-stream-binder")
 }
 ----
 

--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -25,8 +25,8 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-sql-mysql'
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-sql-postgresql'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-sql-mysql")
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-sql-postgresql")
 }
 ----
 

--- a/docs/src/main/asciidoc/storage.adoc
+++ b/docs/src/main/asciidoc/storage.adoc
@@ -18,7 +18,7 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-storage'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-storage")
 }
 ----
 

--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -22,7 +22,7 @@ Gradle coordinates:
 [source,subs="normal"]
 ----
 dependencies {
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-trace'
+    implementation("org.springframework.cloud:spring-cloud-gcp-starter-trace")
 }
 ----
 

--- a/docs/src/main/asciidoc/vision.adoc
+++ b/docs/src/main/asciidoc/vision.adoc
@@ -29,7 +29,7 @@ Gradle coordinates:
 [source]
 ----
 dependencies {
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-vision'
+  implementation("org.springframework.cloud:spring-cloud-gcp-starter-vision")
 }
 ----
 
@@ -68,8 +68,8 @@ Gradle coordinates:
 [source]
 ----
 dependencies {
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-vision'
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter-storage'
+  implementation("org.springframework.cloud:spring-cloud-gcp-starter-vision")
+  implementation("org.springframework.cloud:spring-cloud-gcp-starter-storage")
 }
 ----
 


### PR DESCRIPTION
Fixes the Gradle doc syntax to use updated format.

Cherry pick from the `spring-cloud-gcp` 1.x repo: https://github.com/spring-cloud/spring-cloud-gcp/pull/2549