### PR TITLE
Allow setting maxFetchSize on polling stream binder

### DIFF
--- a/docs/src/main/asciidoc/spring-stream.adoc
+++ b/docs/src/main/asciidoc/spring-stream.adoc
@@ -191,6 +191,9 @@ public class SinkExample {
 }
 ----
 
+By default, the polling will only get 1 message at a time.
+Use the `spring.cloud.stream.gcp.pubsub.default.consumer.maxFetchSize` property to fetch additional messages per network roundtrip.
+
 === Sample
 
 Sample applications are available:

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -128,8 +128,16 @@ public class PubSubMessageChannelBinder
 	@Override
 	protected PolledConsumerResources createPolledConsumerResources(String name, String group, ConsumerDestination destination,
 			ExtendedConsumerProperties<PubSubConsumerProperties> consumerProperties) {
-		return new PolledConsumerResources(new PubSubMessageSource(this.pubSubTemplate, destination.getName()),
+		PubSubMessageSource source = createPubSubMessageSource(destination, consumerProperties);
+		return new PolledConsumerResources(source,
 				registerErrorInfrastructure(destination, group, consumerProperties, true));
+	}
+
+	protected PubSubMessageSource createPubSubMessageSource(ConsumerDestination destination,
+			ExtendedConsumerProperties<PubSubConsumerProperties> consumerProperties) {
+		PubSubMessageSource source = new PubSubMessageSource(this.pubSubTemplate, destination.getName());
+		source.setMaxFetchSize(consumerProperties.getExtension().getMaxFetchSize());
+		return source;
 	}
 
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/properties/PubSubConsumerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/properties/PubSubConsumerProperties.java
@@ -30,11 +30,21 @@ public class PubSubConsumerProperties extends PubSubCommonProperties {
 
 	private AckMode ackMode = AckMode.AUTO;
 
+	private Integer maxFetchSize = 1;
+
 	public AckMode getAckMode() {
 		return ackMode;
 	}
 
 	public void setAckMode(AckMode ackMode) {
 		this.ackMode = ackMode;
+	}
+
+	public Integer getMaxFetchSize() {
+		return maxFetchSize;
+	}
+
+	public void setMaxFetchSize(Integer maxFetchSize) {
+		this.maxFetchSize = maxFetchSize;
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -18,6 +18,7 @@ package com.google.cloud.spring.stream.binder.pubsub;
 
 import com.google.cloud.spring.pubsub.PubSubAdmin;
 import com.google.cloud.spring.pubsub.core.PubSubTemplate;
+import com.google.cloud.spring.pubsub.integration.inbound.PubSubMessageSource;
 import com.google.cloud.spring.pubsub.integration.outbound.PubSubMessageHandler;
 import com.google.cloud.spring.stream.binder.pubsub.config.PubSubBinderConfiguration;
 import com.google.cloud.spring.stream.binder.pubsub.properties.PubSubConsumerProperties;
@@ -90,6 +91,7 @@ public class PubSubMessageChannelBinderTests {
 				this.properties);
 
 		when(producerDestination.getName()).thenReturn("test-topic");
+		when(consumerDestination.getName()).thenReturn("test-subscription");
 	}
 
 	@Test
@@ -129,6 +131,20 @@ public class PubSubMessageChannelBinderTests {
 							errorChannel
 					);
 					assertThat(messageHandler.isSync()).isTrue();
+				});
+	}
+
+	@Test
+	public void consumerMaxFetchPropertyPropagatesToMessageSource() {
+		baseContext
+				.withPropertyValues("spring.cloud.stream.gcp.pubsub.default.consumer.maxFetchSize=20")
+				.run(ctx -> {
+					PubSubMessageChannelBinder binder = ctx.getBean(PubSubMessageChannelBinder.class);
+					PubSubExtendedBindingProperties props = ctx.getBean("pubSubExtendedBindingProperties", PubSubExtendedBindingProperties.class);
+
+					PubSubMessageSource source = binder.createPubSubMessageSource(consumerDestination,
+							new ExtendedConsumerProperties<>(props.getExtendedConsumerProperties("test")));
+					assertThat(source.getMaxFetchSize()).isEqualTo(20);
 				});
 	}
 


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-gcp/issues/1432