### PR TITLE
fix(tests): Re-enable documentation integration tests

### DIFF
--- a/docs/src/main/asciidoc/firestore.adoc
+++ b/docs/src/main/asciidoc/firestore.adoc
@@ -355,9 +355,9 @@ The starter automatically configures and registers a `Firestore` bean in the Spr
  @Autowired
  Firestore firestore;
 
-include::{project-root}/docs/src/test/java/com/google/cloud/spring/sample/firestore/FirestoreDocumentationIntegrationTests.java[tag=write]
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/FirestoreDocumentationIntegrationTests.java[tag=write]
 
-include::{project-root}/docs/src/test/java/com/google/cloud/spring/sample/firestore/FirestoreDocumentationIntegrationTests.java[tag=read]
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/FirestoreDocumentationIntegrationTests.java[tag=read]
 ----
 
 === Emulator Usage

--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -154,7 +154,7 @@ Here is an example of how to publish a message to a Google Cloud Pub/Sub topic:
 
 [source,java,indent=0]
 ----
-include::{project-root}/docs/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=publish]
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=publish]
 ----
 
 By default, the `SimplePubSubMessageConverter` is used to convert payloads of type `byte[]`, `ByteString`, `ByteBuffer`, and `String` to Pub/Sub messages.
@@ -170,7 +170,7 @@ The subscription name could either be a canonical subscription name within the c
 Subscribe to a subscription with a message handler:
 [source,java,indent=0]
 ----
-include::{project-root}/docs/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=subscribe]
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=subscribe]
 ----
 ===== Subscribe methods
 `PubSubTemplate` provides the following subscribe methods:
@@ -196,7 +196,7 @@ This is different from subscribing to a subscription, in the sense that subscrib
 Pull up to 10 messages:
 [source,java,indent=0]
 ----
-include::{project-root}/docs/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=pull]
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=pull]
 ----
 
 ===== Pull methods
@@ -237,7 +237,7 @@ For serialization and deserialization of POJOs using Jackson JSON, configure a `
 
 [source,java,indent=0]
 ----
-include::{project-root}/docs/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=json_bean]
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=json_bean]
 ----
 
 NOTE: Alternatively, you can set it directly by calling the `setMessageConverter()` method on the `PubSubTemplate`.
@@ -247,20 +247,20 @@ Assuming you have the following class defined:
 
 [source,java,indent=0]
 ----
-include::{project-root}/docs/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=json_convertible_class]
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=json_convertible_class]
 ----
 
 You can serialize objects to JSON on publish automatically:
 
 [source,java,indent=0]
 ----
-include::{project-root}/docs/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=json_publish]
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=json_publish]
 ----
 
 And that's how you convert messages to objects on pull:
 [source,java,indent=0]
 ----
-include::{project-root}/docs/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=json_pull]
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=json_pull]
 ----
 
 
@@ -366,7 +366,7 @@ Here is an example of how to list every Google Cloud Pub/Sub topic name in a pro
 
 [source,java,indent=0]
 ----
-include::{project-root}/docs/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=list_topics]
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=list_topics]
 ----
 
 ==== Creating a subscription
@@ -437,7 +437,7 @@ Here is an example of how to list every subscription name in a project:
 
 [source,java,indent=0]
 ----
-include::{project-root}/docs/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=list_subscriptions]
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=list_subscriptions]
 ----
 
 === Sample

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -317,4 +317,23 @@
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>spring-cloud-gcp-ci-it</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <spring.cloud.gcp.firestore.project-id>spring-cloud-gcp-ci-firestore</spring.cloud.gcp.firestore.project-id>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/FirestoreDocumentationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/FirestoreDocumentationIntegrationTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.spring.sample.firestore;
+package com.google.cloud.spring.autoconfigure.firestore.it;
 
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/User.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/User.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.spring.sample.firestore;
+package com.google.cloud.spring.autoconfigure.firestore.it;
 
 import java.util.List;
 import java.util.Objects;


### PR DESCRIPTION
Seems failsafe (maybe surefire too?) doesn't run when `packaging` is `pom`. After discussing with the team, we agreed to move these last two tests into a real module.