### PR TITLE
docs: Have docs module inherit from Spring Cloud pom to get docgen working again

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -7,6 +7,7 @@ on:
   schedule:
     - cron: '30 9 * * *' # 09:30 UTC every day
 
+
 jobs:
   unitTests:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
@@ -55,8 +56,9 @@ jobs:
       continue-on-error: true
       uses: actions/upload-artifact@v2
       with:
-        name: Test logs - ${{ matrix.it}}
+        name: Unit Test Logs - Java ${{ matrix.java }}
         path: "**/target/surefire-reports/*"
+
 
   integrationTests:
     if: |
@@ -137,8 +139,9 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
-          name: Test logs - ${{ matrix.it}}
+          name: Integration Test Logs - ${{ matrix.it}}
           path: "**/target/failsafe-reports/*"
+
 
   releaseCheck:
     if: |
@@ -165,12 +168,24 @@ jobs:
         run: |
           ./mvnw \
             --batch-mode \
-            --activate-profiles release \
+            --activate-profiles release,docs \
             -DskipTests \
             -Dgpg.skip \
             -Dcheckstyle.skip \
             clean \
             package
+      - name: Archive Artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: Release Artifacts
+          path: |
+            **/.flattened-pom.xml
+            **/target/**.jar
+            target/site/apidocs
+            **/target/generated-docs
+            !spring-cloud-gcp-samples
 
 
   linkageCheck:

--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,7 @@ Manual changes to this file will be lost when it is generated again.
 Edit the files in the src/main/asciidoc/ directory instead.
 ////
 
+
 image:https://github.com/GoogleCloudPlatform/spring-cloud-gcp/workflows/Build%20And%20Test/badge.svg?branch=master["Master Build Status", link="https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions?query=branch%3Amaster+"]
 
 == Spring Framework on Google Cloud Platform

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -3,15 +3,18 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
-		<artifactId>spring-cloud-gcp</artifactId>
-		<groupId>com.google.cloud</groupId>
-		<version>2.0.0-SNAPSHOT</version>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-build</artifactId>
+		<version>3.0.0-M4</version>
+		<relativePath/>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>spring-cloud-gcp-docs</artifactId>
-	<packaging>pom</packaging>
 	<name>Spring Cloud GCP Documentation</name>
+	<groupId>com.google.cloud</groupId>
+	<artifactId>spring-cloud-gcp-docs</artifactId>
+	<version>2.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
 
 	<properties>
 		<docs.main>spring-cloud-gcp</docs.main>
@@ -20,73 +23,24 @@
 		<upload-docs-zip.phase>deploy</upload-docs-zip.phase>
 	</properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-bus-pubsub</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-config</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-data-datastore</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-data-spanner</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-firestore</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-logging</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-metrics</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-security-iap</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-sql-mysql</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-sql-postgresql</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-storage</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-trace</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>spring-cloud-gcp-starter-vision</artifactId>
-		</dependency>
-	</dependencies>
+	<repositories>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>https://repo.spring.io/release</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 
 	<profiles>
 		<profile>
@@ -98,9 +52,11 @@
 						<artifactId>git-commit-id-plugin</artifactId>
 					</plugin>
 					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-dependency-plugin</artifactId>
 					</plugin>
 					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-resources-plugin</artifactId>
 					</plugin>
 					<plugin>
@@ -110,17 +66,17 @@
 					<plugin>
 						<groupId>org.asciidoctor</groupId>
 						<artifactId>asciidoctor-maven-plugin</artifactId>
-						<configuration>
-							<attributes>
-								<project-version>${project.version}</project-version>
-							</attributes>
-						</configuration>
 					</plugin>
 					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-antrun-plugin</artifactId>
 					</plugin>
 					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-deploy-plugin</artifactId>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>

--- a/pom.xml
+++ b/pom.xml
@@ -601,8 +601,9 @@
 							<execution>
 								<id>aggregate</id>
 								<goals>
-									<goal>aggregate</goal>
+									<goal>aggregate-no-fork</goal>
 								</goals>
+								<phase>package</phase>
 							</execution>
 						</executions>
 						<configuration>


### PR DESCRIPTION
So the doc setup Spring uses is pretty complex. Instead of doing the normal copy-pasting, if we intend to continue publishing to spring.io, we probably need to continue using their exact doc-generating setup. 

Given that we no longer have any _code_ in the `docs` module, we no longer need to pull in everything as a dependency.

A good portion of this PR involves ensuring GitHub actions saves off these newly-generated archives in each run, so take a look at https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/100/checks and download the `Release Artifacts.zip` file to explore what is actually generated:
* `docs/target/generated-docs/reference/html/index.html` 
* `target/site/apidocs/index.html`

Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/99