### PR TITLE
docs(migration): Adds first draft of migration guide for 2.0

### DIFF
--- a/docs/src/main/asciidoc/migration-guide-1.x.adoc
+++ b/docs/src/main/asciidoc/migration-guide-1.x.adoc
@@ -1,4 +1,4 @@
-== Migration Guide from Spring Cloud GCP 1.x
+== Migration Guide from Spring Cloud GCP 1.x to 2.x
 
 === Maven Group ID Change
 Spring Cloud  link:https://spring.io/blog/2019/07/24/simplifying-the-spring-cloud-release-train[unbundled] Spring Cloud GCP and other cloud providers from their release train.

--- a/docs/src/main/asciidoc/migration-guide-1.x.adoc
+++ b/docs/src/main/asciidoc/migration-guide-1.x.adoc
@@ -5,25 +5,71 @@ Spring Cloud  link:https://spring.io/blog/2019/07/24/simplifying-the-spring-clou
 To use the newly unbundled libraries, change the group IDs in your `pom.xml` files:
 
 [source,xml]
-.pom.xml
+.Before (pom.xml)
 ----
-<dependency>
-  <groupId>com.google.cloud</groupId> <!-- formerly org.springframework.cloud</groupId> -->
-  <artifactId>spring-cloud-gcp-dependencies</artifactId>
-  <version>2.0.0</version>
-  <type>pom</type>
-  <scope>import</scope>
-</dependency>
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-dependencies</artifactId>
+      <version>${spring-cloud.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter</artifactId>
+  </dependency>
+</dependencies>
 ----
+
+[source,xml]
+.After (pom.xml)
+----
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-dependencies</artifactId>
+      <version>2020.0.0</version> <!--1-->
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId> <!--2-->
+      <artifactId>spring-cloud-gcp-dependencies</artifactId>
+      <version>2.0.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>com.google.cloud</groupId> <!--3-->
+    <artifactId>spring-cloud-gcp-starter</artifactId>
+  </dependency>
+  ... <!--4-->
+</dependencies>
+----
+<1> Upgrade to Spring Cloud Ilford release
+<2> Explicitly add `spring-cloud-gcp-dependencies` to import the POM
+<3> Change Group IDs to `com.google.cloud`
+<4> Add other `starters` as desired (i.e., `spring-cloud-gcp-starter-pubsub` or `spring-cloud-gcp-starter-storage`)
 
 === Java Package Name Change
 All code in Spring Cloud GCP has been moved from `org.springframework.cloud.gcp` over to the `com.google.cloud.spring` package.
 
-=== Deprecated Items removed
+=== Deprecated Items Removed
 
-`GCPDatastoreProperties.emulatorHost`:: Use `host` instead
+Property `spring.cloud.gcp.datastore.emulatorHost` :: Use `spring.cloud.gcp.datastore.host` instead
 `GcpPubSubHeaders.ACKNOWLEDGEMENT`:: Use `GcpPubSubHeaders.ORIGINAL_MESSAGE`, which is of type `BasicAcknowledgeablePubsubMessage`
-`SpannerQueryOptions.getQueryOptions`:: Use `getOptions()`
+`SpannerQueryOptions.getQueryOptions()`:: Use `getOptions()`
 `PubSubTemplate.subscribe(String, MessageReceiver)`:: Use `subscribe(String, Consumer<BasicAcknowledgeablePubsubMessage>)`
 `SpannerReadOptions.getReadOptions()`:: Use `getOptions()`
 Stackdriver Logging::

--- a/docs/src/main/asciidoc/migration-guide-1.x.adoc
+++ b/docs/src/main/asciidoc/migration-guide-1.x.adoc
@@ -9,7 +9,10 @@ To use the newly unbundled libraries, change the group IDs in your `pom.xml` fil
 ----
 <dependency>
   <groupId>com.google.cloud</groupId> <!-- formerly org.springframework.cloud</groupId> -->
-  <artifactId>spring-cloud-gcp-starter-config</artifactId>
+  <artifactId>spring-cloud-gcp-dependencies</artifactId>
+  <version>2.0.0</version>
+  <type>pom</type>
+  <scope>import</scope>
 </dependency>
 ----
 
@@ -22,16 +25,16 @@ All code in Spring Cloud GCP has been moved from `org.springframework.cloud.gcp`
 `GcpPubSubHeaders.ACKNOWLEDGEMENT`:: Use `GcpPubSubHeaders.ORIGINAL_MESSAGE`, which is of type `BasicAcknowledgeablePubsubMessage`
 `SpannerQueryOptions.getQueryOptions`:: Use `getOptions()`
 `PubSubTemplate.subscribe(String, MessageReceiver)`:: Use `subscribe(String, Consumer<BasicAcknowledgeablePubsubMessage>)`
-`SpannerReadOptions.getReadOptions()`:: Use `getOptions`
+`SpannerReadOptions.getReadOptions()`:: Use `getOptions()`
 Stackdriver Logging::
   `org.springframework.cloud.gcp.autoconfigure.logging` classes::: Use `com.google.cloud.spring.logging` from the `spring-cloud-gcp-logging` module.
-  Stackdriver Logback Appenders::: Use `com/google/cloud/spring/logging/logback-appender.xml` or `com/google/cloud/spring/logging/logback-json-appender.xml` from the `spring-cloud-gcp-logging` module.
-+  
+  Stackdriver Logback Appenders::: Replace `org/springframework/cloud/gcp/autoconfigure/logging/logback[-json]-appender.xml` with `com/google/cloud/spring/logging/logback[-json]-appender.xml` from the `spring-cloud-gcp-logging` module.
++
 [source,xml]
 .logback-spring.xml
 ----
 <configuration>
-    <include resource="com/google/cloud/spring/logging/logback-appender.xml" />
-    ...
+  <include resource="com/google/cloud/spring/logging/logback-appender.xml" />
+  ...
 </configuration>
 ----

--- a/docs/src/main/asciidoc/migration-guide-1.x.adoc
+++ b/docs/src/main/asciidoc/migration-guide-1.x.adoc
@@ -1,0 +1,37 @@
+== Migration Guide from Spring Cloud GCP 1.x
+
+=== Maven Group ID Change
+Spring Cloud  link:https://spring.io/blog/2019/07/24/simplifying-the-spring-cloud-release-train[unbundled] Spring Cloud GCP and other IaaS providers from their release train.
+To use the newly unbundled libraries, change the group IDs in your `pom.xml` files:
+
+[source,xml]
+.pom.xml
+----
+<dependency>
+  <groupId>com.google.cloud</groupId> <!-- formerly org.springframework.cloud</groupId> -->
+  <artifactId>spring-cloud-gcp-starter-config</artifactId>
+</dependency>
+----
+
+=== Java Package Name Change
+All code in Spring Cloud GCP has been moved from `org.springframework.cloud.gcp` over to the `com.google.cloud.spring` package.
+
+=== Deprecated Items removed
+
+`GCPDatastoreProperties.emulatorHost`:: Use `host` instead
+`GcpPubSubHeaders.ACKNOWLEDGEMENT`:: Use `GcpPubSubHeaders.ORIGINAL_MESSAGE`, which is of type `BasicAcknowledgeablePubsubMessage`
+`SpannerQueryOptions.getQueryOptions`:: Use `getOptions()`
+`PubSubTemplate.subscribe(String, MessageReceiver)`:: Use `subscribe(String, Consumer<BasicAcknowledgeablePubsubMessage>)`
+`SpannerReadOptions.getReadOptions()`:: Use `getOptions`
+Stackdriver Logging::
+  `org.springframework.cloud.gcp.autoconfigure.logging` classes::: Use `com.google.cloud.spring.logging` from the `spring-cloud-gcp-logging` module.
+  Stackdriver Logback Appenders::: Use `com/google/cloud/spring/logging/logback-appender.xml` or `com/google/cloud/spring/logging/logback-json-appender.xml` from the `spring-cloud-gcp-logging` module.
++  
+[source,xml]
+.logback-spring.xml
+----
+<configuration>
+    <include resource="com/google/cloud/spring/logging/logback-appender.xml" />
+    ...
+</configuration>
+----

--- a/docs/src/main/asciidoc/migration-guide-1.x.adoc
+++ b/docs/src/main/asciidoc/migration-guide-1.x.adoc
@@ -1,7 +1,7 @@
 == Migration Guide from Spring Cloud GCP 1.x
 
 === Maven Group ID Change
-Spring Cloud  link:https://spring.io/blog/2019/07/24/simplifying-the-spring-cloud-release-train[unbundled] Spring Cloud GCP and other IaaS providers from their release train.
+Spring Cloud  link:https://spring.io/blog/2019/07/24/simplifying-the-spring-cloud-release-train[unbundled] Spring Cloud GCP and other cloud providers from their release train.
 To use the newly unbundled libraries, change the group IDs in your `pom.xml` files:
 
 [source,xml]

--- a/docs/src/main/asciidoc/migration-guide-1.x.adoc
+++ b/docs/src/main/asciidoc/migration-guide-1.x.adoc
@@ -2,7 +2,7 @@
 
 === Maven Group ID Change
 Spring Cloud  link:https://spring.io/blog/2019/07/24/simplifying-the-spring-cloud-release-train[unbundled] Spring Cloud GCP and other cloud providers from their release train.
-To use the newly unbundled libraries, change the group IDs in your `pom.xml` files:
+To use the newly unbundled libraries, add the `spring-cloud-gcp-dependencies` bill of materials (BOM) and change the `spring-cloud-gcp` group IDs in your `pom.xml` files:
 
 [source,xml]
 .Before (pom.xml)
@@ -58,7 +58,7 @@ To use the newly unbundled libraries, change the group IDs in your `pom.xml` fil
 </dependencies>
 ----
 <1> Upgrade to Spring Cloud Ilford release
-<2> Explicitly add `spring-cloud-gcp-dependencies` to import the POM
+<2> Explicitly add `spring-cloud-gcp-dependencies` to import the BOM
 <3> Change Group IDs to `com.google.cloud`
 <4> Add other `starters` as desired (i.e., `spring-cloud-gcp-starter-pubsub` or `spring-cloud-gcp-starter-storage`)
 
@@ -73,7 +73,7 @@ Property `spring.cloud.gcp.datastore.emulatorHost` :: Use `spring.cloud.gcp.data
 `PubSubTemplate.subscribe(String, MessageReceiver)`:: Use `subscribe(String, Consumer<BasicAcknowledgeablePubsubMessage>)`
 `SpannerReadOptions.getReadOptions()`:: Use `getOptions()`
 Stackdriver Logging::
-  `org.springframework.cloud.gcp.autoconfigure.logging` classes::: Use `com.google.cloud.spring.logging` from the `spring-cloud-gcp-logging` module.
+  `org.springframework.cloud.gcp.autoconfigure.logging` package::: Use `com.google.cloud.spring.logging` from the `spring-cloud-gcp-logging` module.
   Stackdriver Logback Appenders::: Replace `org/springframework/cloud/gcp/autoconfigure/logging/logback[-json]-appender.xml` with `com/google/cloud/spring/logging/logback[-json]-appender.xml` from the `spring-cloud-gcp-logging` module.
 +
 [source,xml]

--- a/docs/src/main/asciidoc/spring-cloud-gcp.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gcp.adoc
@@ -1,6 +1,6 @@
 [[spring-cloud-gcp-reference]]
 = Spring Cloud GCP
-João André Martins; Jisha Abubaker; Ray Tsang; Mike Eltsufin; Artem Bilan; Andreas Berger; Balint Pato; Chengyuan Zhao; Dmitry Solomakha; Elena Felder; Daniel Zou, Eddú Meléndez
+João André Martins; Jisha Abubaker; Ray Tsang; Mike Eltsufin; Artem Bilan; Andreas Berger; Balint Pato; Chengyuan Zhao; Dmitry Solomakha; Elena Felder; Daniel Zou; Eddú Meléndez; Travis Tomsu
 
 include::_attributes.adoc[]
 
@@ -68,3 +68,5 @@ include::kotlin.adoc[]
 == Configuration properties
 
 To see the list of all GCP related configuration properties please check link:appendix.html[the Appendix page].
+
+include::migration-guide-1.x.adoc[]


### PR DESCRIPTION
Y'all tell me where I'm wrong, but beyond the package name change and some deprecations being removed, were there any other breaking changes?