### PR TITLE
fix(docs): disable docs module deployment to fix kokoro CI

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -20,7 +20,7 @@
 		<docs.main>spring-cloud-gcp</docs.main>
 		<main.basedir>${basedir}/..</main.basedir>
 		<configprops.inclusionPattern>spring.cloud.gcp.*</configprops.inclusionPattern>
-		<upload-docs-zip.phase>deploy</upload-docs-zip.phase>
+		<upload-docs-zip.phase>none</upload-docs-zip.phase>
 	</properties>
 
 	<repositories>
@@ -41,6 +41,18 @@
 			</snapshots>
 		</repository>
 	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 	<profiles>
 		<profile>
@@ -70,13 +82,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-antrun-plugin</artifactId>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-deploy-plugin</artifactId>
-						<configuration>
-							<skip>true</skip>
-						</configuration>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
I'm not 100% sure this will do what I intend long-term (i.e don't deploy docs now, but do it later when we need to publish refdocs to Spring) but it should get our Kokoro CI back to green.