### PR TITLE
Allow for manually specifying BigQuery table schema

### DIFF
--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryOperations.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryOperations.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 
 import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.Schema;
 
 import org.springframework.util.concurrent.ListenableFuture;
 
@@ -44,4 +45,33 @@ public interface BigQueryOperations {
 	 */
 	ListenableFuture<Job> writeDataToTable(
 			String tableName, InputStream inputStream, FormatOptions dataFormatOptions);
+
+	/**
+	 * Writes data to a specified BigQuery table with a manually-specified table Schema.
+   *
+   * <p>Example:
+   *
+	 * <pre>
+	 *  Schema schema = Schema.of(
+	 *   	Field.of("CountyId", StandardSQLTypeName.INT64),
+	 * 		Field.of("State", StandardSQLTypeName.STRING),
+	 * 		Field.of("County", StandardSQLTypeName.STRING)
+	 * 	);
+   *
+	 * 	ListenableFuture<Job> bigQueryJobFuture =
+	 * 			bigQueryTemplate.writeDataToTable(
+	 * 					TABLE_NAME, dataFile.getInputStream(), FormatOptions.csv(), schema);
+	 * </pre>
+   *
+	 * @param tableName name of the table to write to
+	 * @param inputStream input stream of the table data to write
+	 * @param dataFormatOptions the format of the data to write
+	 * @param schema the schema of the table being loaded
+	 * @return {@link ListenableFuture} containing the BigQuery Job indicating completion of
+	 * operation
+
+	 * @throws BigQueryException if errors occur when loading data to the BigQuery table
+	 */
+	ListenableFuture<Job> writeDataToTable(
+			String tableName, InputStream inputStream, FormatOptions dataFormatOptions, Schema schema);
 }

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryOperations.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryOperations.java
@@ -51,17 +51,18 @@ public interface BigQueryOperations {
    *
    * <p>Example:
    *
-	 * <pre>
-	 *  Schema schema = Schema.of(
-	 *   	Field.of("CountyId", StandardSQLTypeName.INT64),
-	 * 		Field.of("State", StandardSQLTypeName.STRING),
-	 * 		Field.of("County", StandardSQLTypeName.STRING)
-	 * 	);
+	 * <pre>{@code
+	 *
+	 * Schema schema = Schema.of(
+	 *    Field.of("CountyId", StandardSQLTypeName.INT64),
+	 *    Field.of("State", StandardSQLTypeName.STRING),
+	 *    Field.of("County", StandardSQLTypeName.STRING)
+	 * );
    *
-	 * 	ListenableFuture<Job> bigQueryJobFuture =
-	 * 			bigQueryTemplate.writeDataToTable(
-	 * 					TABLE_NAME, dataFile.getInputStream(), FormatOptions.csv(), schema);
-	 * </pre>
+	 * ListenableFuture<Job> bigQueryJobFuture =
+	 *     bigQueryTemplate.writeDataToTable(
+	 * 	       TABLE_NAME, dataFile.getInputStream(), FormatOptions.csv(), schema);
+	 * }</pre>
    *
 	 * @param tableName name of the table to write to
 	 * @param inputStream input stream of the table data to write

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryOperations.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryOperations.java
@@ -48,9 +48,9 @@ public interface BigQueryOperations {
 
 	/**
 	 * Writes data to a specified BigQuery table with a manually-specified table Schema.
-   *
-   * <p>Example:
-   *
+	 *
+	 * <p>Example:
+	 *
 	 * <pre>{@code
 	 *
 	 * Schema schema = Schema.of(
@@ -58,19 +58,19 @@ public interface BigQueryOperations {
 	 *    Field.of("State", StandardSQLTypeName.STRING),
 	 *    Field.of("County", StandardSQLTypeName.STRING)
 	 * );
-   *
+	 *
 	 * ListenableFuture<Job> bigQueryJobFuture =
 	 *     bigQueryTemplate.writeDataToTable(
 	 * 	       TABLE_NAME, dataFile.getInputStream(), FormatOptions.csv(), schema);
 	 * }</pre>
-   *
+	 *
 	 * @param tableName name of the table to write to
 	 * @param inputStream input stream of the table data to write
 	 * @param dataFormatOptions the format of the data to write
 	 * @param schema the schema of the table being loaded
 	 * @return {@link ListenableFuture} containing the BigQuery Job indicating completion of
 	 * operation
-
+	 *
 	 * @throws BigQueryException if errors occur when loading data to the BigQuery table
 	 */
 	ListenableFuture<Job> writeDataToTable(

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobInfo.WriteDisposition;
 import com.google.cloud.bigquery.JobStatus.State;
+import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TableDataWriteChannel;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.WriteChannelConfiguration;
@@ -124,16 +125,26 @@ public class BigQueryTemplate implements BigQueryOperations {
 	@Override
 	public ListenableFuture<Job> writeDataToTable(
 			String tableName, InputStream inputStream, FormatOptions dataFormatOptions) {
+	  return this.writeDataToTable(tableName, inputStream, dataFormatOptions, null);
+	}
+
+	@Override
+	public ListenableFuture<Job> writeDataToTable(
+			String tableName, InputStream inputStream, FormatOptions dataFormatOptions, Schema schema) {
+
 		TableId tableId = TableId.of(datasetName, tableName);
 
-		WriteChannelConfiguration writeChannelConfiguration = WriteChannelConfiguration
+		WriteChannelConfiguration.Builder writeChannelConfiguration = WriteChannelConfiguration
 				.newBuilder(tableId)
 				.setFormatOptions(dataFormatOptions)
-				.setAutodetect(this.autoDetectSchema)
 				.setWriteDisposition(this.writeDisposition)
-				.build();
+				.setAutodetect(this.autoDetectSchema);
 
-		TableDataWriteChannel writer = bigQuery.writer(writeChannelConfiguration);
+		if (schema != null) {
+			writeChannelConfiguration.setSchema(schema);
+		}
+
+		TableDataWriteChannel writer = bigQuery.writer(writeChannelConfiguration.build());
 
 		try (OutputStream sink = Channels.newOutputStream(writer)) {
 			// Write data from data input file to BigQuery
@@ -163,15 +174,19 @@ public class BigQueryTemplate implements BigQueryOperations {
 		SettableListenableFuture<Job> result = new SettableListenableFuture<>();
 
 		ScheduledFuture<?> scheduledFuture = taskScheduler.scheduleAtFixedRate(() -> {
-			Job job = pendingJob.reload();
-			if (State.DONE.equals(job.getStatus().getState())) {
-				if (job.getStatus().getError() != null) {
-					result.setException(
-							new BigQueryException(job.getStatus().getError().getMessage()));
+		  try {
+				Job job = pendingJob.reload();
+				if (State.DONE.equals(job.getStatus().getState())) {
+					if (job.getStatus().getError() != null) {
+						result.setException(
+								new BigQueryException(job.getStatus().getError().getMessage()));
+					}
+					else {
+						result.set(job);
+					}
 				}
-				else {
-					result.set(job);
-				}
+			} catch (Exception e) {
+				result.setException(new BigQueryException(e.getMessage()));
 			}
 		}, this.jobPollInterval);
 

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
@@ -125,7 +125,7 @@ public class BigQueryTemplate implements BigQueryOperations {
 	@Override
 	public ListenableFuture<Job> writeDataToTable(
 			String tableName, InputStream inputStream, FormatOptions dataFormatOptions) {
-	  return this.writeDataToTable(tableName, inputStream, dataFormatOptions, null);
+		return this.writeDataToTable(tableName, inputStream, dataFormatOptions, null);
 	}
 
 	@Override
@@ -174,7 +174,7 @@ public class BigQueryTemplate implements BigQueryOperations {
 		SettableListenableFuture<Job> result = new SettableListenableFuture<>();
 
 		ScheduledFuture<?> scheduledFuture = taskScheduler.scheduleAtFixedRate(() -> {
-		  try {
+			try {
 				Job job = pendingJob.reload();
 				if (State.DONE.equals(job.getStatus().getState())) {
 					if (job.getStatus().getError() != null) {
@@ -185,7 +185,8 @@ public class BigQueryTemplate implements BigQueryOperations {
 						result.set(job);
 					}
 				}
-			} catch (Exception e) {
+			}
+			catch (Exception e) {
 				result.setException(new BigQueryException(e.getMessage()));
 			}
 		}, this.jobPollInterval);

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/integration/BigQuerySpringMessageHeaders.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/integration/BigQuerySpringMessageHeaders.java
@@ -40,6 +40,11 @@ public final class BigQuerySpringMessageHeaders {
 	 */
 	public static final String FORMAT_OPTIONS = PREFIX + "format_options";
 
+	/**
+	 * The schema of the table to load. Not needed if relying on auto-detecting the schema.
+	 */
+	public static final String TABLE_SCHEMA = PREFIX + "table_schema";
+
 	private BigQuerySpringMessageHeaders() {
 	}
 }

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/integration/outbound/BigQueryFileMessageHandler.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/integration/outbound/BigQueryFileMessageHandler.java
@@ -139,7 +139,7 @@ public class BigQueryFileMessageHandler extends AbstractReplyProducingMessageHan
 	}
 
 	/**
-   * Sets the {@link Schema} of the table to load for the handler.
+	 * Sets the {@link Schema} of the table to load for the handler.
 	 * @param schema the schema of the table to load.
 	 */
 	public void setTableSchema(Schema schema) {

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/integration/outbound/BigQueryFileMessageHandler.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/integration/outbound/BigQueryFileMessageHandler.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeoutException;
 
 import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.Schema;
 import com.google.cloud.spring.bigquery.core.BigQueryTemplate;
 import com.google.cloud.spring.bigquery.integration.BigQuerySpringMessageHeaders;
 
@@ -63,6 +64,8 @@ public class BigQueryFileMessageHandler extends AbstractReplyProducingMessageHan
 
 	private Expression formatOptionsExpression;
 
+	private Expression tableSchemaExpression;
+
 	private Duration timeout = Duration.ofMinutes(5);
 
 	private boolean sync = false;
@@ -78,6 +81,10 @@ public class BigQueryFileMessageHandler extends AbstractReplyProducingMessageHan
 		this.formatOptionsExpression =
 				new FunctionExpression<Message>(
 						message -> message.getHeaders().get(BigQuerySpringMessageHeaders.FORMAT_OPTIONS));
+
+		this.tableSchemaExpression =
+				new FunctionExpression<Message>(
+						message -> message.getHeaders().get(BigQuerySpringMessageHeaders.TABLE_SCHEMA));
 	}
 
 	@Override
@@ -123,6 +130,23 @@ public class BigQueryFileMessageHandler extends AbstractReplyProducingMessageHan
 	}
 
 	/**
+	 * Sets the SpEL expression used to determine the {@link Schema} for the handler.
+	 * @param tableSchemaExpression the SpEL expression used to evaluate the {@link Schema}.
+	 */
+	public void setTableSchemaExpression(Expression tableSchemaExpression) {
+		Assert.notNull(formatOptionsExpression, "The table schema expression cannot be null.");
+		this.tableSchemaExpression = tableSchemaExpression;
+	}
+
+	/**
+   * Sets the {@link Schema} of the table to load for the handler.
+	 * @param schema the schema of the table to load.
+	 */
+	public void setTableSchema(Schema schema) {
+		this.formatOptionsExpression = new ValueExpression<>(schema);
+	}
+
+	/**
 	 * Sets the {@link Duration} to wait for a file to be loaded into BigQuery before timing out
 	 * when waiting synchronously.
 	 * @param timeout the {@link Duration} timeout to wait for a file to load
@@ -154,13 +178,15 @@ public class BigQueryFileMessageHandler extends AbstractReplyProducingMessageHan
 				this.tableNameExpression.getValue(this.evaluationContext, message, String.class);
 		FormatOptions formatOptions =
 				this.formatOptionsExpression.getValue(this.evaluationContext, message, FormatOptions.class);
+		Schema schema =
+				this.tableSchemaExpression.getValue(this.evaluationContext, message, Schema.class);
 
 		Assert.notNull(tableName, "BigQuery table name must not be null.");
 		Assert.notNull(formatOptions, "Data file formatOptions must not be null.");
 
 		try (InputStream inputStream = convertToInputStream(message.getPayload())) {
-			ListenableFuture<Job> jobFuture = this.bigQueryTemplate.writeDataToTable(tableName, inputStream,
-					formatOptions);
+			ListenableFuture<Job> jobFuture =
+					this.bigQueryTemplate.writeDataToTable(tableName, inputStream, formatOptions, schema);
 
 			if (this.sync) {
 				return jobFuture.get(this.timeout.getSeconds(), TimeUnit.SECONDS);

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/core/BigQueryTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/core/BigQueryTemplateIntegrationTests.java
@@ -21,10 +21,13 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobStatus;
 import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import org.junit.After;
@@ -75,10 +78,34 @@ public class BigQueryTemplateIntegrationTests {
 	}
 
 	@Before
-	@After
+  @After
 	public void cleanupTestEnvironment() {
 		// Clear the previous dataset before beginning the test.
 		this.bigQuery.delete(TableId.of(DATASET_NAME, TABLE_NAME));
+	}
+
+	@Test
+	public void testLoadFileWithSchema() throws Exception {
+		Schema schema = Schema.of(
+				Field.of("CountyId", StandardSQLTypeName.INT64),
+				Field.of("State", StandardSQLTypeName.STRING),
+				Field.of("County", StandardSQLTypeName.STRING)
+		);
+
+		ListenableFuture<Job> bigQueryJobFuture =
+				bigQueryTemplate.writeDataToTable(
+						TABLE_NAME, dataFile.getInputStream(), FormatOptions.csv(), schema);
+
+		Job job = bigQueryJobFuture.get();
+		assertThat(job.getStatus().getState()).isEqualTo(JobStatus.State.DONE);
+
+		QueryJobConfiguration queryJobConfiguration = QueryJobConfiguration
+				.newBuilder("SELECT * FROM test_dataset.template_test_table").build();
+		TableResult result = this.bigQuery.query(queryJobConfiguration);
+
+		assertThat(result.getTotalRows()).isEqualTo(1);
+		assertThat(
+				result.getValues().iterator().next().get("State").getStringValue()).isEqualTo("Alabama");
 	}
 
 	@Test

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/core/BigQueryTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/core/BigQueryTemplateIntegrationTests.java
@@ -78,7 +78,7 @@ public class BigQueryTemplateIntegrationTests {
 	}
 
 	@Before
-  @After
+	@After
 	public void cleanupTestEnvironment() {
 		// Clear the previous dataset before beginning the test.
 		this.bigQuery.delete(TableId.of(DATASET_NAME, TABLE_NAME));

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/integration/outbound/BigQueryFileMessageHandlerIntegrationTests.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/integration/outbound/BigQueryFileMessageHandlerIntegrationTests.java
@@ -22,9 +22,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Field.Mode;
 import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.spring.bigquery.core.BigQueryTestConfiguration;
@@ -79,10 +83,50 @@ public class BigQueryFileMessageHandlerIntegrationTests {
 	}
 
 	@Before
-	@After
+  @After
 	public void setup() {
 		// Clear the previous dataset before beginning the test.
 		this.bigquery.delete(TableId.of(DATASET_NAME, TABLE_NAME));
+	}
+
+	@Test
+	public void testLoadFileWithSchema() throws InterruptedException, ExecutionException {
+		Schema schema = Schema.of(
+		    Field.newBuilder("CountyId", StandardSQLTypeName.STRING).setMode(Mode.NULLABLE).build(),
+				Field.newBuilder("State", StandardSQLTypeName.STRING).setMode(Mode.NULLABLE).build(),
+				Field.newBuilder("County", StandardSQLTypeName.STRING).setMode(Mode.NULLABLE).build()
+		);
+
+		HashMap<String, Object> messageHeaders = new HashMap<>();
+		messageHeaders.put(BigQuerySpringMessageHeaders.TABLE_NAME, TABLE_NAME);
+		messageHeaders.put(BigQuerySpringMessageHeaders.FORMAT_OPTIONS, FormatOptions.csv());
+		messageHeaders.put(BigQuerySpringMessageHeaders.TABLE_SCHEMA, schema);
+
+		Message<File> message = MessageBuilder.createMessage(
+				new File("src/test/resources/data.csv"),
+				new MessageHeaders(messageHeaders));
+
+		ListenableFuture<Job> jobFuture =
+				(ListenableFuture<Job>) this.messageHandler.handleRequestMessage(message);
+
+		// Assert that a BigQuery polling task is scheduled successfully.
+		await().atMost(Duration.FIVE_SECONDS)
+				.untilAsserted(
+						() -> assertThat(
+								this.taskScheduler.getScheduledThreadPoolExecutor().getQueue()).hasSize(1));
+		jobFuture.get();
+
+		QueryJobConfiguration queryJobConfiguration = QueryJobConfiguration
+				.newBuilder("SELECT * FROM test_dataset.test_table").build();
+		TableResult result = this.bigquery.query(queryJobConfiguration);
+
+		assertThat(result.getTotalRows()).isEqualTo(1);
+		assertThat(
+				result.getValues().iterator().next().get("State").getStringValue()).isEqualTo("Alabama");
+		assertThat(result.getSchema()).isEqualTo(schema);
+
+		// This asserts that the BigQuery job polling task is no longer in the scheduler.
+		assertThat(this.taskScheduler.getScheduledThreadPoolExecutor().getQueue()).hasSize(0);
 	}
 
 	@Test

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/integration/outbound/BigQueryFileMessageHandlerIntegrationTests.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/integration/outbound/BigQueryFileMessageHandlerIntegrationTests.java
@@ -83,7 +83,7 @@ public class BigQueryFileMessageHandlerIntegrationTests {
 	}
 
 	@Before
-  @After
+	@After
 	public void setup() {
 		// Clear the previous dataset before beginning the test.
 		this.bigquery.delete(TableId.of(DATASET_NAME, TABLE_NAME));
@@ -92,7 +92,7 @@ public class BigQueryFileMessageHandlerIntegrationTests {
 	@Test
 	public void testLoadFileWithSchema() throws InterruptedException, ExecutionException {
 		Schema schema = Schema.of(
-		    Field.newBuilder("CountyId", StandardSQLTypeName.STRING).setMode(Mode.NULLABLE).build(),
+				Field.newBuilder("CountyId", StandardSQLTypeName.STRING).setMode(Mode.NULLABLE).build(),
 				Field.newBuilder("State", StandardSQLTypeName.STRING).setMode(Mode.NULLABLE).build(),
 				Field.newBuilder("County", StandardSQLTypeName.STRING).setMode(Mode.NULLABLE).build()
 		);


### PR DESCRIPTION
This allows for manually specifying BigQuery schema when a datafile is loaded.

Introducing an overloaded method:

```
ListenableFuture<Job> writeDataToTable(
			String tableName, InputStream inputStream, FormatOptions dataFormatOptions, Schema schema);
```

Which allows you to manually specify the `Schema` if you do not want to rely on schema auto-detect and are unable to create the table beforehand.

https://github.com/spring-cloud/spring-cloud-gcp/issues/2576

