### PR TITLE
fix(release): Don't activate release profile until deploy

### DIFF
--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -29,13 +29,13 @@ setup_environment_secrets
 create_settings_xml_file $MAVEN_SETTINGS_FILE
 
 # run unit tests
-./mvnw verify --show-version --batch-mode -Drelease=true
+./mvnw verify --show-version --batch-mode
 
 # change to release version
-./mvnw versions:set --batch-mode -DremoveSnapshot -DprocessAllModules -Drelease=true
+./mvnw versions:set --batch-mode -DremoveSnapshot -DprocessAllModules
 
 # build and install the jars locally
-./mvnw clean install --batch-mode -DskipTests=true -Drelease=true
+./mvnw clean install --batch-mode -DskipTests=true
 
 # stage release
 ./mvnw deploy \


### PR DESCRIPTION
The `verify` stage fails because when `release` is activated it expects the GPG key. I could have added the skip config but I'm sure there's something else in there and we really only need the `release` profile active during the `deploy` invocation.