### PR TITLE
feat(upgrade): Upgrade to Spring Boot 2.4 and Spring Cloud 2020.0.0-M5

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-M5</version>
 		<relativePath/>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
 		<skipTests>false</skipTests>
 		<spring-cloud-build.version>3.0.0-M5</spring-cloud-build.version>
-		<spring-cloud-dependencies.version>2020.0.0-M4</spring-cloud-dependencies.version>
+		<spring-cloud-dependencies.version>2020.0.0-M5</spring-cloud-dependencies.version>
 		<spring-javaformat-checkstyle.version>0.0.25</spring-javaformat-checkstyle.version>
 		<zipkin-gcp.version>0.17.0</zipkin-gcp.version>
 	</properties>

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -168,6 +168,38 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-sleuth-brave</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.zipkin.gcp</groupId>
+            <artifactId>zipkin-sender-stackdriver</artifactId>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-protobuf</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.zipkin.gcp</groupId>
+            <artifactId>brave-propagation-stackdriver</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Firestore -->
         <dependency>
             <groupId>com.google.cloud</groupId>
@@ -195,38 +227,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.zipkin.gcp</groupId>
-            <artifactId>zipkin-sender-stackdriver</artifactId>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-protobuf</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.zipkin.zipkin2</groupId>
-                    <artifactId>zipkin</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>io.zipkin.gcp</groupId>
-            <artifactId>brave-propagation-stackdriver</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java
@@ -81,9 +81,10 @@ public class PubSubTemplateDocumentationIntegrationTests {
 			Map<String, String> headers = Collections.singletonMap("key1", "val1");
 			pubSubTemplate.publish(topicName, "message", headers).get();
 			//end::publish[]
-			PubsubMessage pubsubMessage = pubSubTemplate.pullNext(subscriptionName);
 
 			await().atMost(new Duration(30, TimeUnit.SECONDS)).untilAsserted(() -> {
+				PubsubMessage pubsubMessage = pubSubTemplate.pullNext(subscriptionName);
+
 				assertThat(pubsubMessage).isNotNull();
 				assertThat(pubsubMessage.getData()).isEqualTo(ByteString.copyFromUtf8("message"));
 				assertThat(pubsubMessage.getAttributesCount()).isEqualTo(1);

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-M5</version>
 		<relativePath/>
 	</parent>
 

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.4.0-M3</version>
+		<version>2.4.0</version>
 		<relativePath/>
 	</parent>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
@@ -15,7 +15,7 @@
     <name>Spring Cloud GCP Code Sample - Pub/Sub Bus Configuration Management</name>
 
     <properties>
-        <spring-cloud-config.version>3.0.0-M4</spring-cloud-config.version>
+        <spring-cloud-config.version>3.0.0-M5</spring-cloud-config.version>
     </properties>
 
     <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
@@ -140,7 +140,7 @@ public class TraceSampleApplicationIntegrationTests {
 
 		await().atMost(4, TimeUnit.MINUTES)
 				.pollInterval(Duration.TWO_SECONDS)
-				.ignoreExceptions()
+				.ignoreExceptionsMatching(e -> e.getMessage().contains("Requested entity was not found"))
 				.untilAsserted(() -> {
 
 			log.debug("Getting trace...");

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
@@ -23,6 +23,10 @@
 			<artifactId>spring-cloud-starter-sleuth</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-sleuth-brave</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.zipkin.gcp</groupId>
 			<artifactId>zipkin-sender-stackdriver</artifactId>
 			<exclusions>
@@ -37,10 +41,6 @@
 				<exclusion>
 					<groupId>io.grpc</groupId>
 					<artifactId>grpc-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>io.zipkin.zipkin2</groupId>
-					<artifactId>zipkin</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>


### PR DESCRIPTION
Also fixes a infrequently-flaky test and specified the expected exception in a Trace test.

The `spring-cloud-gcp-autoconfigure/pom.xml ` changes look worse in GH than they really are - there was a zipkin dep under BigQuery instead of Trace, so I shuffled some of them around.