### PR TITLE
GH Actions Updates

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -111,7 +111,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Setup gcloud
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: latest
           project_id: spring-cloud-gcp-ci

--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -18,7 +18,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.pull_request.head.repo.full_name != 'GoogleCloudPlatform/spring-cloud-gcp'
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -80,7 +80,7 @@ jobs:
         github.event_name == 'push' ||
         github.event_name == 'schedule'
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -187,7 +187,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.pull_request.head.repo.full_name != 'GoogleCloudPlatform/spring-cloud-gcp'
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     steps:
@@ -243,7 +243,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'schedule'
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
Fixes some announcement warnings in our GHA workflow, notably:
* `ubuntu-latest` going to 20.04 (since this works, it's not strictly necessary to specify 20.04, but I want the warnings to go away)
* `setup-gcloud` moved to a new repo