### PR TITLE
docs(build): Make ghpages.sh script work for our GH Pages

### DIFF
--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - master
+  release:
+    types: [published] # includes pre-release and regular releases, but does not include draft releases.
   workflow_dispatch:
     inputs:
       committish:
@@ -33,7 +35,9 @@ jobs:
 
     - name: Update Docs
       run: |
-        if [[ "${{ github.event.inputs.committish }}" == "master" ]] ; then
+        if [[ -n "${{ github.event.release.tag_name }}" ]] ; then
+          ./docs/src/main/asciidoc/ghpages.sh --version ${{ github.event.release.tag_name }} --destination . --build
+        elif [[ "${{ github.event.inputs.committish }}" == "master" ]] ; then
           ./docs/src/main/asciidoc/ghpages.sh --build
         else
           ./docs/src/main/asciidoc/ghpages.sh --version ${{ github.event.inputs.committish }} --destination . --build

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -1,6 +1,9 @@
 name: Update Docs
 
 on:
+  push:
+    branches:
+    - master
   workflow_dispatch:
     inputs:
       committish:
@@ -13,6 +16,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
 
     - uses: actions/setup-java@v1
       with:
@@ -28,7 +34,7 @@ jobs:
     - name: Update Docs
       run: |
         if [[ "${{ github.event.inputs.committish }}" == "master" ]] ; then
-          ./docs/src/main/asciidoc/ghpages.sh
+          ./docs/src/main/asciidoc/ghpages.sh --build
         else
-          ./docs/src/main/asciidoc/ghpages.sh --version ${{ github.event.inputs.committish }} --destination .
+          ./docs/src/main/asciidoc/ghpages.sh --version ${{ github.event.inputs.committish }} --destination . --build
         fi

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-set -e
+set -ev
 
 # Set default props like MAVEN_PATH, ROOT_FOLDER etc.
 function set_default_props() {
@@ -54,13 +54,13 @@ function retrieve_current_branch() {
 
 # Switches to the provided value of the release version. We always prefix it with `v`
 function switch_to_tag() {
-    git checkout ${VERSION}
+    git checkout v${VERSION}
 }
 
 # Build the docs if switch is on
 function build_docs_if_applicable() {
     if [[ "${BUILD}" == "yes" ]] ; then
-        ./mvnw clean install -P docs -pl docs -DskipTests
+        ./mvnw clean install -P docs -pl docs -DskipTests -q
     fi
 }
 
@@ -113,11 +113,9 @@ function add_docs_from_target() {
             echo "[${DESTINATION}] is not a git repository"
             exit 1
         fi
-        DESTINATION_REPO_FOLDER=${DESTINATION}/${REPO_NAME}
-        mkdir -p ${DESTINATION_REPO_FOLDER}
+        DESTINATION_REPO_FOLDER=${DESTINATION}
         echo "Destination was provided [${DESTINATION}]"
     fi
-    cd ${DESTINATION_REPO_FOLDER}
     git checkout gh-pages
     git pull origin gh-pages
 
@@ -290,6 +288,7 @@ key="$1"
 case ${key} in
     -v|--version)
     VERSION="$2"
+    VERSION=${VERSION#"v"} # strip leading "v" character, if present.
     shift # past argument
     ;;
     -d|--destination)


### PR DESCRIPTION
Tested with `v2.0.0-RC2` ([live now](https://googlecloudplatform.github.io/spring-cloud-gcp/2.0.0-RC2/reference/html/index.html)) and `master` (reverted - should update when this PR is submitted. [Current live link](https://googlecloudplatform.github.io/spring-cloud-gcp/reference/html/index.html)).

My intention is to also have this run automatically whenever a new release is cut. This should be pretty easy with this automation.