### PR TITLE
chore(releases): Exclude RTC starter from GA release

### DIFF
--- a/.kokoro/promote.sh
+++ b/.kokoro/promote.sh
@@ -39,6 +39,6 @@ create_settings_xml_file $MAVEN_SETTINGS_FILE
   --settings ${MAVEN_SETTINGS_FILE} \
   -DstagingRepositoryId=${STAGING_REPOSITORY_ID} \
   -Drelease=true \
-  --activate-profiles central
+  --activate-profiles skip-unreleased-modules
 
 popd

--- a/.kokoro/promote.sh
+++ b/.kokoro/promote.sh
@@ -38,6 +38,7 @@ create_settings_xml_file $MAVEN_SETTINGS_FILE
   --batch-mode \
   --settings ${MAVEN_SETTINGS_FILE} \
   -DstagingRepositoryId=${STAGING_REPOSITORY_ID} \
-  -Drelease=true
+  -Drelease=true \
+  --activate-profiles central
 
 popd

--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -46,6 +46,6 @@ create_settings_xml_file $MAVEN_SETTINGS_FILE
   -Dgpg.passphrase=${GPG_PASSPHRASE} \
   -Dgpg.homedir=${GPG_HOMEDIR} \
   -Drelease=true \
-  --activate-profiles central
+  --activate-profiles skip-unreleased-modules
 
 popd

--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -45,6 +45,7 @@ create_settings_xml_file $MAVEN_SETTINGS_FILE
   -Dgpg.executable=gpg \
   -Dgpg.passphrase=${GPG_PASSPHRASE} \
   -Dgpg.homedir=${GPG_HOMEDIR} \
-  -Drelease=true
+  -Drelease=true \
+  --activate-profiles central
 
 popd

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/pom.xml
@@ -44,6 +44,16 @@
 							<skip>true</skip>
 						</configuration>
 					</plugin>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<extensions>true</extensions>
+						<configuration>
+							<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+							<serverId>ossrh</serverId>
+							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+						</configuration>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-config/pom.xml
@@ -35,7 +35,7 @@
 	<profiles>
 		<!-- skip for GA releases to Maven Central -->
 		<profile>
-			<id>central</id>
+			<id>skip-unreleased-modules</id>
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
This PR should exclude `spring-cloud-gcp-starter-config` from the GA and future RC releases (but keeps it included in `-SNAPSHOT` releases)