### PR TITLE
Change secret manager module to use v1 instead of v1beta

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -19,8 +19,8 @@ package com.google.cloud.spring.autoconfigure.secretmanager;
 import java.io.IOException;
 
 import com.google.api.gax.core.CredentialsProvider;
-import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient;
-import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceSettings;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
 import com.google.cloud.spring.core.DefaultCredentialsProvider;
 import com.google.cloud.spring.core.DefaultGcpProjectIdProvider;
 import com.google.cloud.spring.core.GcpProjectIdProvider;

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerBootstrapConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerBootstrapConfigurationTests.java
@@ -18,10 +18,10 @@ package com.google.cloud.spring.autoconfigure.secretmanager;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
-import com.google.cloud.secretmanager.v1beta1.AccessSecretVersionResponse;
-import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient;
-import com.google.cloud.secretmanager.v1beta1.SecretPayload;
-import com.google.cloud.secretmanager.v1beta1.SecretVersionName;
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.protobuf.ByteString;
 import org.junit.Test;
 

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertySource.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertySource.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spring.secretmanager;
 
-import com.google.cloud.secretmanager.v1beta1.SecretVersionName;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 
 import org.springframework.core.env.EnumerablePropertySource;

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertyUtils.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertyUtils.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spring.secretmanager;
 
-import com.google.cloud.secretmanager.v1beta1.SecretVersionName;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 
 import org.springframework.util.Assert;

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerTemplate.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerTemplate.java
@@ -17,17 +17,17 @@
 package com.google.cloud.spring.secretmanager;
 
 import com.google.api.gax.rpc.NotFoundException;
-import com.google.cloud.secretmanager.v1beta1.AccessSecretVersionResponse;
-import com.google.cloud.secretmanager.v1beta1.AddSecretVersionRequest;
-import com.google.cloud.secretmanager.v1beta1.CreateSecretRequest;
-import com.google.cloud.secretmanager.v1beta1.DeleteSecretRequest;
-import com.google.cloud.secretmanager.v1beta1.ProjectName;
-import com.google.cloud.secretmanager.v1beta1.Replication;
-import com.google.cloud.secretmanager.v1beta1.Secret;
-import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient;
-import com.google.cloud.secretmanager.v1beta1.SecretName;
-import com.google.cloud.secretmanager.v1beta1.SecretPayload;
-import com.google.cloud.secretmanager.v1beta1.SecretVersionName;
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.AddSecretVersionRequest;
+import com.google.cloud.secretmanager.v1.CreateSecretRequest;
+import com.google.cloud.secretmanager.v1.DeleteSecretRequest;
+import com.google.cloud.secretmanager.v1.ProjectName;
+import com.google.cloud.secretmanager.v1.Replication;
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.protobuf.ByteString;
 

--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/SecretManagerPropertyUtilsTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/SecretManagerPropertyUtilsTests.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spring.secretmanager;
 
-import com.google.cloud.secretmanager.v1beta1.SecretVersionName;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 import org.junit.Test;
 

--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/SecretManagerTemplateTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/SecretManagerTemplateTests.java
@@ -17,16 +17,16 @@
 package com.google.cloud.spring.secretmanager;
 
 import com.google.api.gax.rpc.NotFoundException;
-import com.google.cloud.secretmanager.v1beta1.AccessSecretVersionResponse;
-import com.google.cloud.secretmanager.v1beta1.AddSecretVersionRequest;
-import com.google.cloud.secretmanager.v1beta1.CreateSecretRequest;
-import com.google.cloud.secretmanager.v1beta1.DeleteSecretRequest;
-import com.google.cloud.secretmanager.v1beta1.Replication;
-import com.google.cloud.secretmanager.v1beta1.Secret;
-import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient;
-import com.google.cloud.secretmanager.v1beta1.SecretName;
-import com.google.cloud.secretmanager.v1beta1.SecretPayload;
-import com.google.cloud.secretmanager.v1beta1.SecretVersionName;
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.AddSecretVersionRequest;
+import com.google.cloud.secretmanager.v1.CreateSecretRequest;
+import com.google.cloud.secretmanager.v1.DeleteSecretRequest;
+import com.google.cloud.secretmanager.v1.Replication;
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.protobuf.ByteString;
 import org.junit.Before;
 import org.junit.Test;

--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerTestConfiguration.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerTestConfiguration.java
@@ -19,8 +19,8 @@ package com.google.cloud.spring.secretmanager.it;
 import java.io.IOException;
 
 import com.google.api.gax.core.CredentialsProvider;
-import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceClient;
-import com.google.cloud.secretmanager.v1beta1.SecretManagerServiceSettings;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
 import com.google.cloud.spring.core.Credentials;
 import com.google.cloud.spring.core.DefaultCredentialsProvider;
 import com.google.cloud.spring.core.DefaultGcpEnvironmentProvider;


### PR DESCRIPTION
Change secret manager module packages to depend on the `v1` library version, not `v1beta`.