### PR TITLE
Workaround to keep exception from disappearing (#2617)

### DIFF
--- a/spring-cloud-gcp-pubsub/pom.xml
+++ b/spring-cloud-gcp-pubsub/pom.xml
@@ -45,5 +45,10 @@
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-test-support</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.mapping.HeaderMapper;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 
 /**
@@ -147,6 +148,18 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 						+ "] failed; message neither acked nor nacked.", re);
 			}
 		}
+	}
+
+	/**
+	 * Workaround for GH-2615; prevents successful completion when exception received with closed context.
+	 * @return error channel configured in parent class
+	 */
+	@Override
+	public MessageChannel getErrorChannel() {
+		if (!this.isRunning()) {
+			return null;
+		}
+		return super.getErrorChannel();
 	}
 
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -23,6 +23,7 @@ import com.google.cloud.spring.pubsub.integration.AckMode;
 import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
 import com.google.cloud.spring.pubsub.support.converter.ConvertedBasicAcknowledgeablePubsubMessage;
 import com.google.pubsub.v1.PubsubMessage;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,10 +33,14 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import org.springframework.boot.test.system.OutputCaptureRule;
+import org.springframework.integration.channel.PublishSubscribeChannel;
+import org.springframework.integration.handler.ServiceActivatingHandler;
 import org.springframework.integration.support.MutableMessageBuilder;
 import org.springframework.integration.support.MutableMessageBuilderFactory;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessageHeaders;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,6 +64,8 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class PubSubInboundChannelAdapterTests {
+
+	private TestUtils.TestApplicationContext context = TestUtils.createTestApplicationContext();
 
 	PubSubInboundChannelAdapter adapter;
 
@@ -84,6 +91,7 @@ public class PubSubInboundChannelAdapterTests {
 		this.adapter = new PubSubInboundChannelAdapter(
 				this.mockPubSubSubscriberOperations, "testSubscription");
 		this.adapter.setOutputChannel(this.mockMessageChannel);
+		this.adapter.setBeanFactory(this.context);
 
 		when(this.mockMessageChannel.send(any())).thenReturn(true);
 
@@ -97,6 +105,11 @@ public class PubSubInboundChannelAdapterTests {
 					messageConsumer.accept(mockAcknowledgeableMessage);
 				return null;
 		});
+	}
+
+	@After
+	public void tearDown() {
+		this.context.close();
 	}
 
 	@Test
@@ -121,6 +134,41 @@ public class PubSubInboundChannelAdapterTests {
 		verify(mockAcknowledgeableMessage).nack();
 
 		assertThat(output.getOut()).contains("failed; message nacked automatically");
+		assertThat(output.getOut()).contains(EXCEPTION_MESSAGE);
+	}
+
+	@Test
+	public void testAckModeAuto_nacksWhenDownstreamProcessingFailsWhenContextShutdown()  {
+
+		this.adapter.setAckMode(AckMode.AUTO);
+		this.adapter.setOutputChannel(this.mockMessageChannel);
+
+		PublishSubscribeChannel errorChannel = new PublishSubscribeChannel();
+		// Simulating what FinalRethrowingErrorMessageHandler would do.
+		MessageHandler errorHandler = message -> {
+			throw new RuntimeException("error channel fails, too");
+		};
+		errorChannel.subscribe(errorHandler);
+		ServiceActivatingHandler handler = new ServiceActivatingHandler(msg -> {
+					throw new RuntimeException("error handling failed");
+		});
+		handler.setBeanFactory(this.context);
+		handler.afterPropertiesSet();
+		this.adapter.setErrorChannel(errorChannel);
+
+		when(this.mockMessageChannel.send(any())).then(input -> {
+			errorChannel.unsubscribe(errorHandler);
+			this.adapter.stop();
+			throw new RuntimeException(EXCEPTION_MESSAGE);
+		});
+
+		this.adapter.start();
+
+		verify(mockAcknowledgeableMessage).nack();
+		verify(mockAcknowledgeableMessage, times(0)).ack();
+
+		assertThat(output.getOut()).contains("failed; message nacked automatically");
+		// original message handling exception
 		assertThat(output.getOut()).contains(EXCEPTION_MESSAGE);
 	}
 
@@ -191,5 +239,7 @@ public class PubSubInboundChannelAdapterTests {
 		assertThat(headers.get(GcpPubSubHeaders.ORIGINAL_MESSAGE)).isNotNull();
 		assertThat(headers.get(GcpPubSubHeaders.ORIGINAL_MESSAGE)).isEqualTo(mockAcknowledgeableMessage);
 	}
+
+
 
 }


### PR DESCRIPTION
The workaround will force the exception in MessageProducerSupport to bubble up without trying to go through message infrastructure, in the scenario where context shutdown is detected. This will prevent losing the exception during shutdown.

Forward port of spring-cloud/spring-cloud-gcp#2617