### PR TITLE
chore(builds): Use JCenter instead of the less reliable Maven Central

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -25,6 +25,11 @@
 
 	<repositories>
 		<repository>
+			<id>jcenter</id>
+			<name>jcenter</name>
+			<url>https://jcenter.bintray.com</url>
+		</repository>
+		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
 			<url>https://repo.spring.io/milestone</url>

--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,11 @@
 			<id>spring</id>
 			<repositories>
 				<repository>
+					<id>jcenter</id>
+					<name>jcenter</name>
+					<url>https://jcenter.bintray.com</url>
+				</repository>
+				<repository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
 					<url>https://repo.spring.io/milestone</url>
@@ -373,6 +378,11 @@
 				</repository>
 			</repositories>
 			<pluginRepositories>
+				<pluginRepository>
+					<id>jcenter</id>
+					<name>jcenter</name>
+					<url>https://jcenter.bintray.com</url>
+				</pluginRepository>
 				<pluginRepository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -266,6 +266,11 @@
 			<id>spring</id>
 			<repositories>
 				<repository>
+					<id>jcenter</id>
+					<name>jcenter</name>
+					<url>https://jcenter.bintray.com</url>
+				</repository>
+				<repository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
 					<url>https://repo.spring.io/snapshot</url>
@@ -294,6 +299,11 @@
 				</repository>
 			</repositories>
 			<pluginRepositories>
+				<pluginRepository>
+					<id>jcenter</id>
+					<name>jcenter</name>
+					<url>https://jcenter.bintray.com</url>
+				</pluginRepository>
 				<pluginRepository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -206,6 +206,11 @@
 
 	<repositories>
 		<repository>
+			<id>jcenter</id>
+			<name>jcenter</name>
+			<url>https://jcenter.bintray.com</url>
+		</repository>
+		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
 			<url>https://repo.spring.io/snapshot</url>
@@ -221,6 +226,11 @@
 	</repositories>
 
 	<pluginRepositories>
+		<pluginRepository>
+			<id>jcenter</id>
+			<name>jcenter</name>
+			<url>https://jcenter.bintray.com</url>
+		</pluginRepository>
 		<pluginRepository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-kotlin-samples/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-kotlin-samples/pom.xml
@@ -74,36 +74,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<repositories>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-		</pluginRepository>
-	</pluginRepositories>
 </project>


### PR DESCRIPTION
Most of our flakey integration tests from the past month have been download errors from Maven Central. 

I recall reading somewhere (probably some JFrog marketing material) that Bintray is more reliable than Maven Central, so I'm proposing we prioritize JCenter. A recent clean build performed like so:

```
$ rm -rf ~/.m2

$ time ./mvnw install -DskipTests --quiet

real	3m16.721s
user	2m2.449s
sys	0m19.088s
```