### PR TITLE
Fix Logging Sample Appender Path

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/main/resources/logback-spring.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="com/google/cloud/spring/autoconfigure/logging/logback-appender.xml" />
+    <include resource="com/google/cloud/spring/logging/logback-appender.xml" />
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
 


### PR DESCRIPTION
Fix the path to the logging appender in our logging sample.