### PR TITLE
mvn install before updating docs to catch version updates

### DIFF
--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -36,6 +36,16 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
 
+    - name: Mvn install # Need this when the version/directory/pom structure changes
+      run: |
+        ./mvnw \
+          --batch-mode \
+          --show-version \
+          --threads 1.5C \
+          --define maven.test.skip=true \
+          --define maven.javadoc.skip=true \
+          install
+
     - name: Update Docs
       run: |
         if [[ -n "${{ github.event.release.tag_name }}" ]] ; then


### PR DESCRIPTION
Recent bump to 2.0.1-SNAPSHOT failed to update the docs because it couldn't find the `spring-cloud-gcp-depdendencies:2.0.1-SNAPSHOT`, so it looks like we've gotta install it.

Run for reference: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/482978202