### PR TITLE
Test effect of upgrading error prone version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,10 +489,9 @@
 					<plugins>
 						<plugin>
 							<artifactId>maven-compiler-plugin</artifactId>
+							<version>3.8.1</version>
 							<configuration>
-								<compilerId>javac-with-errorprone</compilerId>
-								<forceJavacCompilerUse>true</forceJavacCompilerUse>
-								<compilerArgs>
+								<compilerArgs combine.children="append">
 									<!-- Enable all warnings -->
 									<compilerArg>-Xlint:all</compilerArg>
 									<!-- Disable options warning because we will have differences between the compiler and source code level-->
@@ -501,14 +500,11 @@
 									<compilerArg>-Xlint:-serial</compilerArg>
 									<!--compilerArg>-Werror</compilerArg-->
 									<arg>-parameters</arg>
+									<!-- Needed for errorprone version 2.4.0 -->
+									<arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
 								</compilerArgs>
 							</configuration>
 							<dependencies>
-								<dependency>
-									<groupId>org.codehaus.plexus</groupId>
-									<artifactId>plexus-compiler-javac-errorprone</artifactId>
-									<version>2.8.6</version>
-								</dependency>
 								<dependency>
 									<groupId>com.google.errorprone</groupId>
 									<artifactId>error_prone_core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 	<properties>
 		<app-engine-maven-plugin.version>2.3.0</app-engine-maven-plugin.version>
 		<asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
-		<errorprone.version>2.3.4</errorprone.version>
+		<errorprone.version>2.4.0</errorprone.version>
 		<integration-test.pattern>**/*IntegrationTest*</integration-test.pattern>
 		<java-cfenv.version>2.1.2.RELEASE</java-cfenv.version>
 		<javadoc.failOnError>false</javadoc.failOnError>
@@ -448,7 +448,7 @@
 		<profile>
 			<id>errorprone_java_9_and_up</id>
 			<activation>
-				<jdk>[9,13]</jdk>
+				<jdk>[9,)</jdk>
 			</activation>
 			<build>
 				<pluginManagement>


### PR DESCRIPTION
This is just a test PR to see the CI when the errorprone version is upgraded. Followup to a user submitted PR https://github.com/spring-cloud/spring-cloud-gcp/pull/2624