### PR TITLE
Remove unused getters/setters from FirestoreTemplate

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfiguration.java
@@ -129,7 +129,6 @@ public class GcpFirestoreEmulatorAutoConfiguration {
 					ROOT_PATH + "/documents",
 					classMapper,
 					firestoreMappingContext);
-			template.setUsingStreamTokens(false);
 			return template;
 		}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationIntegrationTests.java
@@ -65,7 +65,6 @@ public class GcpFirestoreEmulatorAutoConfigurationIntegrationTests {
 					assertThat(endpoint).isEqualTo("localhost:9000");
 
 					FirestoreTemplate firestoreTemplate = context.getBean(FirestoreTemplate.class);
-					assertThat(firestoreTemplate.isUsingStreamTokens()).isFalse();
 				});
 	}
 
@@ -80,7 +79,6 @@ public class GcpFirestoreEmulatorAutoConfigurationIntegrationTests {
 					assertThat(endpoint).isEqualTo("firestore.googleapis.com:443");
 
 					FirestoreTemplate firestoreTemplate = context.getBean(FirestoreTemplate.class);
-					assertThat(firestoreTemplate.isUsingStreamTokens()).isTrue();
 				});
 	}
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
@@ -87,8 +87,6 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 
 	private int writeBufferSize = FIRESTORE_WRITE_MAX_SIZE;
 
-	private boolean usingStreamTokens = true;
-
 	/**
 	 * Constructor for FirestoreTemplate.
 	 * @param firestore Firestore gRPC stub
@@ -110,7 +108,6 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 	public <T> FirestoreReactiveOperations withParent(T parent) {
 		FirestoreTemplate firestoreTemplate =
 						new FirestoreTemplate(this.firestore, buildResourceName(parent), this.classMapper, this.mappingContext);
-		firestoreTemplate.setUsingStreamTokens(this.usingStreamTokens);
 		firestoreTemplate.setWriteBufferSize(this.writeBufferSize);
 		firestoreTemplate.setWriteBufferTimeout(this.writeBufferTimeout);
 
@@ -145,25 +142,6 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 
 	public int getWriteBufferSize() {
 		return this.writeBufferSize;
-	}
-
-	/**
-	 * Sets whether the {@link FirestoreTemplate} should attach stream resume tokens to write
-	 * requests.
-	 *
-	 * <p>Note that this should always be set to true unless you are using the
-	 * Firestore emulator in which case it should be set to false because the emulator
-	 * does not support using resume tokens.
-	 *
-	 * @param usingStreamTokens whether the template should use stream tokens
-   * @since 1.2.3
-	 */
-	public void setUsingStreamTokens(boolean usingStreamTokens) {
-		this.usingStreamTokens = usingStreamTokens;
-	}
-
-	public boolean isUsingStreamTokens() {
-		return usingStreamTokens;
 	}
 
 	@Override


### PR DESCRIPTION
The getters/setters of `usingStreamTokens` does not appear to be used anymore.