### PR TITLE
Implement withParent overload for FirestoreTemplate

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreReactiveOperations.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreReactiveOperations.java
@@ -140,10 +140,11 @@ public interface FirestoreReactiveOperations {
 	<T> Flux<T> execute(StructuredQuery.Builder builder, Class<T> entityClass);
 
 	/**
-	 * Creates FirestoreReactiveOperations object with a provided parent.
+	 * Creates FirestoreReactiveOperations object with a specified parent document.
 	 * The parent doesn't have to exist in Firestore, but should have a non-empty id field.
 	 * All operations and queries will be scoped to that parent's subcollections.
-	 * By default, FirestoreReactiveOperations uses the root as a "parent".
+	 * By default, FirestoreReactiveOperations uses the root document as the parent.
+	 *
 	 * @param <T> the type param of the parent.
 	 * @param parent the query builder.
 	 * @return template with a given parent.
@@ -151,4 +152,15 @@ public interface FirestoreReactiveOperations {
 	 */
 	<T> FirestoreReactiveOperations withParent(T parent);
 
+	/**
+	 * Creates FirestoreReactiveOperations object with a specified parent document.
+	 * All operations and queries will be scoped to that parent document's subcollections.
+	 * By default, FirestoreReactiveOperations uses the root document as the parent.
+	 *
+	 * @param id the id of the Document entity
+	 * @param entityClass the class of the Document entity
+	 * @return template with a given parent.
+	 * @since 2.0.1
+	 */
+	FirestoreReactiveOperations withParent(Object id, Class<?> entityClass);
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
@@ -104,16 +104,6 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 		this.mappingContext = mappingContext;
 	}
 
-	@Override
-	public <T> FirestoreReactiveOperations withParent(T parent) {
-		FirestoreTemplate firestoreTemplate =
-						new FirestoreTemplate(this.firestore, buildResourceName(parent), this.classMapper, this.mappingContext);
-		firestoreTemplate.setWriteBufferSize(this.writeBufferSize);
-		firestoreTemplate.setWriteBufferTimeout(this.writeBufferTimeout);
-
-		return firestoreTemplate;
-	}
-
 	/**
 	 * Sets the {@link Duration} for how long to wait for the entity buffer to fill before sending
 	 * the buffered entities to Firestore for insert/update/delete operations.
@@ -257,6 +247,25 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 				.map(document -> getClassMapper().documentToEntity(document, entityType)));
 	}
 
+	@Override
+	public FirestoreReactiveOperations withParent(Object id, Class<?> entityClass) {
+		return withParent(buildResourceName(id, entityClass));
+	}
+
+	@Override
+	public <T> FirestoreReactiveOperations withParent(T parent) {
+		return withParent(buildResourceName(parent));
+	}
+
+	private FirestoreReactiveOperations withParent(String resourceName) {
+		FirestoreTemplate firestoreTemplate =
+				new FirestoreTemplate(this.firestore, resourceName, this.classMapper, this.mappingContext);
+		firestoreTemplate.setWriteBufferSize(this.writeBufferSize);
+		firestoreTemplate.setWriteBufferTimeout(this.writeBufferTimeout);
+
+		return firestoreTemplate;
+	}
+
 	public FirestoreMappingContext getMappingContext() {
 		return this.mappingContext;
 	}
@@ -387,6 +396,12 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 			}
 		}
 		return builder.setUpdate(document).build();
+	}
+
+	private <T> String buildResourceName(Object entityId, Class<T> entityClass) {
+		FirestorePersistentEntity<?> persistentEntity =
+				this.mappingContext.getPersistentEntity(entityClass);
+		return buildResourceName(persistentEntity, entityId.toString());
 	}
 
 	private <T> String buildResourceName(T entity) {

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
@@ -407,6 +407,11 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 	private <T> String buildResourceName(T entity) {
 		FirestorePersistentEntity<?> persistentEntity =
 				this.mappingContext.getPersistentEntity(entity.getClass());
+
+		if (persistentEntity == null) {
+			throw new IllegalArgumentException(entity.getClass().toString() + " is not a valid Firestore entity class.");
+		}
+
 		FirestorePersistentProperty idProperty = persistentEntity.getIdPropertyOrFail();
 		Object idVal = persistentEntity.getPropertyAccessor(entity).getProperty(idProperty);
 		if (idVal == null) {

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
@@ -50,7 +50,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Dmitry Solomakha

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
@@ -50,6 +50,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Dmitry Solomakha
@@ -442,6 +443,48 @@ public class FirestoreTemplateTests {
 		verify(this.firestoreStub, times(1)).getDocument(eq(request), any());
 		verify(this.firestoreStub, times(1)).getDocument(any(), any());
 
+	}
+
+	@Test
+	public void withParentTest_entityReference() {
+		doAnswer(invocation -> {
+			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
+			streamObserver.onNext(buildDocument("e1", 100L));
+			streamObserver.onCompleted();
+			return null;
+		}).when(this.firestoreStub).getDocument(any(), any());
+
+		this.firestoreTemplate
+				.withParent(new TestEntity("parent",  0L))
+				.findById(Mono.just("child"), TestEntity.class)
+				.block();
+
+		GetDocumentRequest request = GetDocumentRequest.newBuilder()
+				.setName(this.parent + "/testEntities/parent/testEntities/child")
+				.build();
+
+		verify(this.firestoreStub, times(1)).getDocument(eq(request), any());
+	}
+
+	@Test
+	public void withParentTest_idClassReference() {
+		doAnswer(invocation -> {
+			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
+			streamObserver.onNext(buildDocument("e1", 100L));
+			streamObserver.onCompleted();
+			return null;
+		}).when(this.firestoreStub).getDocument(any(), any());
+
+		this.firestoreTemplate
+				.withParent("parent", TestEntity.class)
+				.findById(Mono.just("child"), TestEntity.class)
+				.block();
+
+		GetDocumentRequest request = GetDocumentRequest.newBuilder()
+				.setName(this.parent + "/testEntities/parent/testEntities/child")
+				.build();
+
+		verify(this.firestoreStub, times(1)).getDocument(eq(request), any());
 	}
 
 	private static Map<String, Value> createValuesMap(long value) {

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/entities/PhoneNumber.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/entities/PhoneNumber.java
@@ -29,6 +29,7 @@ import com.google.cloud.spring.data.firestore.Document;
 
 @Document(collectionName = "phoneNumbers")
 public class PhoneNumber {
+
 	@DocumentId
 	private String phoneNumber;
 


### PR DESCRIPTION
This adds an overloaded `withParent(Object id, Class<?> entityClass)` method so that users are not required to have a reference to an entity to scope the template to some subcollection.

Fixes #206.