### PR TITLE
Remove broken link in Spanner refdocs

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -58,7 +58,7 @@ To setup Spring Data Cloud Spanner, you have to configure the following:
 
 ==== Cloud Spanner settings
 
-You can the use Spring Boot Starter for Spring Data Spanner to autoconfigure Google Cloud Spanner in your Spring application.
+You can use the Spring Boot Starter for Spring Data Spanner to autoconfigure Google Cloud Spanner in your Spring application.
 It contains all the necessary setup that makes it easy to authenticate with your Google Cloud project.
 The following configuration options are available:
 

--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -58,7 +58,7 @@ To setup Spring Data Cloud Spanner, you have to configure the following:
 
 ==== Cloud Spanner settings
 
-You can the use link:../spring-cloud-gcp-starters/spring-cloud-gcp-starter-data-spanner[Spring Boot Starter for Spring Data Spanner] to autoconfigure Google Cloud Spanner in your Spring application.
+You can the use Spring Boot Starter for Spring Data Spanner to autoconfigure Google Cloud Spanner in your Spring application.
 It contains all the necessary setup that makes it easy to authenticate with your Google Cloud project.
 The following configuration options are available:
 


### PR DESCRIPTION
Remove the broken link in the Spanner refdocs.

No need to link to the Spanner starter as the artifact is linked directly above.