### PR TITLE
Add additional null check for FirestoreTemplate

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
@@ -401,6 +401,11 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 	private <T> String buildResourceName(Object entityId, Class<T> entityClass) {
 		FirestorePersistentEntity<?> persistentEntity =
 				this.mappingContext.getPersistentEntity(entityClass);
+
+		if (persistentEntity == null) {
+			throw new IllegalArgumentException(entityClass.toString() + " is not a valid Firestore entity class.");
+		}
+
 		return buildResourceName(persistentEntity, entityId.toString());
 	}
 


### PR DESCRIPTION
This adds an additional null check to FirestoreTemplate to resolve the null pointer exception issue reported by Sonar.