### PR TITLE
Replace deprecated EmitterProcessor with Sinks.Many

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/src/main/java/com/example/FrontendController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/src/main/java/com/example/FrontendController.java
@@ -17,7 +17,7 @@
 package com.example;
 
 import com.example.model.UserMessage;
-import reactor.core.publisher.EmitterProcessor;
+import reactor.core.publisher.Sinks;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,7 +28,7 @@ import org.springframework.web.servlet.view.RedirectView;
 /**
  * Controller for the user message form submission.
  *
- * <p>The {@link EmitterProcessor} is used to locally send messages to {@link Source}.
+ * <p>The {@link Sinks.Many} is used to locally send messages to {@link Source}.
  *
  * @author Elena Felder
  *
@@ -38,14 +38,14 @@ import org.springframework.web.servlet.view.RedirectView;
 public class FrontendController {
 
 	@Autowired
-	private EmitterProcessor<UserMessage> postOffice;
+	private Sinks.Many<UserMessage> postOffice;
 
 	@PostMapping("/postMessage")
 	public RedirectView sendMessage(
 			@RequestParam("messageBody") String messageBody,
 			@RequestParam("username") String username) {
 		UserMessage userMessage = new UserMessage(messageBody, username);
-		postOffice.onNext(userMessage);
+		postOffice.tryEmitNext(userMessage);
 
 		return new RedirectView("index.html");
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/src/main/java/com/example/FunctionalSourceApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/src/main/java/com/example/FunctionalSourceApplication.java
@@ -17,7 +17,7 @@
 package com.example;
 
 import com.example.model.UserMessage;
-import reactor.core.publisher.EmitterProcessor;
+import reactor.core.publisher.Sinks;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Bean;
 /**
  * Spring Boot application for running the Spring Cloud Stream source.
  *
- * <p>This class bootstraps the Spring Boot application and creates the {@link EmitterProcessor}
+ * <p>This class bootstraps the Spring Boot application and creates the {@link Sinks.Many}
  * bean that is used for communication between {@link FrontendController} and {@link Source}.
  *
  * @author Elena Felder
@@ -38,11 +38,11 @@ public class FunctionalSourceApplication {
 
 	/**
 	 * Allows {@link Source} to subscribe to {@link UserMessage} instances from front-end.
-	 * @return {@link EmitterProcessor} used for passing {@link UserMessage} objects.
+	 * @return {@link Sinks.Many} used for passing {@link UserMessage} objects.
 	 */
 	@Bean
-	public EmitterProcessor<UserMessage> postOffice() {
-		return EmitterProcessor.create();
+	public Sinks.Many<UserMessage> postOffice() {
+		return Sinks.many().unicast().onBackpressureBuffer();
 	}
 
 	public static void main(String[] args) {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/src/main/java/com/example/Source.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-source/src/main/java/com/example/Source.java
@@ -19,8 +19,8 @@ package com.example;
 import java.util.function.Supplier;
 
 import com.example.model.UserMessage;
-import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
  * <p>What makes this class a valid Spring Cloud Stream source is the presence of a {@link Supplier}
  * bean.
  *
- * The {@link EmitterProcessor} is used only as a local communication mechanism between the
+ * The {@link Sinks.Many} is used only as a local communication mechanism between the
  * {@link FrontendController} and this Spring Cloud Stream source.
  *
  * @author Elena Felder
@@ -43,11 +43,11 @@ import org.springframework.context.annotation.Configuration;
 public class Source {
 
 	@Autowired
-	private EmitterProcessor<UserMessage> postOffice;
+	private Sinks.Many<UserMessage> postOffice;
 
 	@Bean
 	Supplier<Flux<UserMessage>> generateUserMessages() {
-		return () -> postOffice;
+		return () -> postOffice.asFlux();
 	}
 
 }


### PR DESCRIPTION
`Processors` are now deprecated, being replaced by `Sinks` in Reactive 3.5: https://projectreactor.io/docs/core/release/reference/#processors