### PR TITLE
Add a note in the sample for how to use default values

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -8,6 +8,8 @@
 my-app-secret-1=${sm://application-secret/latest}
 my-app-secret-2=${sm://application-secret/1}
 
-# If you would like to specify a secret from another project,
-# you may specify the project ID in the first token of the URI.
+# You can also specify a secret from another project.
 # example.property=${sm://MY_PROJECT/MY_SECRET_ID/MY_VERSION}
+
+# Using SpEL, you can reference an environment variable and fallback to a secret if it is missing.
+# example.secret=${MY_ENV_VARIABLE:${sm://application-secret/latest}}


### PR DESCRIPTION
In `application.properties`, you can set a property to an environment variable and then fallback to using a secret manager secret if the env var is not set via this syntax:

```
example.secret=${MY_ENV_VARIABLE:${sm://application-secret/latest}}
```

Fixes: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/213

This helps enable a use-case asked for in https://github.com/spring-cloud/spring-cloud-gcp/pull/2302#issuecomment-763075877 about allowing an app to be less coupled to a platform -- i.e. rely on ENV vars if provided since it's not guaranteed the app will run on google cloud.