### PR TITLE
Allow pubsub binder to use fully qualified topic name when creating subscription (consumer destination)

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -114,6 +114,7 @@ public class PubSubMessageChannelBinderTests {
 		this.binder = new PubSubMessageChannelBinder(new String[0], this.channelProvisioner, this.pubSubTemplate,
 				this.properties);
 
+		when(pubSubAdmin.getProjectId()).thenReturn("test-project");
 		when(producerDestination.getName()).thenReturn("test-topic");
 		when(consumerDestination.getName()).thenReturn("test-subscription");
 	}

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -114,7 +114,6 @@ public class PubSubMessageChannelBinderTests {
 		this.binder = new PubSubMessageChannelBinder(new String[0], this.channelProvisioner, this.pubSubTemplate,
 				this.properties);
 
-		when(pubSubAdmin.getProjectId()).thenReturn("test-project");
 		when(producerDestination.getName()).thenReturn("test-topic");
 		when(consumerDestination.getName()).thenReturn("test-subscription");
 	}

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
@@ -104,7 +104,7 @@ public class PubSubAdmin implements AutoCloseable {
 	public Topic createTopic(String topicName) {
 		Assert.hasText(topicName, "No topic name was specified.");
 
-		return this.topicAdminClient.createTopic(PubSubTopicUtils.toProjectTopicName(topicName, this.projectId));
+		return this.topicAdminClient.createTopic(PubSubTopicUtils.toTopicName(topicName, this.projectId));
 	}
 
 	/**
@@ -118,7 +118,7 @@ public class PubSubAdmin implements AutoCloseable {
 		Assert.hasText(topicName, "No topic name was specified.");
 
 		try {
-			return this.topicAdminClient.getTopic(PubSubTopicUtils.toProjectTopicName(topicName, this.projectId));
+			return this.topicAdminClient.getTopic(PubSubTopicUtils.toTopicName(topicName, this.projectId));
 		}
 		catch (ApiException aex) {
 			if (aex.getStatusCode().getCode() == StatusCode.Code.NOT_FOUND) {
@@ -138,7 +138,7 @@ public class PubSubAdmin implements AutoCloseable {
 	public void deleteTopic(String topicName) {
 		Assert.hasText(topicName, "No topic name was specified.");
 
-		this.topicAdminClient.deleteTopic(PubSubTopicUtils.toProjectTopicName(topicName, this.projectId));
+		this.topicAdminClient.deleteTopic(PubSubTopicUtils.toTopicName(topicName, this.projectId));
 	}
 
 	/**
@@ -231,7 +231,7 @@ public class PubSubAdmin implements AutoCloseable {
 
 		return this.subscriptionAdminClient.createSubscription(
 				PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, this.projectId),
-				PubSubTopicUtils.toProjectTopicName(topicName, this.projectId),
+				PubSubTopicUtils.toTopicName(topicName, this.projectId),
 				pushConfigBuilder.build(),
 				finalAckDeadline);
 	}

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
@@ -325,4 +325,7 @@ public class PubSubAdmin implements AutoCloseable {
 		}
 	}
 
+	public String getProjectId() {
+		return projectId;
+	}
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
@@ -48,9 +48,9 @@ import org.springframework.util.Assert;
  */
 public class PubSubAdmin implements AutoCloseable {
 
-	private static final int MIN_ACK_DEADLINE_SECONDS = 10;
+	protected static final int MIN_ACK_DEADLINE_SECONDS = 10;
 
-	private static final int MAX_ACK_DEADLINE_SECONDS = 600;
+	protected static final int MAX_ACK_DEADLINE_SECONDS = 600;
 
 	private final String projectId;
 

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
@@ -324,8 +324,4 @@ public class PubSubAdmin implements AutoCloseable {
 			this.subscriptionAdminClient.close();
 		}
 	}
-
-	public String getProjectId() {
-		return projectId;
-	}
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactory.java
@@ -128,7 +128,7 @@ public class DefaultPublisherFactory implements PublisherFactory {
 		return this.publishers.computeIfAbsent(topic, (key) -> {
 			try {
 				Publisher.Builder publisherBuilder =
-						Publisher.newBuilder(PubSubTopicUtils.toProjectTopicName(topic, this.projectId));
+						Publisher.newBuilder(PubSubTopicUtils.toTopicName(topic, this.projectId));
 
 				if (this.executorProvider != null) {
 					publisherBuilder.setExecutorProvider(this.executorProvider);

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtils.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtils.java
@@ -41,9 +41,7 @@ public final class PubSubTopicUtils {
 	 * @param topic the topic name in the project or the fully-qualified project name
 	 * @param projectId the project ID to use if the topic is not a fully-qualified name
 	 * @return the Pub/Sub object representing the topic name
-	 * @deprecated Use toTopicName instead.
 	 */
-	@Deprecated
 	public static ProjectTopicName toProjectTopicName(String topic, @Nullable String projectId) {
 		Assert.notNull(topic, "The topic can't be null.");
 
@@ -61,20 +59,17 @@ public final class PubSubTopicUtils {
 		return projectTopicName;
 	}
 
+	/**
+	 * Create a {@link TopicName} based on a topic name within a project or the
+	 * fully-qualified topic name. If the specified topic is in the
+	 * {@code projects/<project_name>/topics/<topic_name>} format, then the {@code projectId} is
+	 * ignored}
+	 * @param topic the topic name in the project or the fully-qualified project name
+	 * @param projectId the project ID to use if the topic is not a fully-qualified name
+	 * @return the Pub/Sub object representing the topic name
+	 */
 	public static TopicName toTopicName(String topic, @Nullable String projectId) {
-		Assert.notNull(topic, "The topic can't be null.");
-
-		TopicName topicName = null;
-
-		if (TopicName.isParsableFrom(topic)) {
-			// Fully-qualified topic name in the "projects/<project_name>/topics/<topic_name>" format
-			topicName = TopicName.parse(topic);
-		}
-		else {
-			Assert.notNull(projectId, "The project ID can't be null when using canonical topic name.");
-			topicName = TopicName.of(projectId, topic);
-		}
-
-		return topicName;
+		ProjectTopicName ptn = toProjectTopicName(topic, projectId);
+		return TopicName.ofProjectTopicName(ptn.getProject(), ptn.getTopic());
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtils.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtils.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spring.pubsub.support;
 
 import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.TopicName;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -40,7 +41,9 @@ public final class PubSubTopicUtils {
 	 * @param topic the topic name in the project or the fully-qualified project name
 	 * @param projectId the project ID to use if the topic is not a fully-qualified name
 	 * @return the Pub/Sub object representing the topic name
+	 * @deprecated Use toTopicName instead.
 	 */
+	@Deprecated
 	public static ProjectTopicName toProjectTopicName(String topic, @Nullable String projectId) {
 		Assert.notNull(topic, "The topic can't be null.");
 
@@ -56,5 +59,22 @@ public final class PubSubTopicUtils {
 		}
 
 		return projectTopicName;
+	}
+
+	public static TopicName toTopicName(String topic, @Nullable String projectId) {
+		Assert.notNull(topic, "The topic can't be null.");
+
+		TopicName topicName = null;
+
+		if (TopicName.isParsableFrom(topic)) {
+			// Fully-qualified topic name in the "projects/<project_name>/topics/<topic_name>" format
+			topicName = TopicName.parse(topic);
+		}
+		else {
+			Assert.notNull(projectId, "The project ID can't be null when using canonical topic name.");
+			topicName = TopicName.of(projectId, topic);
+		}
+
+		return topicName;
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/PubSubAdminTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/PubSubAdminTests.java
@@ -16,14 +16,31 @@
 
 package com.google.cloud.spring.pubsub;
 
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.NoCredentials;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
-import org.junit.Rule;
+import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.TopicName;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for the Pub/Sub admin operations.
@@ -34,12 +51,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class PubSubAdminTests {
 
-	/**
-	 * used to check exception messages and types.
-	 */
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-
 	@Mock
 	private TopicAdminClient mockTopicAdminClient;
 
@@ -48,22 +59,237 @@ public class PubSubAdminTests {
 
 	@Test
 	public void testNewPubSubAdmin_nullProjectProvider() {
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("The project ID provider can't be null.");
-		new PubSubAdmin(null, this.mockTopicAdminClient, this.mockSubscriptionAdminClient);
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new PubSubAdmin(null, this.mockTopicAdminClient, this.mockSubscriptionAdminClient))
+				.withMessage("The project ID provider can't be null.");
 	}
 
 	@Test
 	public void testNewPubSubAdmin_nullTopicAdminClient() {
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("The topic administration client can't be null");
-		new PubSubAdmin(() -> "test-project", null, this.mockSubscriptionAdminClient);
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new PubSubAdmin(() -> "test-project", null, this.mockSubscriptionAdminClient))
+				.withMessage("The topic administration client can't be null");
 	}
 
 	@Test
 	public void testNewPubSubAdmin_nullSubscriptionAdminClient() {
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("The subscription administration client can't be null");
-		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, null);
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, null))
+				.withMessage("The subscription administration client can't be null");
+	}
+
+	@Test
+	public void testNewPubSubAdmin() throws IOException {
+		assertThat(new PubSubAdmin(() -> "test-project", NoCredentials::getInstance)).isNotNull();
+	}
+
+	@Test
+	public void testCreateTopic() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.createTopic("fooTopic");
+		verify(this.mockTopicAdminClient).createTopic(TopicName.of("test-project", "fooTopic"));
+	}
+
+	@Test
+	public void testCreateTopic_fullName() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.createTopic("projects/differentProject/topics/fooTopic");
+		verify(this.mockTopicAdminClient).createTopic(TopicName.of("differentProject", "fooTopic"));
+	}
+
+	@Test
+	public void testGetTopic() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getTopic("fooTopic");
+		verify(this.mockTopicAdminClient).getTopic(TopicName.of("test-project", "fooTopic"));
+	}
+
+	@Test
+	public void testGetTopic_fullName() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getTopic("projects/differentProject/topics/fooTopic");
+		verify(this.mockTopicAdminClient).getTopic(TopicName.of("differentProject", "fooTopic"));
+	}
+
+	@Test
+	public void testGetTopic_notFound() {
+		when(this.mockTopicAdminClient.getTopic(any(TopicName.class)))
+				.thenThrow(new ApiException(null, GrpcStatusCode.of(io.grpc.Status.Code.NOT_FOUND), false));
+		assertThat(new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getTopic("fooTopic")).isNull();
+		verify(this.mockTopicAdminClient).getTopic(TopicName.of("test-project", "fooTopic"));
+	}
+
+	@Test
+	public void testGetTopic_serviceDown() {
+		when(this.mockTopicAdminClient.getTopic(any(TopicName.class)))
+				.thenThrow(new ApiException(null, GrpcStatusCode.of(io.grpc.Status.Code.UNAVAILABLE), false));
+		assertThatExceptionOfType(ApiException.class)
+				.isThrownBy(() -> new PubSubAdmin(() -> "test-project",
+						this.mockTopicAdminClient, this.mockSubscriptionAdminClient).getTopic("fooTopic"));
+		verify(this.mockTopicAdminClient).getTopic(TopicName.of("test-project", "fooTopic"));
+	}
+
+	@Test
+	public void testDeleteTopic() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.deleteTopic("fooTopic");
+		verify(this.mockTopicAdminClient).deleteTopic(TopicName.of("test-project", "fooTopic"));
+	}
+
+	@Test
+	public void testDeleteTopic_fullName() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.deleteTopic("projects/differentProject/topics/fooTopic");
+		verify(this.mockTopicAdminClient).deleteTopic(TopicName.of("differentProject", "fooTopic"));
+	}
+
+	@Test
+	public void testListTopic() throws ExecutionException, InterruptedException {
+		when(this.mockTopicAdminClient.listTopics(any(ProjectName.class))).thenReturn(
+				mock(TopicAdminClient.ListTopicsPagedResponse.class)
+		);
+
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.listTopics();
+		verify(this.mockTopicAdminClient).listTopics(ProjectName.of("test-project"));
+	}
+
+	@Test
+	public void testCreateSubscription_nullArgs() {
+		PubSubAdmin psa = new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient,
+				this.mockSubscriptionAdminClient);
+
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> psa.createSubscription(null, "testTopic"));
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> psa.createSubscription("testSubscription", null));
+	}
+
+	@Test
+	public void testCreateSubscription() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.createSubscription("testSubscription", "testTopic");
+		verify(this.mockSubscriptionAdminClient).createSubscription(
+				eq(ProjectSubscriptionName.of("test-project", "testSubscription")),
+				eq(TopicName.of("test-project", "testTopic")),
+				any(),
+				anyInt()
+		);
+	}
+
+	@Test
+	public void testCreateSubscription_ackDeadline() {
+		PubSubAdmin psa = new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient,
+				this.mockSubscriptionAdminClient);
+
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> psa.createSubscription("a", "b", PubSubAdmin.MIN_ACK_DEADLINE_SECONDS - 1));
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> psa.createSubscription("a", "b", PubSubAdmin.MAX_ACK_DEADLINE_SECONDS + 1));
+
+		psa.createSubscription("testSubscription", "testTopic", 100);
+		verify(this.mockSubscriptionAdminClient).createSubscription(
+				eq(ProjectSubscriptionName.of("test-project", "testSubscription")),
+				eq(TopicName.of("test-project", "testTopic")),
+				any(),
+				eq(100)
+		);
+	}
+
+	@Test
+	public void testCreateSubscription_pushEndpoint() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.createSubscription("testSubscription", "testTopic", "endpoint");
+		verify(this.mockSubscriptionAdminClient).createSubscription(
+				eq(ProjectSubscriptionName.of("test-project", "testSubscription")),
+				eq(TopicName.of("test-project", "testTopic")),
+				argThat(arg -> "endpoint".equals(arg.getPushEndpoint())),
+				anyInt()
+		);
+	}
+
+	@Test
+	public void testGetSubscription() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getSubscription("fooSubscription");
+		verify(this.mockSubscriptionAdminClient).getSubscription(
+				ProjectSubscriptionName.of("test-project", "fooSubscription"));
+	}
+
+	@Test
+	public void testGetSubscription_fullName() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getSubscription("projects/differentProject/subscriptions/fooSubscription");
+		verify(this.mockSubscriptionAdminClient).getSubscription(
+				ProjectSubscriptionName.of("differentProject", "fooSubscription"));
+	}
+
+	@Test
+	public void testGetSubscription_notFound() {
+		when(this.mockSubscriptionAdminClient.getSubscription(any(ProjectSubscriptionName.class)))
+				.thenThrow(new ApiException(null, GrpcStatusCode.of(io.grpc.Status.Code.NOT_FOUND), false));
+		assertThat(new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getSubscription("fooSubscription"))
+				.isNull();
+		verify(this.mockSubscriptionAdminClient).getSubscription(
+				ProjectSubscriptionName.of("test-project", "fooSubscription"));
+	}
+
+	@Test
+	public void testGetSubscription_serviceDown() {
+		when(this.mockSubscriptionAdminClient.getSubscription(any(ProjectSubscriptionName.class)))
+				.thenThrow(new ApiException(null, GrpcStatusCode.of(io.grpc.Status.Code.UNAVAILABLE), false));
+		assertThatExceptionOfType(ApiException.class).isThrownBy(() -> new PubSubAdmin(
+				() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.getSubscription("fooSubscription"));
+		verify(this.mockSubscriptionAdminClient).getSubscription(
+				ProjectSubscriptionName.of("test-project", "fooSubscription"));
+	}
+
+	@Test
+	public void testDeleteSubscription() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.deleteSubscription("fooSubscription");
+		verify(this.mockSubscriptionAdminClient).deleteSubscription(
+				ProjectSubscriptionName.of("test-project", "fooSubscription"));
+	}
+
+	@Test
+	public void testDeleteSubscription_fullName() {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.deleteSubscription("projects/differentProject/subscriptions/fooSubscription");
+		verify(this.mockSubscriptionAdminClient).deleteSubscription(
+				ProjectSubscriptionName.of("differentProject", "fooSubscription"));
+	}
+
+	@Test
+	public void testListSubscription() {
+		when(this.mockSubscriptionAdminClient.listSubscriptions(any(ProjectName.class))).thenReturn(
+				mock(SubscriptionAdminClient.ListSubscriptionsPagedResponse.class)
+		);
+
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.listSubscriptions();
+		verify(this.mockSubscriptionAdminClient).listSubscriptions(ProjectName.of("test-project"));
+	}
+
+	@Test
+	public void testDefaultAckDeadline() throws IOException {
+		PubSubAdmin psa = new PubSubAdmin(() -> "test-project", NoCredentials::getInstance);
+		int defaultAckDeadline = psa.getDefaultAckDeadline();
+		psa.setDefaultAckDeadline(defaultAckDeadline + 1);
+		assertThat(psa.getDefaultAckDeadline()).isEqualTo(defaultAckDeadline + 1);
+
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> psa.setDefaultAckDeadline(PubSubAdmin.MIN_ACK_DEADLINE_SECONDS - 1));
+	}
+
+	@Test
+	public void testClose() throws Exception {
+		new PubSubAdmin(() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
+				.close();
+		verify(this.mockTopicAdminClient).close();
+		verify(this.mockSubscriptionAdminClient).close();
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/PubSubAdminTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/PubSubAdminTests.java
@@ -124,9 +124,10 @@ public class PubSubAdminTests {
 	public void testGetTopic_serviceDown() {
 		when(this.mockTopicAdminClient.getTopic(any(TopicName.class)))
 				.thenThrow(new ApiException(null, GrpcStatusCode.of(io.grpc.Status.Code.UNAVAILABLE), false));
-		assertThatExceptionOfType(ApiException.class)
-				.isThrownBy(() -> new PubSubAdmin(() -> "test-project",
-						this.mockTopicAdminClient, this.mockSubscriptionAdminClient).getTopic("fooTopic"));
+		PubSubAdmin psa = new PubSubAdmin(() -> "test-project",
+				this.mockTopicAdminClient, this.mockSubscriptionAdminClient);
+
+		assertThatExceptionOfType(ApiException.class).isThrownBy(() -> psa.getTopic("fooTopic"));
 		verify(this.mockTopicAdminClient).getTopic(TopicName.of("test-project", "fooTopic"));
 	}
 
@@ -240,9 +241,10 @@ public class PubSubAdminTests {
 	public void testGetSubscription_serviceDown() {
 		when(this.mockSubscriptionAdminClient.getSubscription(any(ProjectSubscriptionName.class)))
 				.thenThrow(new ApiException(null, GrpcStatusCode.of(io.grpc.Status.Code.UNAVAILABLE), false));
-		assertThatExceptionOfType(ApiException.class).isThrownBy(() -> new PubSubAdmin(
-				() -> "test-project", this.mockTopicAdminClient, this.mockSubscriptionAdminClient)
-				.getSubscription("fooSubscription"));
+		PubSubAdmin psa = new PubSubAdmin(() -> "test-project",
+				this.mockTopicAdminClient, this.mockSubscriptionAdminClient);
+
+		assertThatExceptionOfType(ApiException.class).isThrownBy(() -> psa.getSubscription("fooSubscription"));
 		verify(this.mockSubscriptionAdminClient).getSubscription(
 				ProjectSubscriptionName.of("test-project", "fooSubscription"));
 	}

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubSubscriptionUtilsTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubSubscriptionUtilsTests.java
@@ -38,8 +38,9 @@ public class PubSubSubscriptionUtilsTests {
 		ProjectSubscriptionName parsedProjectSubscriptionName = PubSubSubscriptionUtils
 				.toProjectSubscriptionName(subscription, project);
 
-		assertThat(parsedProjectSubscriptionName).isEqualTo(ProjectSubscriptionName.of(project, subscription));
-		assertThat(parsedProjectSubscriptionName).hasToString(fqn);
+		assertThat(parsedProjectSubscriptionName)
+				.isEqualTo(ProjectSubscriptionName.of(project, subscription))
+				.hasToString(fqn);
 	}
 
 	@Test
@@ -65,8 +66,9 @@ public class PubSubSubscriptionUtilsTests {
 		ProjectSubscriptionName parsedProjectSubscriptionName = PubSubSubscriptionUtils.toProjectSubscriptionName(fqn,
 				project);
 
-		assertThat(parsedProjectSubscriptionName).isEqualTo(ProjectSubscriptionName.of(project, subscription));
-		assertThat(parsedProjectSubscriptionName).hasToString(fqn);
+		assertThat(parsedProjectSubscriptionName)
+				.isEqualTo(ProjectSubscriptionName.of(project, subscription))
+				.hasToString(fqn);
 	}
 
 	@Test
@@ -78,7 +80,8 @@ public class PubSubSubscriptionUtilsTests {
 		ProjectSubscriptionName parsedProjectSubscriptionName = PubSubSubscriptionUtils.toProjectSubscriptionName(fqn,
 				null);
 
-		assertThat(parsedProjectSubscriptionName).isEqualTo(ProjectSubscriptionName.of(project, subscription));
-		assertThat(parsedProjectSubscriptionName).hasToString(fqn);
+		assertThat(parsedProjectSubscriptionName)
+				.isEqualTo(ProjectSubscriptionName.of(project, subscription))
+				.hasToString(fqn);
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubSubscriptionUtilsTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubSubscriptionUtilsTests.java
@@ -39,7 +39,7 @@ public class PubSubSubscriptionUtilsTests {
 				.toProjectSubscriptionName(subscription, project);
 
 		assertThat(parsedProjectSubscriptionName).isEqualTo(ProjectSubscriptionName.of(project, subscription));
-		assertThat(parsedProjectSubscriptionName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectSubscriptionName).hasToString(fqn);
 	}
 
 	@Test
@@ -66,7 +66,7 @@ public class PubSubSubscriptionUtilsTests {
 				project);
 
 		assertThat(parsedProjectSubscriptionName).isEqualTo(ProjectSubscriptionName.of(project, subscription));
-		assertThat(parsedProjectSubscriptionName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectSubscriptionName).hasToString(fqn);
 	}
 
 	@Test
@@ -79,6 +79,6 @@ public class PubSubSubscriptionUtilsTests {
 				null);
 
 		assertThat(parsedProjectSubscriptionName).isEqualTo(ProjectSubscriptionName.of(project, subscription));
-		assertThat(parsedProjectSubscriptionName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectSubscriptionName).hasToString(fqn);
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtilsTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtilsTests.java
@@ -39,7 +39,7 @@ public class PubSubTopicUtilsTests {
 		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(topic, project);
 
 		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
-		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectTopicName).hasToString(fqn);
 	}
 
 	@Test
@@ -65,7 +65,7 @@ public class PubSubTopicUtilsTests {
 		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(fqn, project);
 
 		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
-		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectTopicName).hasToString(fqn);
 	}
 
 	@Test
@@ -77,7 +77,7 @@ public class PubSubTopicUtilsTests {
 		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(fqn, null);
 
 		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
-		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
+		assertThat(parsedProjectTopicName).hasToString(fqn);
 	}
 
 	@Test
@@ -89,7 +89,7 @@ public class PubSubTopicUtilsTests {
 		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(topic, project);
 
 		assertThat(parsedTopicName).isEqualTo(TopicName.of(project, topic));
-		assertThat(parsedTopicName.toString()).isEqualTo(fqn);
+		assertThat(parsedTopicName).hasToString(fqn);
 	}
 
 	@Test
@@ -115,7 +115,7 @@ public class PubSubTopicUtilsTests {
 		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(fqn, project);
 
 		assertThat(parsedTopicName).isEqualTo(TopicName.of(project, topic));
-		assertThat(parsedTopicName.toString()).isEqualTo(fqn);
+		assertThat(parsedTopicName).hasToString(fqn);
 	}
 
 	@Test
@@ -127,6 +127,6 @@ public class PubSubTopicUtilsTests {
 		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(fqn, null);
 
 		assertThat(parsedTopicName).isEqualTo(TopicName.of(project, topic));
-		assertThat(parsedTopicName.toString()).isEqualTo(fqn);
+		assertThat(parsedTopicName).hasToString(fqn);
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtilsTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtilsTests.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spring.pubsub.support;
 
 import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.TopicName;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -77,5 +78,55 @@ public class PubSubTopicUtilsTests {
 
 		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
 		assertThat(parsedProjectTopicName.toString()).isEqualTo(fqn);
+	}
+
+	@Test
+	public void testToTopicName_canonical() {
+		String project = "projectA";
+		String topic = "topicA";
+		String fqn = "projects/" + project + "/topics/" + topic;
+
+		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(topic, project);
+
+		assertThat(parsedTopicName).isEqualTo(TopicName.of(project, topic));
+		assertThat(parsedTopicName.toString()).isEqualTo(fqn);
+	}
+
+	@Test
+	public void testToTopicName_no_topic() {
+		assertThatThrownBy(() -> PubSubTopicUtils.toTopicName(null, "topicA"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("The topic can't be null.");
+	}
+
+	@Test
+	public void testToTopicName_canonical_no_project() {
+		assertThatThrownBy(() -> PubSubTopicUtils.toTopicName("topicA", null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("The project ID can't be null when using canonical topic name.");
+	}
+
+	@Test
+	public void testToTopicName_fqn() {
+		String project = "projectA";
+		String topic = "topicA";
+		String fqn = "projects/" + project + "/topics/" + topic;
+
+		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(fqn, project);
+
+		assertThat(parsedTopicName).isEqualTo(TopicName.of(project, topic));
+		assertThat(parsedTopicName.toString()).isEqualTo(fqn);
+	}
+
+	@Test
+	public void testToTopicName_fqn_no_project() {
+		String project = "projectA";
+		String topic = "topicA";
+		String fqn = "projects/" + project + "/topics/" + topic;
+
+		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(fqn, null);
+
+		assertThat(parsedTopicName).isEqualTo(TopicName.of(project, topic));
+		assertThat(parsedTopicName.toString()).isEqualTo(fqn);
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtilsTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtilsTests.java
@@ -38,8 +38,9 @@ public class PubSubTopicUtilsTests {
 
 		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(topic, project);
 
-		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
-		assertThat(parsedProjectTopicName).hasToString(fqn);
+		assertThat(parsedProjectTopicName)
+				.isEqualTo(ProjectTopicName.of(project, topic))
+				.hasToString(fqn);
 	}
 
 	@Test
@@ -64,8 +65,9 @@ public class PubSubTopicUtilsTests {
 
 		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(fqn, project);
 
-		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
-		assertThat(parsedProjectTopicName).hasToString(fqn);
+		assertThat(parsedProjectTopicName)
+				.isEqualTo(ProjectTopicName.of(project, topic))
+				.hasToString(fqn);
 	}
 
 	@Test
@@ -76,8 +78,9 @@ public class PubSubTopicUtilsTests {
 
 		ProjectTopicName parsedProjectTopicName = PubSubTopicUtils.toProjectTopicName(fqn, null);
 
-		assertThat(parsedProjectTopicName).isEqualTo(ProjectTopicName.of(project, topic));
-		assertThat(parsedProjectTopicName).hasToString(fqn);
+		assertThat(parsedProjectTopicName)
+				.isEqualTo(ProjectTopicName.of(project, topic))
+				.hasToString(fqn);
 	}
 
 	@Test
@@ -88,8 +91,9 @@ public class PubSubTopicUtilsTests {
 
 		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(topic, project);
 
-		assertThat(parsedTopicName).isEqualTo(TopicName.of(project, topic));
-		assertThat(parsedTopicName).hasToString(fqn);
+		assertThat(parsedTopicName)
+				.isEqualTo(TopicName.of(project, topic))
+				.hasToString(fqn);
 	}
 
 	@Test
@@ -114,8 +118,9 @@ public class PubSubTopicUtilsTests {
 
 		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(fqn, project);
 
-		assertThat(parsedTopicName).isEqualTo(TopicName.of(project, topic));
-		assertThat(parsedTopicName).hasToString(fqn);
+		assertThat(parsedTopicName)
+				.isEqualTo(TopicName.of(project, topic))
+				.hasToString(fqn);
 	}
 
 	@Test
@@ -126,7 +131,8 @@ public class PubSubTopicUtilsTests {
 
 		TopicName parsedTopicName = PubSubTopicUtils.toTopicName(fqn, null);
 
-		assertThat(parsedTopicName).isEqualTo(TopicName.of(project, topic));
-		assertThat(parsedTopicName).hasToString(fqn);
+		assertThat(parsedTopicName)
+				.isEqualTo(TopicName.of(project, topic))
+				.hasToString(fqn);
 	}
 }

--- a/spring-cloud-gcp-pubsub/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/spring-cloud-gcp-pubsub/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/PubSubStreamBinderSampleAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-binder-functional-sample/spring-cloud-gcp-pubsub-stream-binder-functional-sample-test/src/test/java/com/example/PubSubStreamBinderSampleAppIntegrationTest.java
@@ -81,7 +81,7 @@ public class PubSubStreamBinderSampleAppIntegrationTest {
 		RestTemplate restTemplate = new RestTemplate();
 
 		URI redirect = restTemplate.postForLocation("http://localhost:8080/postMessage", map);
-		assertThat(redirect.toString()).isEqualTo("http://localhost:8080/index.html");
+		assertThat(redirect).hasToString("http://localhost:8080/index.html");
 
 		Awaitility.await().atMost(10, TimeUnit.SECONDS)
 				.until(() -> this.output.getOut()


### PR DESCRIPTION
Two commits in here:

1.) Update from deprecated `ProjectTopicName` to `TopicName`

2.) Allow specifying a fully-qualified consumer destination, which allows that destination to be in a different project. To do this, I had to add a public `getProjectId()` to the `PubSubAdmin` object, which simply returns its immutable project ID.

Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/232