### PR TITLE
Remove returning generic wildcard types

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
@@ -307,7 +307,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 	}
 
 	@Override
-	public <T> DatastoreResultsIterable<?> queryKeysOrEntities(Query query, Class<T> entityClass) {
+	public <T> DatastoreResultsIterable<Object> queryKeysOrEntities(Query query, Class<T> entityClass) {
 		QueryResults results = getDatastoreReadWriter().run(query);
 		DatastoreResultsIterable resultsIterable;
 		if (results.getResultClass() == Key.class) {

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQuery.java
@@ -419,7 +419,7 @@ public class PartTreeDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 
 		private boolean isCountingQuery;
 
-		private Builder<?> structuredQueryBuilder;
+		private Builder structuredQueryBuilder;
 
 		private boolean singularResult;
 
@@ -451,7 +451,7 @@ public class PartTreeDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 			return isCountingQuery;
 		}
 
-		Builder<?> getQueryBuilder() {
+		Builder getQueryBuilder() {
 			return structuredQueryBuilder;
 		}
 


### PR DESCRIPTION
From SC:

> It is highly recommended not to use wildcard types as return types. Because the type inference rules are fairly complex it is unlikely the user of that API will know how to use it correctly.

There are dozens and dozens of 'raw use of parameterized class' warnings all over Datastore, so I didn't feel bad about adding one more (it isn't clear how to fix this since there are a handful of `Builder` objects, the code smashed them all together, and the parameterized classes don't have a common base class).  