### PR TITLE
Add gating asserts to OnGcpEnvironmentCondition

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/core/environment/OnGcpEnvironmentCondition.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/core/environment/OnGcpEnvironmentCondition.java
@@ -49,11 +49,18 @@ public class OnGcpEnvironmentCondition extends SpringBootCondition {
 	@Override
 	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
 
+		Assert.notNull(context, "Application context cannot be null.");
+		Assert.notNull(metadata, "AnnotationTypeMetadata cannot be null.");
+		Assert.notNull(context.getBeanFactory(), "Bean factory cannot be null.");
+
 		Map<String, Object> attributes = metadata.getAnnotationAttributes(ConditionalOnGcpEnvironment.class.getName());
+		Assert.notNull(attributes, "@ConditionalOnGcpEnvironment annotation not declared on type.");
+
 		GcpEnvironment[] targetEnvironments = (GcpEnvironment[]) attributes.get("value");
 		Assert.notNull(targetEnvironments, "Value attribute of ConditionalOnGcpEnvironment cannot be null.");
 
 		GcpEnvironmentProvider environmentProvider = context.getBeanFactory().getBean(GcpEnvironmentProvider.class);
+		Assert.notNull(environmentProvider, "GcpEnvironmentProvider not found in context.");
 		GcpEnvironment currentEnvironment = environmentProvider.getCurrentEnvironment();
 
 		if (Arrays.stream(targetEnvironments).noneMatch((env) -> env == currentEnvironment)) {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/core/environment/OnGcpEnvironmentConditionTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/core/environment/OnGcpEnvironmentConditionTests.java
@@ -21,9 +21,7 @@ import java.util.Collections;
 import com.google.cloud.spring.core.GcpEnvironment;
 import com.google.cloud.spring.core.GcpEnvironmentProvider;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -35,6 +33,7 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -46,12 +45,6 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class OnGcpEnvironmentConditionTests {
-
-	/**
-	 * used to check exception messages and types.
-	 */
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	@Mock
 	AnnotatedTypeMetadata mockMetadata;
@@ -72,28 +65,80 @@ public class OnGcpEnvironmentConditionTests {
 	}
 
 	@Test
+	public void nullArgumentsTriggerAssertErrors() {
+		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(null, mockMetadata))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Application context cannot be null.");
+
+		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(mockContext, null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("AnnotationTypeMetadata cannot be null.");
+
+	}
+
+	@Test
+	public void nullBeanContextTriggerAssertErrors() {
+		when(mockContext.getBeanFactory()).thenReturn(null);
+
+		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(mockContext, mockMetadata))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Bean factory cannot be null.");
+
+	}
+
+	@Test
 	public void testNoEnvironmentsMatchWhenMissingEnvironmentProvider() {
-
-		this.expectedException.expect(NoSuchBeanDefinitionException.class);
-		this.expectedException.expectMessage("No bean named 'no environment' available");
-
-		OnGcpEnvironmentCondition onGcpEnvironmentCondition = new OnGcpEnvironmentCondition();
 
 		setUpAnnotationValue(new GcpEnvironment[] { GcpEnvironment.UNKNOWN });
 		when(this.mockBeanFactory.getBean(GcpEnvironmentProvider.class))
 				.thenThrow(new NoSuchBeanDefinitionException("no environment"));
-		onGcpEnvironmentCondition.getMatchOutcome(this.mockContext, this.mockMetadata);
+
+		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(this.mockContext, this.mockMetadata))
+				.isInstanceOf(NoSuchBeanDefinitionException.class)
+				.hasMessage("No bean named 'no environment' available");
 	}
 
 	@Test
 	public void testExceptionThrownWhenWrongAttributeType() {
 
-		this.expectedException.expect(ClassCastException.class);
-		this.expectedException.expectMessage("java.lang.String cannot be cast");
-
 		setUpAnnotationValue("invalid type");
-		OnGcpEnvironmentCondition onGcpEnvironmentCondition = new OnGcpEnvironmentCondition();
-		onGcpEnvironmentCondition.getMatchOutcome(this.mockContext, this.mockMetadata);
+		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(this.mockContext, this.mockMetadata))
+				.isInstanceOf(ClassCastException.class)
+				.hasMessageContaining("java.lang.String cannot be cast");
+	}
+
+	@Test
+	public void testExceptionThrownWhenMissingAttributeType() {
+
+		// Should never happen in real life, as annotation value is not optional.
+		setUpAnnotationValue(null);
+		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(this.mockContext, this.mockMetadata))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Value attribute of ConditionalOnGcpEnvironment cannot be null.");
+
+	}
+
+	@Test
+	public void testExceptionThrownWhenAnnotationNotDeclared() {
+
+		when(mockMetadata.getAnnotationAttributes(ConditionalOnGcpEnvironment.class.getName()))
+				.thenReturn(null);
+		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(this.mockContext, this.mockMetadata))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("@ConditionalOnGcpEnvironment annotation not declared on type.");
+
+	}
+
+	@Test
+	public void testExceptionThrownWhenEnvironmentProviderBeanMissing() {
+
+		setUpAnnotationValue(new GcpEnvironment[] { GcpEnvironment.COMPUTE_ENGINE });
+		when(mockBeanFactory.getBean(GcpEnvironmentProvider.class)).thenReturn(null);
+
+		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(this.mockContext, this.mockMetadata))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("GcpEnvironmentProvider not found in context.");
+
 	}
 
 	@Test

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/core/environment/OnGcpEnvironmentConditionTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/core/environment/OnGcpEnvironmentConditionTests.java
@@ -46,6 +46,8 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class OnGcpEnvironmentConditionTests {
 
+	OnGcpEnvironmentCondition onGcpEnvironmentCondition = new OnGcpEnvironmentCondition();
+
 	@Mock
 	AnnotatedTypeMetadata mockMetadata;
 
@@ -66,11 +68,11 @@ public class OnGcpEnvironmentConditionTests {
 
 	@Test
 	public void nullArgumentsTriggerAssertErrors() {
-		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(null, mockMetadata))
+		assertThatThrownBy(() -> onGcpEnvironmentCondition.getMatchOutcome(null, mockMetadata))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Application context cannot be null.");
 
-		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(mockContext, null))
+		assertThatThrownBy(() -> onGcpEnvironmentCondition.getMatchOutcome(mockContext, null))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("AnnotationTypeMetadata cannot be null.");
 
@@ -80,7 +82,7 @@ public class OnGcpEnvironmentConditionTests {
 	public void nullBeanContextTriggerAssertErrors() {
 		when(mockContext.getBeanFactory()).thenReturn(null);
 
-		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(mockContext, mockMetadata))
+		assertThatThrownBy(() -> onGcpEnvironmentCondition.getMatchOutcome(mockContext, mockMetadata))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Bean factory cannot be null.");
 
@@ -93,7 +95,7 @@ public class OnGcpEnvironmentConditionTests {
 		when(this.mockBeanFactory.getBean(GcpEnvironmentProvider.class))
 				.thenThrow(new NoSuchBeanDefinitionException("no environment"));
 
-		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(this.mockContext, this.mockMetadata))
+		assertThatThrownBy(() -> onGcpEnvironmentCondition.getMatchOutcome(this.mockContext, this.mockMetadata))
 				.isInstanceOf(NoSuchBeanDefinitionException.class)
 				.hasMessage("No bean named 'no environment' available");
 	}
@@ -102,7 +104,7 @@ public class OnGcpEnvironmentConditionTests {
 	public void testExceptionThrownWhenWrongAttributeType() {
 
 		setUpAnnotationValue("invalid type");
-		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(this.mockContext, this.mockMetadata))
+		assertThatThrownBy(() -> onGcpEnvironmentCondition.getMatchOutcome(this.mockContext, this.mockMetadata))
 				.isInstanceOf(ClassCastException.class)
 				.hasMessageContaining("java.lang.String cannot be cast");
 	}
@@ -112,7 +114,7 @@ public class OnGcpEnvironmentConditionTests {
 
 		// Should never happen in real life, as annotation value is not optional.
 		setUpAnnotationValue(null);
-		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(this.mockContext, this.mockMetadata))
+		assertThatThrownBy(() -> onGcpEnvironmentCondition.getMatchOutcome(this.mockContext, this.mockMetadata))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Value attribute of ConditionalOnGcpEnvironment cannot be null.");
 
@@ -123,7 +125,7 @@ public class OnGcpEnvironmentConditionTests {
 
 		when(mockMetadata.getAnnotationAttributes(ConditionalOnGcpEnvironment.class.getName()))
 				.thenReturn(null);
-		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(this.mockContext, this.mockMetadata))
+		assertThatThrownBy(() -> onGcpEnvironmentCondition.getMatchOutcome(this.mockContext, this.mockMetadata))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("@ConditionalOnGcpEnvironment annotation not declared on type.");
 
@@ -135,7 +137,7 @@ public class OnGcpEnvironmentConditionTests {
 		setUpAnnotationValue(new GcpEnvironment[] { GcpEnvironment.COMPUTE_ENGINE });
 		when(mockBeanFactory.getBean(GcpEnvironmentProvider.class)).thenReturn(null);
 
-		assertThatThrownBy(() -> new OnGcpEnvironmentCondition().getMatchOutcome(this.mockContext, this.mockMetadata))
+		assertThatThrownBy(() -> onGcpEnvironmentCondition.getMatchOutcome(this.mockContext, this.mockMetadata))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("GcpEnvironmentProvider not found in context.");
 
@@ -146,7 +148,6 @@ public class OnGcpEnvironmentConditionTests {
 		setUpAnnotationValue(new GcpEnvironment[] { GcpEnvironment.COMPUTE_ENGINE });
 		when(this.mockGcpEnvironmentProvider.getCurrentEnvironment()).thenReturn(GcpEnvironment.UNKNOWN);
 
-		OnGcpEnvironmentCondition onGcpEnvironmentCondition = new OnGcpEnvironmentCondition();
 		ConditionOutcome outcome = onGcpEnvironmentCondition.getMatchOutcome(this.mockContext, this.mockMetadata);
 
 		assertThat(outcome.isMatch()).isFalse();
@@ -158,7 +159,6 @@ public class OnGcpEnvironmentConditionTests {
 		setUpAnnotationValue(new GcpEnvironment[] { GcpEnvironment.COMPUTE_ENGINE, GcpEnvironment.KUBERNETES_ENGINE });
 		when(this.mockGcpEnvironmentProvider.getCurrentEnvironment()).thenReturn(GcpEnvironment.UNKNOWN);
 
-		OnGcpEnvironmentCondition onGcpEnvironmentCondition = new OnGcpEnvironmentCondition();
 		ConditionOutcome outcome = onGcpEnvironmentCondition.getMatchOutcome(this.mockContext, this.mockMetadata);
 
 		assertThat(outcome.isMatch()).isFalse();
@@ -171,7 +171,6 @@ public class OnGcpEnvironmentConditionTests {
 		setUpAnnotationValue(new GcpEnvironment[] { GcpEnvironment.COMPUTE_ENGINE, GcpEnvironment.KUBERNETES_ENGINE });
 		when(this.mockGcpEnvironmentProvider.getCurrentEnvironment()).thenReturn(GcpEnvironment.KUBERNETES_ENGINE);
 
-		OnGcpEnvironmentCondition onGcpEnvironmentCondition = new OnGcpEnvironmentCondition();
 		ConditionOutcome outcome = onGcpEnvironmentCondition.getMatchOutcome(this.mockContext, this.mockMetadata);
 
 		assertThat(outcome.isMatch()).isTrue();
@@ -183,7 +182,6 @@ public class OnGcpEnvironmentConditionTests {
 		setUpAnnotationValue(new GcpEnvironment[] { GcpEnvironment.COMPUTE_ENGINE });
 		when(this.mockGcpEnvironmentProvider.getCurrentEnvironment()).thenReturn(GcpEnvironment.COMPUTE_ENGINE);
 
-		OnGcpEnvironmentCondition onGcpEnvironmentCondition = new OnGcpEnvironmentCondition();
 		ConditionOutcome outcome = onGcpEnvironmentCondition.getMatchOutcome(this.mockContext, this.mockMetadata);
 
 		assertThat(outcome.isMatch()).isTrue();


### PR DESCRIPTION
* Added asserts to prevent NPEs.
* Removed deprecated rule in favor of `assertThatThrownBy`.
* Added tests for new asserts, plus one missed test for an old assert.