### PR TITLE
Remove expressions that always evaluate to true/false

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
@@ -411,7 +411,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 		if (queryOptions.getCursor() != null) {
 			builder.setStartCursor(queryOptions.getCursor());
 		}
-		if (queryOptions.getSort() != null && persistentEntity != null) {
+		if (queryOptions.getSort() != null) {
 			queryOptions.getSort().stream()
 					.map((order) -> createOrderBy(persistentEntity, order))
 					.forEachOrdered((orderBy) -> builder.addOrderBy(orderBy));

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQuery.java
@@ -223,9 +223,7 @@ public class PartTreeDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 		ProjectionInformation projectionInformation =
 				this.projectionFactory.getProjectionInformation(this.queryMethod.getReturnedObjectType());
 
-		if (projectionInformation != null &&
-				projectionInformation.getType() != this.entityType
-				&& projectionInformation.isClosed()) {
+		if (projectionInformation.getType() != this.entityType && projectionInformation.isClosed()) {
 			ProjectionEntityQuery.Builder projectionEntityQueryBuilder = Query.newProjectionEntityQueryBuilder();
 			projectionInformation.getInputProperties().forEach(
 					propertyDescriptor ->

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/repository/query/PartTreeFirestoreQuery.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/repository/query/PartTreeFirestoreQuery.java
@@ -136,13 +136,13 @@ public class PartTreeFirestoreQuery implements RepositoryQuery {
 			ParameterAccessor paramAccessor = new ParametersParameterAccessor(getQueryMethod().getParameters(),
 					parameters);
 			Pageable pageable = paramAccessor.getPageable();
-			if (pageable != null && pageable.isPaged()) {
+			if (pageable.isPaged()) {
 				builder.setOffset((int) Math.min(Integer.MAX_VALUE, pageable.getOffset()));
 				builder.setLimit(Int32Value.newBuilder().setValue(pageable.getPageSize()));
 			}
 
 			Sort sort = paramAccessor.getSort();
-			if (sort != null) {
+			if (sort.isSorted()) {
 				builder.addAllOrderBy(createFirestoreSortOrders(sort));
 			}
 		}

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -315,9 +315,7 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 					writeConverter);
 		}
 		else {
-			if (!valueSet) {
-				valueSet = attemptSetIterableValueOnBinder(value, valueBinder, writeConverter, innerType);
-			}
+			valueSet = attemptSetIterableValueOnBinder(value, valueBinder, writeConverter, innerType);
 		}
 		return valueSet;
 	}
@@ -403,9 +401,7 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 						this.writeConverter);
 			}
 			else {
-				if (!valueSet) {
-					valueSet = attemptBindSingleValue(propertyValue, propertyType, valueBinder, this.writeConverter);
-				}
+				valueSet = attemptBindSingleValue(propertyValue, propertyType, valueBinder, this.writeConverter);
 			}
 		}
 


### PR DESCRIPTION
There is [one more](https://sonarcloud.io/project/issues?assignees=ttomsu%40github&id=GoogleCloudPlatform_spring-cloud-gcp&open=AXZNafd0hMoO4rKzKcLg&resolved=false) of these that I'm not convinced will always return non-null, but would like some additional eyes to help out. 