### PR TITLE
Add a null guard around Datastore getPersistentEntity

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContext.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContext.java
@@ -121,7 +121,8 @@ public class DatastoreMappingContext extends
 		DatastorePersistentEntity<?> result = super.getPersistentEntity(type);
 		if (result != null) {
 			return result;
-		} else {
+		}
+		else {
 			throw new IllegalArgumentException("Cannot create Datastore persistent entity from: " + type);
 		}
 	}

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContext.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContext.java
@@ -115,4 +115,14 @@ public class DatastoreMappingContext extends
 		return new DatastorePersistentPropertyImpl(property, owner, simpleTypeHolder,
 				this.fieldNamingStrategy);
 	}
+
+	@Override
+	public DatastorePersistentEntity<?> getPersistentEntity(Class<?> type) {
+		DatastorePersistentEntity<?> result = super.getPersistentEntity(type);
+		if (result != null) {
+			return result;
+		} else {
+			throw new IllegalArgumentException("Cannot create Datastore persistent entity from: " + type);
+		}
+	}
 }

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
@@ -22,6 +22,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -56,6 +57,16 @@ public class DatastoreMappingContextTests {
 		context.createPersistentEntity(ClassTypeInformation.from(Object.class));
 
 		verifyZeroInteractions(mockEntity);
+	}
+
+	@Test
+	public void testGetInvalidEntity() {
+		DatastorePersistentEntityImpl mockEntity = mock(
+				DatastorePersistentEntityImpl.class);
+		DatastoreMappingContext context = createDatastoreMappingContextWith(mockEntity);
+
+		assertThatThrownBy(() -> context.getPersistentEntity(Integer.class))
+				.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	private DatastoreMappingContext createDatastoreMappingContextWith(


### PR DESCRIPTION
Adds a null check around `getPersistentEntity(...)` usage in Datastore.

If a user passes in an invalid class to be converted to a Datastore entity (such as `Integer`, `Boolean`, etc.) this will throw `IllegalArgumentException` now instead of yielding a null pointer.