### PR TITLE
Only one invocation in a lambda that throws and exception

### DIFF
--- a/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/MapBuilderTests.java
+++ b/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/MapBuilderTests.java
@@ -51,21 +51,24 @@ public class MapBuilderTests {
 
 	@Test
 	public void mapWithNullKeyThrowsException() {
-		assertThatThrownBy(() -> new MapBuilder<String, String>().put(null, "nope"))
+		MapBuilder<String, String> mb = new MapBuilder<>();
+		assertThatThrownBy(() -> mb.put(null, "nope"))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Map key cannot be null.");
 	}
 
 	@Test
 	public void mapWithNullValueThrowsException() {
-		assertThatThrownBy(() -> new MapBuilder<String, String>().put("nope", null))
+		MapBuilder<String, String> mb = new MapBuilder<>();
+		assertThatThrownBy(() -> mb.put("nope", null))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Map value cannot be null.");
 	}
 
 	@Test
 	public void mapWithDuplicateKeysThrowsException() {
-		assertThatThrownBy(() -> new MapBuilder<String, String>().put("b", "beta").put("b", "vita"))
+		MapBuilder<String, String> mb = new MapBuilder<>();
+		assertThatThrownBy(() -> mb.put("b", "beta").put("b", "vita"))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Duplicate keys not allowed.");
 	}

--- a/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/MapBuilderTests.java
+++ b/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/MapBuilderTests.java
@@ -68,7 +68,8 @@ public class MapBuilderTests {
 	@Test
 	public void mapWithDuplicateKeysThrowsException() {
 		MapBuilder<String, String> mb = new MapBuilder<>();
-		assertThatThrownBy(() -> mb.put("b", "beta").put("b", "vita"))
+		mb.put("b", "beta");
+		assertThatThrownBy(() -> mb.put("b", "vita"))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Duplicate keys not allowed.");
 	}

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/reactive/PubSubReactiveFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/reactive/PubSubReactiveFactoryTests.java
@@ -72,7 +72,8 @@ public class PubSubReactiveFactoryTests {
 
 	@Test
 	public void testIllegalArgumentExceptionWithMaxMessagesLessThanOne() {
-		assertThatThrownBy(() -> new PubSubReactiveFactory(subscriberOperations, VirtualTimeScheduler.getOrSet(), 0))
+		VirtualTimeScheduler vts = VirtualTimeScheduler.getOrSet();
+		assertThatThrownBy(() -> new PubSubReactiveFactory(subscriberOperations, vts, 0))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("maxMessages cannot be less than 1.");
 	}

--- a/spring-cloud-gcp-security-firebase/src/test/java/com/google/cloud/spring/security/firebase/FirebaseJwtTokenDecoderTests.java
+++ b/spring-cloud-gcp-security-firebase/src/test/java/com/google/cloud/spring/security/firebase/FirebaseJwtTokenDecoderTests.java
@@ -82,10 +82,11 @@ public class FirebaseJwtTokenDecoderTests {
 				.expirationTime(Date.from(Instant.now().plusSeconds(60)))
 				.build();
 		PlainJWT plainJWT = new PlainJWT(claimsSet);
+		String plainJWTString = plainJWT.serialize();
 
 		FirebaseJwtTokenDecoder decoder = new FirebaseJwtTokenDecoder(mock(RestOperations.class), "https://spring.local", mock(OAuth2TokenValidator.class));
 		assertThatExceptionOfType(JwtException.class)
-				.isThrownBy(() -> decoder.decode(plainJWT.serialize()))
+				.isThrownBy(() -> decoder.decode(plainJWTString))
 				.withMessageStartingWith("An error occurred while attempting to decode the Jwt");
 	}
 
@@ -96,11 +97,11 @@ public class FirebaseJwtTokenDecoderTests {
 				.subject("test-subject")
 				.expirationTime(Date.from(Instant.now().plusSeconds(60)))
 				.build();
-		SignedJWT signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
+		String signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
 		OAuth2TokenValidator validator = mock(OAuth2TokenValidator.class);
 		when(validator.validate(any())).thenReturn(OAuth2TokenValidatorResult.success());
 		FirebaseJwtTokenDecoder decoder = new FirebaseJwtTokenDecoder(mockRestOperations(), "https://spring.local", validator);
-		decoder.decode(signedJWT.serialize());
+		decoder.decode(signedJWT);
 	}
 
 	@Test
@@ -110,13 +111,13 @@ public class FirebaseJwtTokenDecoderTests {
 				.subject("test-subject")
 				.expirationTime(Date.from(Instant.now().plusSeconds(60)))
 				.build();
-		SignedJWT signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
+		String signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
 		OAuth2TokenValidator validator = mock(OAuth2TokenValidator.class);
 		when(validator.validate(any())).thenReturn(OAuth2TokenValidatorResult.success());
 		RestOperations operations = mockRestOperations();
 		FirebaseJwtTokenDecoder decoder = new FirebaseJwtTokenDecoder(operations, "https://spring.local", validator);
-		decoder.decode(signedJWT.serialize());
-		decoder.decode(signedJWT.serialize());
+		decoder.decode(signedJWT);
+		decoder.decode(signedJWT);
 		verify(operations, times(1)).exchange(eq("https://spring.local"),
 				eq(HttpMethod.GET),
 				isNull(),
@@ -130,12 +131,13 @@ public class FirebaseJwtTokenDecoderTests {
 				.subject("test-subject")
 				.expirationTime(Date.from(Instant.now().plusSeconds(60)))
 				.build();
-		SignedJWT signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
+		String signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
+
 		OAuth2TokenValidator validator = mock(OAuth2TokenValidator.class);
 		when(validator.validate(any())).thenReturn(OAuth2TokenValidatorResult.success());
 		FirebaseJwtTokenDecoder decoder = new FirebaseJwtTokenDecoder(mockRestOperations(), "https://spring.local", validator);
 		assertThatExceptionOfType(JwtException.class)
-				.isThrownBy(() -> decoder.decode(signedJWT.serialize()))
+				.isThrownBy(() -> decoder.decode(signedJWT))
 				.withMessageStartingWith("No certificate found for key: ");
 	}
 
@@ -146,7 +148,7 @@ public class FirebaseJwtTokenDecoderTests {
 				.subject("test-subject")
 				.expirationTime(Date.from(Instant.now().plusSeconds(60)))
 				.build();
-		SignedJWT signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
+		String signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
 		OAuth2TokenValidator validator = mock(OAuth2TokenValidator.class);
 		when(validator.validate(any())).thenReturn(OAuth2TokenValidatorResult.success());
 		RestOperations operations = mock(RestOperations.class);
@@ -156,7 +158,7 @@ public class FirebaseJwtTokenDecoderTests {
 				eq(new ParameterizedTypeReference<Map<String, String>>() { }))).thenThrow(new RestClientException("Could not connect to remote peer"));
 		FirebaseJwtTokenDecoder decoder = new FirebaseJwtTokenDecoder(operations, "https://spring.local", validator);
 		assertThatExceptionOfType(JwtException.class)
-				.isThrownBy(() -> decoder.decode(signedJWT.serialize()))
+				.isThrownBy(() -> decoder.decode(signedJWT))
 				.withMessageStartingWith("Error fetching public keys");
 	}
 
@@ -167,14 +169,14 @@ public class FirebaseJwtTokenDecoderTests {
 				.subject("test-subject")
 				.expirationTime(Date.from(Instant.now().minusSeconds(3600)))
 				.build();
-		SignedJWT signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
+		String signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
 		List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
 		validators.add(new JwtTimestampValidator());
 		DelegatingOAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<Jwt>(validators);
 		RestOperations operations = mockRestOperations();
 		FirebaseJwtTokenDecoder decoder = new FirebaseJwtTokenDecoder(operations, "https://spring.local", validator);
 		assertThatExceptionOfType(JwtException.class)
-				.isThrownBy(() -> decoder.decode(signedJWT.serialize()))
+				.isThrownBy(() -> decoder.decode(signedJWT))
 				.withMessageStartingWith("An error occurred while attempting to decode the Jwt: Jwt expired at");
 	}
 
@@ -189,7 +191,7 @@ public class FirebaseJwtTokenDecoderTests {
 				.issueTime(Date.from(Instant.now().minusSeconds(3600)))
 				.claim("auth_time", Instant.now().minusSeconds(3600).getEpochSecond())
 				.build();
-		SignedJWT signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
+		String signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
 		List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
 		validators.add(new JwtTimestampValidator());
 		validators.add(new JwtIssuerValidator("https://securetoken.google.com/123456"));
@@ -197,7 +199,7 @@ public class FirebaseJwtTokenDecoderTests {
 		RestOperations operations = mockRestOperations();
 		FirebaseJwtTokenDecoder decoder = new FirebaseJwtTokenDecoder(operations, "https://spring.local", validator);
 		assertThatExceptionOfType(JwtException.class)
-				.isThrownBy(() -> decoder.decode(signedJWT.serialize()))
+				.isThrownBy(() -> decoder.decode(signedJWT))
 				.withMessageStartingWith("An error occurred while attempting to decode the Jwt");
 	}
 
@@ -212,7 +214,7 @@ public class FirebaseJwtTokenDecoderTests {
 				.issueTime(Date.from(Instant.now().minusSeconds(3600)))
 				.claim("auth_time", Instant.now().minusSeconds(3600).getEpochSecond())
 				.build();
-		SignedJWT signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
+		String signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
 		List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
 		validators.add(new JwtTimestampValidator());
 		validators.add(new JwtIssuerValidator("https://securetoken.google.com/123456"));
@@ -220,7 +222,7 @@ public class FirebaseJwtTokenDecoderTests {
 		DelegatingOAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<Jwt>(validators);
 		RestOperations operations = mockRestOperations();
 		FirebaseJwtTokenDecoder decoder = new FirebaseJwtTokenDecoder(operations, "https://spring.local", validator);
-		Jwt jwt = decoder.decode(signedJWT.serialize());
+		Jwt jwt = decoder.decode(signedJWT);
 		assertThat(jwt.getClaims()).isNotEmpty();
 	}
 
@@ -235,7 +237,7 @@ public class FirebaseJwtTokenDecoderTests {
 				.issueTime(Date.from(Instant.now().minusSeconds(3600)))
 				.claim("auth_time", Instant.now().minusSeconds(3600).getEpochSecond())
 				.build();
-		SignedJWT signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
+		String signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
 		List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
 		validators.add(new JwtTimestampValidator());
 		validators.add(new JwtIssuerValidator("https://securetoken.google.com/123456"));
@@ -244,7 +246,7 @@ public class FirebaseJwtTokenDecoderTests {
 		RestOperations operations = mockRestOperations();
 		FirebaseJwtTokenDecoder decoder = new FirebaseJwtTokenDecoder(operations, "https://spring.local", validator);
 		assertThatExceptionOfType(JwtException.class)
-				.isThrownBy(() -> decoder.decode(signedJWT.serialize()))
+				.isThrownBy(() -> decoder.decode(signedJWT))
 				.withMessageStartingWith("An error occurred while attempting to decode the Jwt: This aud claim is not equal to the configured audience");
 	}
 
@@ -259,7 +261,7 @@ public class FirebaseJwtTokenDecoderTests {
 				.issueTime(Date.from(Instant.now().plusSeconds(3600)))
 				.claim("auth_time", Instant.now().minusSeconds(3600).getEpochSecond())
 				.build();
-		SignedJWT signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
+		String signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
 		List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
 		validators.add(new JwtTimestampValidator());
 		validators.add(new JwtIssuerValidator("https://securetoken.google.com/123456"));
@@ -268,7 +270,7 @@ public class FirebaseJwtTokenDecoderTests {
 		RestOperations operations = mockRestOperations();
 		FirebaseJwtTokenDecoder decoder = new FirebaseJwtTokenDecoder(operations, "https://spring.local", validator);
 		assertThatExceptionOfType(JwtException.class)
-				.isThrownBy(() -> decoder.decode(signedJWT.serialize()))
+				.isThrownBy(() -> decoder.decode(signedJWT))
 				.withMessageStartingWith("An error occurred while attempting to decode the Jwt: iat claim header must be in the past");
 	}
 
@@ -282,7 +284,7 @@ public class FirebaseJwtTokenDecoderTests {
 				.issueTime(Date.from(Instant.now().minusSeconds(3600)))
 				.claim("auth_time", Instant.now().minusSeconds(3600).getEpochSecond())
 				.build();
-		SignedJWT signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
+		String signedJWT = signedJwt(keyGeneratorUtils.getPrivateKey(), header, claimsSet);
 		List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
 		validators.add(new JwtTimestampValidator());
 		validators.add(new JwtIssuerValidator("https://securetoken.google.com/123456"));
@@ -291,7 +293,7 @@ public class FirebaseJwtTokenDecoderTests {
 		RestOperations operations = mockRestOperations();
 		FirebaseJwtTokenDecoder decoder = new FirebaseJwtTokenDecoder(operations, "https://spring.local", validator);
 		assertThatExceptionOfType(JwtException.class)
-				.isThrownBy(() -> decoder.decode(signedJWT.serialize()))
+				.isThrownBy(() -> decoder.decode(signedJWT))
 				.withMessageStartingWith("An error occurred while attempting to decode the Jwt: sub claim can not be empty");
 	}
 
@@ -314,15 +316,15 @@ public class FirebaseJwtTokenDecoderTests {
 		return mock;
 	}
 
-	private SignedJWT signedJwt(PrivateKey privateKey, JWSHeader header, JWTClaimsSet claimsSet) throws Exception {
+	private String signedJwt(PrivateKey privateKey, JWSHeader header, JWTClaimsSet claimsSet) throws Exception {
 		JWSSigner signer = new RSASSASigner(privateKey);
 		return signedJwt(signer, header, claimsSet);
 	}
 
-	private SignedJWT signedJwt(JWSSigner signer, JWSHeader header, JWTClaimsSet claimsSet) throws Exception {
+	private String signedJwt(JWSSigner signer, JWSHeader header, JWTClaimsSet claimsSet) throws Exception {
 		SignedJWT signedJWT = new SignedJWT(header, claimsSet);
 		signedJWT.sign(signer);
-		return signedJWT;
+		return signedJWT.serialize();
 	}
 
 }

--- a/spring-cloud-gcp-security-iap/src/test/java/com/google/cloud/spring/security/iap/AppEngineAudienceProviderTests.java
+++ b/spring-cloud-gcp-security-iap/src/test/java/com/google/cloud/spring/security/iap/AppEngineAudienceProviderTests.java
@@ -54,30 +54,24 @@ public class AppEngineAudienceProviderTests {
 	@Test
 	public void testNullProjectIdProviderDisallowed() {
 
-		assertThatThrownBy(() -> {
-			new AppEngineAudienceProvider(null);
-		})
+		assertThatThrownBy(() -> new AppEngineAudienceProvider(null))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("GcpProjectIdProvider cannot be null.");
 	}
 
 	@Test
 	public void testNullResourceManagerDisallowed() {
-
-		assertThatThrownBy(() -> {
-			new AppEngineAudienceProvider(this.mockProjectIdProvider).setResourceManager(null);
-		})
+		AppEngineAudienceProvider audienceProvider = new AppEngineAudienceProvider(this.mockProjectIdProvider);
+		assertThatThrownBy(() -> audienceProvider.setResourceManager(null))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("ResourceManager cannot be null.");
 	}
 
 	@Test
 	public void testNullProjectDisallowed() {
-		assertThatThrownBy(() -> {
-			AppEngineAudienceProvider provider = new AppEngineAudienceProvider(this.mockProjectIdProvider);
-			provider.setResourceManager(this.mockResourceManager);
-			provider.getAudience();
-		})
+		AppEngineAudienceProvider provider = new AppEngineAudienceProvider(this.mockProjectIdProvider);
+		provider.setResourceManager(this.mockResourceManager);
+		assertThatThrownBy(provider::getAudience)
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageStartingWith("Project expected not to be null. Is Cloud Resource Manager API enabled");
 
@@ -89,11 +83,9 @@ public class AppEngineAudienceProviderTests {
 		when(this.mockResourceManager.get("steal-spaceship")).thenReturn(this.mockProject);
 		when(this.mockProject.getProjectNumber()).thenReturn(null);
 
-		assertThatThrownBy(() -> {
-			AppEngineAudienceProvider provider = new AppEngineAudienceProvider(this.mockProjectIdProvider);
-			provider.setResourceManager(this.mockResourceManager);
-			provider.getAudience();
-		})
+		AppEngineAudienceProvider provider = new AppEngineAudienceProvider(this.mockProjectIdProvider);
+		provider.setResourceManager(this.mockResourceManager);
+		assertThatThrownBy(provider::getAudience)
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Project Number expected not to be null.");
 	}
@@ -104,11 +96,9 @@ public class AppEngineAudienceProviderTests {
 		when(this.mockResourceManager.get(null)).thenReturn(this.mockProject);
 		when(this.mockProject.getProjectNumber()).thenReturn(42L);
 
-		assertThatThrownBy(() -> {
-			AppEngineAudienceProvider provider = new AppEngineAudienceProvider(this.mockProjectIdProvider);
-			provider.setResourceManager(this.mockResourceManager);
-			provider.getAudience();
-		})
+		AppEngineAudienceProvider provider = new AppEngineAudienceProvider(this.mockProjectIdProvider);
+		provider.setResourceManager(this.mockResourceManager);
+		assertThatThrownBy(provider::getAudience)
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Project Id expected not to be null.");
 	}

--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/DocumentOcrResultSetTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/DocumentOcrResultSetTests.java
@@ -18,6 +18,7 @@ package com.google.cloud.spring.vision;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import com.google.cloud.storage.Blob;
 import org.junit.Test;
@@ -34,7 +35,8 @@ public class DocumentOcrResultSetTests {
 		Blob blob = Mockito.mock(Blob.class);
 		when(blob.getName()).thenReturn("output.json");
 
-		assertThatThrownBy(() -> new DocumentOcrResultSet(Collections.singletonList(blob)))
+		List<Blob> blobList = Collections.singletonList(blob);
+		assertThatThrownBy(() -> new DocumentOcrResultSet(blobList))
 				.hasMessageContaining("Cannot create a DocumentOcrResultSet with blob: ")
 				.isInstanceOf(IllegalArgumentException.class);
 	}


### PR DESCRIPTION
From SC: "Refactor the code of the lambda to have only one invocation possibly throwing a runtime exception.

When verifying that code raises a runtime exception, a good practice is to avoid having multiple method calls inside the tested code, to be explicit about which method call is expected to raise the exception."