### PR TITLE
Cleanup in case of failures in PubSubAdmin constructor

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
@@ -73,16 +73,16 @@ public class PubSubAdmin implements AutoCloseable {
 	public PubSubAdmin(GcpProjectIdProvider projectIdProvider,
 			CredentialsProvider credentialsProvider) throws IOException {
 		try (
-				TopicAdminClient topicAdminClient = TopicAdminClient.create(
+				TopicAdminClient topicClient = TopicAdminClient.create(
 						TopicAdminSettings.newBuilder()
 								.setCredentialsProvider(credentialsProvider)
 								.build());
-				SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create(
+				SubscriptionAdminClient subscriptionClient = SubscriptionAdminClient.create(
 						SubscriptionAdminSettings.newBuilder()
 								.setCredentialsProvider(credentialsProvider)
 								.build());
 		) {
-			build(projectIdProvider, topicAdminClient, subscriptionAdminClient);
+			build(projectIdProvider, topicClient, subscriptionClient);
 		}
 	}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
@@ -72,7 +72,6 @@ public class PubSubAdmin implements AutoCloseable {
 	 */
 	public PubSubAdmin(GcpProjectIdProvider projectIdProvider,
 			CredentialsProvider credentialsProvider) throws PubSubException {
-		SubscriptionAdminClient subscriptionClient;
 		Assert.notNull(projectIdProvider, "The project ID provider can't be null.");
 		this.projectId = projectIdProvider.getProjectId();
 		Assert.hasText(this.projectId, "The project ID can't be null or empty.");


### PR DESCRIPTION
Fixes blocker SonarCloud finding:
"Use try-with-resources or close this "TopicAdminClient" in a "finally" clause."