### PR TITLE
Remove use of excessive Mockito arg matchers

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfigurationTests.java
@@ -35,7 +35,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -101,7 +100,7 @@ public class GcpStorageAutoConfigurationTests {
 			Blob mockedBlob = mock(Blob.class);
 			when(mockedBlob.exists()).thenReturn(true);
 			when(mockedBlob.getSize()).thenReturn(4096L);
-			when(storage.get(eq(validBlob))).thenReturn(mockedBlob);
+			when(storage.get(validBlob)).thenReturn(mockedBlob);
 			return storage;
 		}
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplateTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplateTests.java
@@ -237,9 +237,9 @@ public class DatastoreTemplateTests {
 			QueryResults childTestEntityQueryResults, QueryResults testEntityQueryResults) {
 		// mocking the converter to return the final objects corresponding to their
 		// specific entities.
-		when(this.datastoreEntityConverter.read(eq(TestEntity.class), eq(this.e1)))
+		when(this.datastoreEntityConverter.read(TestEntity.class, this.e1))
 				.thenReturn(this.ob1);
-		when(this.datastoreEntityConverter.read(eq(TestEntity.class), eq(this.e2)))
+		when(this.datastoreEntityConverter.read(TestEntity.class, this.e2))
 				.thenReturn(this.ob2);
 		when(this.datastoreEntityConverter.read(eq(ChildEntity.class), same(ce1)))
 				.thenAnswer(invocationOnMock -> createChildEntity());
@@ -258,11 +258,11 @@ public class DatastoreTemplateTests {
 			return null;
 		}).when(this.datastoreEntityConverter).write(same(this.simpleTestEntityNullVallues), any());
 
-		when(this.datastore.run(eq(this.testEntityQuery)))
+		when(this.datastore.run(this.testEntityQuery))
 				.thenReturn(testEntityQueryResults);
-		when(this.datastore.run(eq(this.findAllTestEntityQuery)))
+		when(this.datastore.run(this.findAllTestEntityQuery))
 				.thenReturn(testEntityQueryResults);
-		when(this.datastore.run(eq(childTestEntityQuery)))
+		when(this.datastore.run(childTestEntityQuery))
 				.thenReturn(childTestEntityQueryResults);
 
 		// Because get() takes varags, there is difficulty in matching the single param
@@ -421,7 +421,7 @@ public class DatastoreTemplateTests {
 
 	@Test
 	public void findAllByIdTest() {
-		when(this.datastore.fetch(eq(this.key2), eq(this.key1)))
+		when(this.datastore.fetch(this.key2, this.key1))
 				.thenReturn(Arrays.asList(this.e1, this.e2));
 		List<Key> keys = Arrays.asList(this.key1, this.key2);
 
@@ -437,7 +437,7 @@ public class DatastoreTemplateTests {
 	public void findAllByIdReferenceConsistencyTest() {
 		when(this.objectToKeyFactory.getKeyFromObject(eq(this.childEntity1), any())).thenReturn(this.childEntity1.id);
 
-		when(this.datastore.fetch(eq(this.key1)))
+		when(this.datastore.fetch(this.key1))
 				.thenReturn(Collections.singletonList(this.e1));
 
 		verifyBeforeAndAfterEvents(null,
@@ -472,11 +472,11 @@ public class DatastoreTemplateTests {
 		Entity child = Entity.newBuilder(this.key1).build();
 		Entity child2 = Entity.newBuilder(this.childKey2).build();
 
-		when(this.datastore.fetch(eq(this.key1)))
+		when(this.datastore.fetch(this.key1))
 				.thenReturn(Collections.singletonList(referenceTestDatastoreEntity));
-		when(this.datastore.fetch(eq(this.key2)))
+		when(this.datastore.fetch(this.key2))
 				.thenReturn(Collections.singletonList(child));
-		when(this.datastore.fetch(eq(this.childKey2)))
+		when(this.datastore.fetch(this.childKey2))
 				.thenReturn(Collections.singletonList(child2));
 
 		ReferenceTestEntity referenceTestEntity = new ReferenceTestEntity();
@@ -503,12 +503,12 @@ public class DatastoreTemplateTests {
 
 					assertThat(readReferenceTestEntity.lazyChildren).hasSize(1);
 					verify(this.datastore, times(2)).fetch(any());
-					verify(this.datastore, times(1)).fetch(eq(this.key1));
-					verify(this.datastore, times(1)).fetch(eq(this.key2));
+					verify(this.datastore, times(1)).fetch(this.key1);
+					verify(this.datastore, times(1)).fetch(this.key2);
 
 					assertThat(readReferenceTestEntity.lazyChild.toString()).isNotNull();
 					verify(this.datastore, times(3)).fetch(any());
-					verify(this.datastore, times(1)).fetch(eq(this.childKey2));
+					verify(this.datastore, times(1)).fetch(this.childKey2);
 				}, x -> {
 				});
 	}
@@ -849,7 +849,7 @@ public class DatastoreTemplateTests {
 
 		KeyQuery query = Query.newKeyQueryBuilder().setKind("custom_test_kind").setLimit(1).build();
 		when(this.datastore
-				.run(eq(query)))
+				.run(query))
 				.thenReturn(queryResults);
 
 		QueryResults<Key> nextPageQueryResults = mock(QueryResults.class);
@@ -859,7 +859,7 @@ public class DatastoreTemplateTests {
 				query.toBuilder().setStartCursor(cursor).setOffset(0).setLimit(1).build();
 
 		when(this.datastore
-				.run(eq(nextPageQuery)))
+				.run(nextPageQuery))
 				.thenReturn(nextPageQueryResults);
 
 		Slice<Key> resultsSlice =
@@ -877,7 +877,7 @@ public class DatastoreTemplateTests {
 			return null;
 		}).when(queryResults).forEachRemaining(any());
 		when(this.datastore
-				.run(eq(Query.newKeyQueryBuilder().setKind("custom_test_kind").build())))
+				.run(Query.newKeyQueryBuilder().setKind("custom_test_kind").build()))
 						.thenReturn(queryResults);
 		assertThat(this.datastoreTemplate.count(TestEntity.class)).isEqualTo(2);
 	}
@@ -937,7 +937,7 @@ public class DatastoreTemplateTests {
 						Arrays.asList(this.ob1, this.ob2)),
 				new AfterDeleteEvent(new Key[] { this.key1, this.key2 }, null, null, Arrays.asList(this.ob1, this.ob2)),
 				() -> this.datastoreTemplate.deleteAll(Arrays.asList(this.ob1, this.ob2)),
-				x -> x.verify(this.datastore, times(1)).delete(eq(this.key1), eq(this.key2)));
+				x -> x.verify(this.datastore, times(1)).delete(this.key1, this.key2));
 	}
 
 	@Test
@@ -950,7 +950,7 @@ public class DatastoreTemplateTests {
 			return null;
 		}).when(queryResults).forEachRemaining(any());
 		when(this.datastore
-				.run(eq(Query.newKeyQueryBuilder().setKind("custom_test_kind").build())))
+				.run(Query.newKeyQueryBuilder().setKind("custom_test_kind").build()))
 						.thenReturn(queryResults);
 
 		verifyBeforeAndAfterEvents(
@@ -983,11 +983,11 @@ public class DatastoreTemplateTests {
 
 		operation.run();
 		if (expectedBefore != null) {
-			inOrder.verify(mockBeforePublisher, times(1)).publishEvent(eq(expectedBefore));
+			inOrder.verify(mockBeforePublisher, times(1)).publishEvent(expectedBefore);
 		}
 		verifyOperation.accept(inOrder);
 		if (expectedAfter != null) {
-			inOrder.verify(mockAfterPublisher, times(1)).publishEvent(eq(expectedAfter));
+			inOrder.verify(mockAfterPublisher, times(1)).publishEvent(expectedAfter);
 		}
 	}
 
@@ -1197,12 +1197,12 @@ public class DatastoreTemplateTests {
 		map.put("field1", 1L);
 		Key keyForMap = createFakeKey("map1");
 
-		when(this.readWriteConversions.convertOnWriteSingle(eq(1L))).thenReturn(LongValue.of(1L));
+		when(this.readWriteConversions.convertOnWriteSingle(1L)).thenReturn(LongValue.of(1L));
 
 		this.datastoreTemplate.writeMap(keyForMap, map);
 
 		Entity datastoreEntity = Entity.newBuilder(keyForMap).set("field1", 1L).build();
-		verify(this.datastore, times(1)).put(eq(datastoreEntity));
+		verify(this.datastore, times(1)).put(datastoreEntity);
 	}
 
 	@Test
@@ -1210,17 +1210,17 @@ public class DatastoreTemplateTests {
 		Key keyForMap = createFakeKey("map1");
 
 		Entity datastoreEntity = Entity.newBuilder(keyForMap).set("field1", 1L).build();
-		when(this.datastore.get(eq(keyForMap))).thenReturn(datastoreEntity);
+		when(this.datastore.get(keyForMap)).thenReturn(datastoreEntity);
 
 		this.datastoreTemplate.findByIdAsMap(keyForMap, Long.class);
 		verify(this.datastoreEntityConverter, times(1))
-				.readAsMap(eq(String.class), eq(ClassTypeInformation.from(Long.class)), eq(datastoreEntity));
+				.readAsMap(String.class, ClassTypeInformation.from(Long.class), datastoreEntity);
 	}
 
 	@Test
 	public void createKeyTest() {
 		this.datastoreTemplate.createKey("kind1", 1L);
-		verify(this.objectToKeyFactory, times(1)).getKeyFromId(eq(1L), eq("kind1"));
+		verify(this.objectToKeyFactory, times(1)).getKeyFromId(1L, "kind1");
 	}
 
 	@com.google.cloud.spring.data.datastore.core.mapping.Entity(name = "custom_test_kind")

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
@@ -23,7 +23,6 @@ import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -45,7 +44,7 @@ public class DatastoreMappingContextTests {
 
 		context.createPersistentEntity(ClassTypeInformation.from(Object.class));
 
-		verify(mockEntity, times(1)).setApplicationContext(eq(applicationContext));
+		verify(mockEntity, times(1)).setApplicationContext(applicationContext);
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/DatastoreQueryLookupStrategyTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/DatastoreQueryLookupStrategyTests.java
@@ -88,8 +88,8 @@ public class DatastoreQueryLookupStrategyTests {
 			return param;
 		});
 
-		when(namedQueries.hasQuery(eq(queryName))).thenReturn(true);
-		when(namedQueries.getQuery(eq(queryName))).thenReturn(query);
+		when(namedQueries.hasQuery(queryName)).thenReturn(true);
+		when(namedQueries.getQuery(queryName)).thenReturn(query);
 
 		this.datastoreQueryLookupStrategy.resolveQuery(null, null, null, namedQueries);
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
@@ -655,7 +655,7 @@ public class PartTreeDatastoreQueryTests {
 				.queryKeysOrEntities(any(), any());
 
 		verify(this.datastoreTemplate, times(1))
-				.deleteAll(eq(Arrays.asList(3, 4, 5)));
+				.deleteAll(Arrays.asList(3, 4, 5));
 	}
 	private void prepareDeleteResults(boolean isCollection) {
 		Cursor cursor = Cursor.copyFrom("abc".getBytes());
@@ -803,7 +803,7 @@ public class PartTreeDatastoreQueryTests {
 				getClass().getMethod("findByActionAndId", String.class, String.class), true, null);
 
 		Object[] params = new Object[] { "BUY", "id1"};
-		when(this.datastoreTemplate.createKey(eq("trades"), eq("id1")))
+		when(this.datastoreTemplate.createKey("trades", "id1"))
 				.thenAnswer((invocation) ->
 						Key.newBuilder("project", invocation.getArgument(0), invocation.getArgument(1)).build());
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepositoryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepositoryTests.java
@@ -84,40 +84,40 @@ public class SimpleDatastoreRepositoryTests {
 	public void findByIdTest() {
 		String id = "key";
 		this.simpleDatastoreRepository.findById(id);
-		verify(this.datastoreTemplate, times(1)).findById(eq(id), eq(Object.class));
+		verify(this.datastoreTemplate, times(1)).findById(id, Object.class);
 	}
 
 	@Test
 	public void existsByIdTest() {
 		String id = "key";
 		this.simpleDatastoreRepository.existsById(id);
-		verify(this.datastoreTemplate, times(1)).existsById(eq(id), eq(Object.class));
+		verify(this.datastoreTemplate, times(1)).existsById(id, Object.class);
 	}
 
 	@Test
 	public void findAllTest() {
 		this.simpleDatastoreRepository.findAll();
-		verify(this.datastoreTemplate, times(1)).findAll(eq(Object.class));
+		verify(this.datastoreTemplate, times(1)).findAll(Object.class);
 	}
 
 	@Test
 	public void findAllByIdTest() {
 		List<String> keys = Arrays.asList("1", "2");
 		this.simpleDatastoreRepository.findAllById(keys);
-		verify(this.datastoreTemplate, times(1)).findAllById(eq(keys), eq(Object.class));
+		verify(this.datastoreTemplate, times(1)).findAllById(keys, Object.class);
 	}
 
 	@Test
 	public void countTest() {
 		this.simpleDatastoreRepository.count();
-		verify(this.datastoreTemplate, times(1)).count(eq(Object.class));
+		verify(this.datastoreTemplate, times(1)).count(Object.class);
 	}
 
 	@Test
 	public void deleteByIdTest() {
 		String id = "key";
 		this.simpleDatastoreRepository.deleteById(id);
-		verify(this.datastoreTemplate, times(1)).deleteById(eq(id), eq(Object.class));
+		verify(this.datastoreTemplate, times(1)).deleteById(id, Object.class);
 	}
 
 	@Test
@@ -137,7 +137,7 @@ public class SimpleDatastoreRepositoryTests {
 	@Test
 	public void deleteAllClassTest() {
 		this.simpleDatastoreRepository.deleteAll();
-		verify(this.datastoreTemplate, times(1)).deleteAll(eq(Object.class));
+		verify(this.datastoreTemplate, times(1)).deleteAll(Object.class);
 	}
 
 	@Test
@@ -156,19 +156,19 @@ public class SimpleDatastoreRepositoryTests {
 	public void findAllPageableAsc() {
 		this.simpleDatastoreRepository.findAll(PageRequest.of(0, 5, Sort.Direction.ASC, "property1"));
 
-		verify(this.datastoreTemplate, times(1)).findAll(eq(Object.class),
-				eq(new DatastoreQueryOptions.Builder().setLimit(5).setOffset(0)
-						.setSort(Sort.by("property1")).build()));
+		verify(this.datastoreTemplate, times(1)).findAll(Object.class,
+				new DatastoreQueryOptions.Builder().setLimit(5).setOffset(0)
+						.setSort(Sort.by("property1")).build());
 		verify(this.datastoreTemplate, times(1)).count(any());
 	}
 
 	@Test
 	public void findAllPageableDesc() {
 		this.simpleDatastoreRepository.findAll(PageRequest.of(1, 5, Sort.Direction.DESC, "property1", "property2"));
-		verify(this.datastoreTemplate, times(1)).findAll(eq(Object.class),
-				eq(new DatastoreQueryOptions.Builder().setLimit(5).setOffset(5).setSort(Sort.by(
+		verify(this.datastoreTemplate, times(1)).findAll(Object.class,
+				new DatastoreQueryOptions.Builder().setLimit(5).setOffset(5).setSort(Sort.by(
 						new Sort.Order(Sort.Direction.DESC, "property1"),
-						new Sort.Order(Sort.Direction.DESC, "property2"))).setCursor(null).build()));
+						new Sort.Order(Sort.Direction.DESC, "property2"))).setCursor(null).build());
 		verify(this.datastoreTemplate, times(1)).count(any());
 	}
 
@@ -178,10 +178,10 @@ public class SimpleDatastoreRepositoryTests {
 		Pageable pageable = DatastorePageable.from(PageRequest.of(1, 5, Sort.Direction.DESC, "property1", "property2"),
 				cursor, 10L);
 		this.simpleDatastoreRepository.findAll(pageable);
-		verify(this.datastoreTemplate, times(1)).findAll(eq(Object.class),
-				eq(new DatastoreQueryOptions.Builder().setLimit(5).setOffset(5).setSort(Sort.by(
+		verify(this.datastoreTemplate, times(1)).findAll(Object.class,
+				new DatastoreQueryOptions.Builder().setLimit(5).setOffset(5).setSort(Sort.by(
 						new Sort.Order(Sort.Direction.DESC, "property1"),
-						new Sort.Order(Sort.Direction.DESC, "property2"))).setCursor(cursor).build()));
+						new Sort.Order(Sort.Direction.DESC, "property2"))).setCursor(cursor).build());
 		verify(this.datastoreTemplate, times(0)).count(any());
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
@@ -178,21 +178,21 @@ public class SpannerTemplateTests {
 			return transactionCallable.run(context);
 		});
 
-		when(context.executeUpdate(eq(DML))).thenReturn(333L);
+		when(context.executeUpdate(DML)).thenReturn(333L);
 
 		verifyBeforeAndAfterEvents(new BeforeExecuteDmlEvent(DML), new AfterExecuteDmlEvent(DML, 333L),
 				() -> this.spannerTemplate.executeDmlStatement(DML),
 				x -> {
 				});
-		verify(context, times(1)).executeUpdate(eq(DML));
+		verify(context, times(1)).executeUpdate(DML);
 	}
 
 	@Test
 	public void executePartitionedDmlTest() {
-		when(this.databaseClient.executePartitionedUpdate(eq(DML))).thenReturn(333L);
+		when(this.databaseClient.executePartitionedUpdate(DML)).thenReturn(333L);
 		verifyBeforeAndAfterEvents(new BeforeExecuteDmlEvent(DML), new AfterExecuteDmlEvent(DML, 333L),
 				() -> this.spannerTemplate.executePartitionedDmlStatement(DML),
-				x -> x.verify(this.databaseClient, times(1)).executePartitionedUpdate(eq(DML)));
+				x -> x.verify(this.databaseClient, times(1)).executePartitionedUpdate(DML));
 	}
 
 	@Test
@@ -221,7 +221,7 @@ public class SpannerTemplateTests {
 		assertThat(finalResult).isEqualTo("all done");
 		verify(transactionContext, times(1)).buffer((List<Mutation>) any());
 		verify(transactionContext, times(1)).read(eq("custom_test_table"), any(), any());
-		verify(transactionContext, times(1)).executeUpdate(eq(DML));
+		verify(transactionContext, times(1)).executeUpdate(DML);
 	}
 
 	@Test
@@ -238,7 +238,7 @@ public class SpannerTemplateTests {
 
 		verify(this.databaseClient, times(1)).singleUse();
 		verify(this.readContext, times(1))
-				.read(eq("custom_test_table"), eq(keySet), eq(Collections.singleton("id")));
+				.read("custom_test_table", keySet, Collections.singleton("id"));
 	}
 
 	@Test
@@ -255,7 +255,7 @@ public class SpannerTemplateTests {
 
 		verify(this.databaseClient, times(1)).singleUse();
 		verify(this.readContext, times(1))
-				.read(eq("test_table_embedded_pk"), eq(keySet), eq(Collections.singleton("stringId")));
+				.read("test_table_embedded_pk", keySet, Collections.singleton("stringId"));
 	}
 
 	@Test
@@ -263,7 +263,7 @@ public class SpannerTemplateTests {
 
 		ReadOnlyTransaction readOnlyTransaction = mock(ReadOnlyTransaction.class);
 		when(this.databaseClient.readOnlyTransaction(
-				eq(TimestampBound.ofMinReadTimestamp(Timestamp.ofTimeMicroseconds(333)))))
+				TimestampBound.ofMinReadTimestamp(Timestamp.ofTimeMicroseconds(333))))
 						.thenReturn(readOnlyTransaction);
 
 		String finalResult = this.spannerTemplate
@@ -287,7 +287,7 @@ public class SpannerTemplateTests {
 		ReadOnlyTransaction readOnlyTransaction = mock(ReadOnlyTransaction.class);
 		when(this.databaseClient.readOnlyTransaction(
 				// exact staleness is expected.
-				eq(TimestampBound.ofReadTimestamp(Timestamp.ofTimeMicroseconds(333)))))
+				TimestampBound.ofReadTimestamp(Timestamp.ofTimeMicroseconds(333))))
 						.thenReturn(readOnlyTransaction);
 
 		this.spannerTemplate
@@ -306,7 +306,7 @@ public class SpannerTemplateTests {
 
 		ReadOnlyTransaction readOnlyTransaction = mock(ReadOnlyTransaction.class);
 		when(this.databaseClient.readOnlyTransaction(
-				eq(TimestampBound.ofReadTimestamp(Timestamp.ofTimeMicroseconds(333)))))
+				TimestampBound.ofReadTimestamp(Timestamp.ofTimeMicroseconds(333))))
 						.thenReturn(readOnlyTransaction);
 
 		this.spannerTemplate
@@ -411,7 +411,7 @@ public class SpannerTemplateTests {
 		ResultSet resultSet = mock(ResultSet.class);
 		when(resultSet.next()).thenReturn(false);
 		Statement query = Statement.of("test");
-		when(this.readContext.executeQuery(eq(query))).thenReturn(resultSet);
+		when(this.readContext.executeQuery(query)).thenReturn(resultSet);
 		verifyAfterEvents(new AfterQueryEvent(Collections.emptyList(), query, null),
 				() -> assertThat(this.spannerTemplate.query(x -> null, query, null)).isEmpty(), x -> {
 				});
@@ -421,8 +421,7 @@ public class SpannerTemplateTests {
 	public void findSingleKeyTest() {
 		SpannerTemplate spyTemplate = spy(this.spannerTemplate);
 		spyTemplate.read(TestEntity.class, Key.of("key"));
-		verify(spyTemplate, times(1)).read(eq(TestEntity.class), eq(Key.of("key")),
-				eq(null));
+		verify(spyTemplate, times(1)).read(TestEntity.class, Key.of("key"), null);
 		verify(this.databaseClient, times(1)).singleUse();
 	}
 
@@ -485,7 +484,7 @@ public class SpannerTemplateTests {
 				.setTimestampBound(TimestampBound.ofMinReadTimestamp(Timestamp.ofTimeMicroseconds(333L)));
 		KeySet keySet = KeySet.singleKey(Key.of("key"));
 		when(this.readContext.read(any(), any(), any(), any())).thenReturn(results);
-		when(this.databaseClient.singleUse(eq(TimestampBound.ofMinReadTimestamp(Timestamp.ofTimeMicroseconds(333L)))))
+		when(this.databaseClient.singleUse(TimestampBound.ofMinReadTimestamp(Timestamp.ofTimeMicroseconds(333L))))
 				.thenReturn(this.readContext);
 
 		verifyAfterEvents(new AfterReadEvent(Collections.emptyList(), keySet, options),
@@ -537,7 +536,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), null),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), null),
 				() -> this.spannerTemplate.insert(entity), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(mutations)));
+						.write(mutations));
 	}
 
 	@Test
@@ -553,7 +552,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeSaveEvent(entities, null),
 				new AfterSaveEvent(mutations, entities, null),
 				() -> this.spannerTemplate.insertAll(entities), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(mutations)));
+						.write(mutations));
 	}
 
 	@Test
@@ -567,7 +566,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), null),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), null),
 				() -> this.spannerTemplate.update(entity), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(mutations)));
+						.write(mutations));
 	}
 
 	@Test
@@ -583,7 +582,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeSaveEvent(entities, null),
 				new AfterSaveEvent(mutations, entities, null),
 				() -> this.spannerTemplate.updateAll(entities), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(mutations)));
+						.write(mutations));
 	}
 
 	@Test
@@ -600,7 +599,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), cols),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), cols),
 				() -> this.spannerTemplate.update(entity, "a", "b"), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(mutations)));
+						.write(mutations));
 	}
 
 	@Test
@@ -616,7 +615,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), cols),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), cols),
 				() -> this.spannerTemplate.update(entity, cols), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(mutations)));
+						.write(mutations));
 	}
 
 	@Test
@@ -631,7 +630,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), null),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), null),
 				() -> this.spannerTemplate.upsert(entity), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(mutations)));
+						.write(mutations));
 	}
 
 	@Test
@@ -647,7 +646,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeSaveEvent(entities, null),
 				new AfterSaveEvent(mutations, entities, null),
 				() -> this.spannerTemplate.upsertAll(entities), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(mutations)));
+						.write(mutations));
 	}
 
 	@Test
@@ -664,7 +663,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), cols),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), cols),
 				() -> this.spannerTemplate.upsert(entity, "a", "b"), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(mutations)));
+						.write(mutations));
 	}
 
 	@Test
@@ -680,7 +679,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeSaveEvent(Collections.singletonList(entity), cols),
 				new AfterSaveEvent(mutations, Collections.singletonList(entity), cols),
 				() -> this.spannerTemplate.upsert(entity, cols), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(mutations)));
+						.write(mutations));
 	}
 
 	@Test
@@ -695,7 +694,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeDeleteEvent(mutations, null, keys, TestEntity.class),
 				new AfterDeleteEvent(mutations, null, keys, TestEntity.class),
 				() -> this.spannerTemplate.delete(TestEntity.class, key), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(Collections.singletonList(mutation))));
+						.write(Collections.singletonList(mutation)));
 	}
 
 	@Test
@@ -708,7 +707,7 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeDeleteEvent(mutations, Collections.singletonList(entity), null, null),
 				new AfterDeleteEvent(mutations, Collections.singletonList(entity), null, null),
 				() -> this.spannerTemplate.delete(entity), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(Collections.singletonList(mutation))));
+						.write(Collections.singletonList(mutation)));
 	}
 
 	@Test
@@ -723,7 +722,7 @@ public class SpannerTemplateTests {
 				new AfterDeleteEvent(mutations, entities, null, null),
 				() -> this.spannerTemplate.deleteAll(Arrays.asList(entity, entity, entity)),
 				x -> x.verify(this.databaseClient, times(1))
-						.write(eq(mutations)));
+						.write(mutations));
 	}
 
 	@Test
@@ -738,18 +737,17 @@ public class SpannerTemplateTests {
 		verifyBeforeAndAfterEvents(new BeforeDeleteEvent(mutations, null, keys, TestEntity.class),
 				new AfterDeleteEvent(mutations, null, keys, TestEntity.class),
 				() -> this.spannerTemplate.delete(TestEntity.class, keys), x -> x.verify(this.databaseClient, times(1))
-						.write(eq(Collections.singletonList(mutation))));
+						.write(Collections.singletonList(mutation)));
 	}
 
 	@Test
 	public void countTest() {
 		ResultSet results = mock(ResultSet.class);
-		when(this.readContext
-				.executeQuery(eq(Statement.of("SELECT COUNT(*) FROM custom_test_table"))))
-						.thenReturn(results);
+		when(this.readContext.executeQuery(Statement.of("SELECT COUNT(*) FROM custom_test_table")))
+				.thenReturn(results);
 		this.spannerTemplate.count(TestEntity.class);
 		verify(results, times(1)).next();
-		verify(results, times(1)).getLong(eq(0));
+		verify(results, times(1)).getLong(0);
 		verify(results, times(1)).close();
 	}
 
@@ -759,7 +757,7 @@ public class SpannerTemplateTests {
 		Sort sort = mock(Sort.class);
 		Pageable pageable = mock(Pageable.class);
 
-		when(this.databaseClient.singleUse(eq(TimestampBound.ofMinReadTimestamp(Timestamp.ofTimeMicroseconds(333L)))))
+		when(this.databaseClient.singleUse(TimestampBound.ofMinReadTimestamp(Timestamp.ofTimeMicroseconds(333L))))
 				.thenReturn(this.readContext);
 
 		long offset = 5L;
@@ -785,8 +783,7 @@ public class SpannerTemplateTests {
 		items.add(t2);
 		items.add(t3);
 
-		doReturn(items).when(spyTemplate).queryAll(eq(TestEntity.class),
-				same(queryOption));
+		doReturn(items).when(spyTemplate).queryAll(eq(TestEntity.class), same(queryOption));
 
 		List results = spyTemplate.queryAll(TestEntity.class,
 				queryOption.setSort(pageable.getSort()));
@@ -888,11 +885,11 @@ public class SpannerTemplateTests {
 
 		operation.run();
 		if (expectedBefore != null) {
-			inOrder.verify(mockBeforePublisher, times(1)).publishEvent(eq(expectedBefore));
+			inOrder.verify(mockBeforePublisher, times(1)).publishEvent(expectedBefore);
 		}
 		verifyOperation.accept(inOrder);
 		if (expectedAfter != null) {
-			inOrder.verify(mockAfterPublisher, times(1)).publishEvent(eq(expectedAfter));
+			inOrder.verify(mockAfterPublisher, times(1)).publishEvent(expectedAfter);
 		}
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTransactionManagerTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTransactionManagerTests.java
@@ -173,7 +173,7 @@ public class SpannerTemplateTransactionManagerTests {
 						Mockito.any());
 		verify(this.transactionContext, times(1)).buffer(Arrays.asList(DELETE_MUTATION));
 		verify(this.transactionContext, times(1)).buffer(UPSERT_MUTATION);
-		verify(this.transactionContext, times(1)).executeUpdate(eq(DML_STATEMENT));
+		verify(this.transactionContext, times(1)).executeUpdate(DML_STATEMENT);
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
@@ -56,7 +56,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -157,136 +156,136 @@ public class ConverterAwareMappingSpannerEntityWriterTests {
 
 		ValueBinder<WriteBuilder> idBinder = mock(ValueBinder.class);
 		when(idBinder.to(anyString())).thenReturn(null);
-		when(writeBuilder.set(eq("id"))).thenReturn(idBinder);
+		when(writeBuilder.set("id")).thenReturn(idBinder);
 
 		ValueBinder<WriteBuilder> id2Binder = mock(ValueBinder.class);
 		when(id2Binder.to(anyString())).thenReturn(null);
-		when(writeBuilder.set(eq("id2"))).thenReturn(id2Binder);
+		when(writeBuilder.set("id2")).thenReturn(id2Binder);
 
 		ValueBinder<WriteBuilder> id3Binder = mock(ValueBinder.class);
 		when(id3Binder.to(anyString())).thenReturn(null);
-		when(writeBuilder.set(eq("id3"))).thenReturn(id3Binder);
+		when(writeBuilder.set("id3")).thenReturn(id3Binder);
 
 		ValueBinder<WriteBuilder> id4Binder = mock(ValueBinder.class);
 		when(id4Binder.to(anyString())).thenReturn(null);
-		when(writeBuilder.set(eq("id4"))).thenReturn(id4Binder);
+		when(writeBuilder.set("id4")).thenReturn(id4Binder);
 
 		ValueBinder<WriteBuilder> stringFieldBinder = mock(ValueBinder.class);
 		when(stringFieldBinder.to(anyString())).thenReturn(null);
-		when(writeBuilder.set(eq("custom_col"))).thenReturn(stringFieldBinder);
+		when(writeBuilder.set("custom_col")).thenReturn(stringFieldBinder);
 
 		ValueBinder<WriteBuilder> booleanFieldBinder = mock(ValueBinder.class);
 		when(booleanFieldBinder.to((Boolean) any())).thenReturn(null);
-		when(writeBuilder.set(eq("booleanField"))).thenReturn(booleanFieldBinder);
+		when(writeBuilder.set("booleanField")).thenReturn(booleanFieldBinder);
 
 		ValueBinder<WriteBuilder> intFieldBinder = mock(ValueBinder.class);
 		when(intFieldBinder.to(anyLong())).thenReturn(null);
-		when(writeBuilder.set(eq("intField"))).thenReturn(intFieldBinder);
+		when(writeBuilder.set("intField")).thenReturn(intFieldBinder);
 
 		ValueBinder<WriteBuilder> intField2Binder = mock(ValueBinder.class);
 		when(intField2Binder.to(anyLong())).thenReturn(null);
-		when(writeBuilder.set(eq("intField2"))).thenReturn(intField2Binder);
+		when(writeBuilder.set("intField2")).thenReturn(intField2Binder);
 
 		ValueBinder<WriteBuilder> longFieldBinder = mock(ValueBinder.class);
 		when(longFieldBinder.to(anyString())).thenReturn(null);
-		when(writeBuilder.set(eq("longField"))).thenReturn(longFieldBinder);
+		when(writeBuilder.set("longField")).thenReturn(longFieldBinder);
 
 		ValueBinder<WriteBuilder> doubleFieldBinder = mock(ValueBinder.class);
 		when(doubleFieldBinder.to(anyDouble())).thenReturn(null);
-		when(writeBuilder.set(eq("doubleField"))).thenReturn(doubleFieldBinder);
+		when(writeBuilder.set("doubleField")).thenReturn(doubleFieldBinder);
 
 		ValueBinder<WriteBuilder> doubleArrayFieldBinder = mock(ValueBinder.class);
 		when(doubleArrayFieldBinder.toStringArray(any())).thenReturn(null);
-		when(writeBuilder.set(eq("doubleArray"))).thenReturn(doubleArrayFieldBinder);
+		when(writeBuilder.set("doubleArray")).thenReturn(doubleArrayFieldBinder);
 
 		ValueBinder<WriteBuilder> doubleListFieldBinder = mock(ValueBinder.class);
 		when(doubleListFieldBinder.toFloat64Array((Iterable<Double>) any()))
 				.thenReturn(null);
-		when(writeBuilder.set(eq("doubleList"))).thenReturn(doubleListFieldBinder);
+		when(writeBuilder.set("doubleList")).thenReturn(doubleListFieldBinder);
 
 		ValueBinder<WriteBuilder> stringListFieldBinder = mock(ValueBinder.class);
 		when(stringListFieldBinder.toStringArray(any())).thenReturn(null);
-		when(writeBuilder.set(eq("stringList"))).thenReturn(stringListFieldBinder);
+		when(writeBuilder.set("stringList")).thenReturn(stringListFieldBinder);
 
 		ValueBinder<WriteBuilder> booleanListFieldBinder = mock(ValueBinder.class);
 		when(booleanListFieldBinder.toBoolArray((Iterable<Boolean>) any()))
 				.thenReturn(null);
-		when(writeBuilder.set(eq("booleanList"))).thenReturn(booleanListFieldBinder);
+		when(writeBuilder.set("booleanList")).thenReturn(booleanListFieldBinder);
 
 		ValueBinder<WriteBuilder> longListFieldBinder = mock(ValueBinder.class);
 		when(longListFieldBinder.toStringArray(any())).thenReturn(null);
-		when(writeBuilder.set(eq("longList"))).thenReturn(longListFieldBinder);
+		when(writeBuilder.set("longList")).thenReturn(longListFieldBinder);
 
 		ValueBinder<WriteBuilder> timestampListFieldBinder = mock(ValueBinder.class);
 		when(timestampListFieldBinder.toTimestampArray(any())).thenReturn(null);
-		when(writeBuilder.set(eq("timestampList"))).thenReturn(timestampListFieldBinder);
+		when(writeBuilder.set("timestampList")).thenReturn(timestampListFieldBinder);
 
 		ValueBinder<WriteBuilder> dateListFieldBinder = mock(ValueBinder.class);
 		when(dateListFieldBinder.toDateArray(any())).thenReturn(null);
-		when(writeBuilder.set(eq("dateList"))).thenReturn(dateListFieldBinder);
+		when(writeBuilder.set("dateList")).thenReturn(dateListFieldBinder);
 
 		ValueBinder<WriteBuilder> instantListFieldBinder = mock(ValueBinder.class);
 		when(instantListFieldBinder.toTimestampArray(any())).thenReturn(null);
-		when(writeBuilder.set(eq("momentsInTime"))).thenReturn(instantListFieldBinder);
+		when(writeBuilder.set("momentsInTime")).thenReturn(instantListFieldBinder);
 
 		ValueBinder<WriteBuilder> bytesListFieldBinder = mock(ValueBinder.class);
 		when(bytesListFieldBinder.toDateArray(any())).thenReturn(null);
-		when(writeBuilder.set(eq("bytesList"))).thenReturn(bytesListFieldBinder);
+		when(writeBuilder.set("bytesList")).thenReturn(bytesListFieldBinder);
 
 		ValueBinder<WriteBuilder> dateFieldBinder = mock(ValueBinder.class);
 		when(dateFieldBinder.to((Date) any())).thenReturn(null);
-		when(writeBuilder.set(eq("dateField"))).thenReturn(dateFieldBinder);
+		when(writeBuilder.set("dateField")).thenReturn(dateFieldBinder);
 
 		ValueBinder<WriteBuilder> timestampFieldBinder = mock(ValueBinder.class);
 		when(timestampFieldBinder.to((Timestamp) any())).thenReturn(null);
-		when(writeBuilder.set(eq("timestampField"))).thenReturn(timestampFieldBinder);
+		when(writeBuilder.set("timestampField")).thenReturn(timestampFieldBinder);
 
 		ValueBinder<WriteBuilder> bytesFieldBinder = mock(ValueBinder.class);
 		when(bytesFieldBinder.to((ByteArray) any())).thenReturn(null);
-		when(writeBuilder.set(eq("bytes"))).thenReturn(bytesFieldBinder);
+		when(writeBuilder.set("bytes")).thenReturn(bytesFieldBinder);
 
 		ValueBinder<WriteBuilder> commitTimestampBinder = mock(ValueBinder.class);
 		when(commitTimestampBinder.to((Timestamp) any())).thenReturn(null);
-		when(writeBuilder.set(eq("commitTimestamp"))).thenReturn(commitTimestampBinder);
+		when(writeBuilder.set("commitTimestamp")).thenReturn(commitTimestampBinder);
 
 		ValueBinder<WriteBuilder> bigDecimalFieldBinder = mock(ValueBinder.class);
 		when(bigDecimalFieldBinder.to((BigDecimal) any())).thenReturn(null);
-		when(writeBuilder.set(eq("bigDecimalField"))).thenReturn(bigDecimalFieldBinder);
+		when(writeBuilder.set("bigDecimalField")).thenReturn(bigDecimalFieldBinder);
 
 		ValueBinder<WriteBuilder> bigDecimalsBinder = mock(ValueBinder.class);
 		when(bigDecimalsBinder.toNumericArray(any())).thenReturn(null);
-		when(writeBuilder.set(eq("bigDecimals"))).thenReturn(bigDecimalsBinder);
+		when(writeBuilder.set("bigDecimals")).thenReturn(bigDecimalsBinder);
 
 		this.spannerEntityWriter.write(t, writeBuilder::set);
 
-		verify(idBinder, times(1)).to(eq(t.id));
-		verify(id2Binder, times(1)).to(eq(t.testEmbeddedColumns.id2));
-		verify(id3Binder, times(1)).to(eq(t.testEmbeddedColumns.id3));
-		verify(stringFieldBinder, times(1)).to(eq(t.enumField.toString()));
-		verify(booleanFieldBinder, times(1)).to(eq(Boolean.valueOf(t.booleanField)));
-		verify(intFieldBinder, times(1)).to(eq(Long.valueOf(t.intField)));
-		verify(intField2Binder, times(1)).to(eq(Long.valueOf(t.testEmbeddedColumns.intField2)));
-		verify(longFieldBinder, times(1)).to(eq(String.valueOf(t.longField)));
-		verify(doubleFieldBinder, times(1)).to(eq(Double.valueOf(t.doubleField)));
+		verify(idBinder, times(1)).to(t.id);
+		verify(id2Binder, times(1)).to(t.testEmbeddedColumns.id2);
+		verify(id3Binder, times(1)).to(t.testEmbeddedColumns.id3);
+		verify(stringFieldBinder, times(1)).to(t.enumField.toString());
+		verify(booleanFieldBinder, times(1)).to(Boolean.valueOf(t.booleanField));
+		verify(intFieldBinder, times(1)).to(Long.valueOf(t.intField));
+		verify(intField2Binder, times(1)).to(Long.valueOf(t.testEmbeddedColumns.intField2));
+		verify(longFieldBinder, times(1)).to(String.valueOf(t.longField));
+		verify(doubleFieldBinder, times(1)).to(Double.valueOf(t.doubleField));
 		verify(doubleArrayFieldBinder, times(1)).to("3.33,3.33,3.33");
-		verify(doubleListFieldBinder, times(1)).toFloat64Array(eq(t.doubleList));
-		verify(stringListFieldBinder, times(1)).toStringArray(eq(t.stringList));
-		verify(booleanListFieldBinder, times(1)).toBoolArray(eq(t.booleanList));
+		verify(doubleListFieldBinder, times(1)).toFloat64Array(t.doubleList);
+		verify(stringListFieldBinder, times(1)).toStringArray(t.stringList);
+		verify(booleanListFieldBinder, times(1)).toBoolArray(t.booleanList);
 		verify(longListFieldBinder, times(1)).toStringArray(any());
-		verify(timestampListFieldBinder, times(1)).toTimestampArray(eq(t.timestampList));
-		verify(dateListFieldBinder, times(1)).toDateArray(eq(t.dateList));
-		verify(bytesListFieldBinder, times(1)).toBytesArray(eq(t.bytesList));
-		verify(dateFieldBinder, times(1)).to(eq(t.dateField));
-		verify(timestampFieldBinder, times(1)).to(eq(t.timestampField));
-		verify(bytesFieldBinder, times(1)).to(eq(t.bytes));
-		verify(instantListFieldBinder, times(1)).toTimestampArray(eq(timestamps));
+		verify(timestampListFieldBinder, times(1)).toTimestampArray(t.timestampList);
+		verify(dateListFieldBinder, times(1)).toDateArray(t.dateList);
+		verify(bytesListFieldBinder, times(1)).toBytesArray(t.bytesList);
+		verify(dateFieldBinder, times(1)).to(t.dateField);
+		verify(timestampFieldBinder, times(1)).to(t.timestampField);
+		verify(bytesFieldBinder, times(1)).to(t.bytes);
+		verify(instantListFieldBinder, times(1)).toTimestampArray(timestamps);
 
 		// the positive value set earlier must not be passed to Spanner. it must be replaced by
 		// the dummy value.
-		verify(commitTimestampBinder, times(1)).to(eq(Value.COMMIT_TIMESTAMP));
+		verify(commitTimestampBinder, times(1)).to(Value.COMMIT_TIMESTAMP);
 
-		verify(bigDecimalFieldBinder, times(1)).to(eq(t.bigDecimalField));
-		verify(bigDecimalsBinder, times(1)).toNumericArray(eq(t.bigDecimals));
+		verify(bigDecimalFieldBinder, times(1)).to(t.bigDecimalField);
+		verify(bigDecimalsBinder, times(1)).toNumericArray(t.bigDecimals);
 
 	}
 
@@ -301,12 +300,12 @@ public class ConverterAwareMappingSpannerEntityWriterTests {
 
 		ValueBinder<WriteBuilder> dateFieldBinder = mock(ValueBinder.class);
 		when(dateFieldBinder.to((Date) any())).thenReturn(null);
-		when(writeBuilder.set(eq("dateField"))).thenReturn(dateFieldBinder);
+		when(writeBuilder.set("dateField")).thenReturn(dateFieldBinder);
 
 		ValueBinder<WriteBuilder> doubleListFieldBinder = mock(ValueBinder.class);
 		when(doubleListFieldBinder.toFloat64Array((Iterable<Double>) any()))
 				.thenReturn(null);
-		when(writeBuilder.set(eq("doubleList"))).thenReturn(doubleListFieldBinder);
+		when(writeBuilder.set("doubleList")).thenReturn(doubleListFieldBinder);
 
 		this.spannerEntityWriter.write(t, writeBuilder::set,
 				Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("dateField", "doubleList"))));
@@ -326,21 +325,21 @@ public class ConverterAwareMappingSpannerEntityWriterTests {
 
 		ValueBinder<WriteBuilder> idBinder = mock(ValueBinder.class);
 		when(idBinder.to(anyString())).thenReturn(null);
-		when(writeBuilder.set(eq("id"))).thenReturn(idBinder);
+		when(writeBuilder.set("id")).thenReturn(idBinder);
 
 		ValueBinder<WriteBuilder> stringFieldBinder = mock(ValueBinder.class);
 		when(stringFieldBinder.to(anyString())).thenReturn(null);
-		when(writeBuilder.set(eq("custom_col"))).thenReturn(stringFieldBinder);
+		when(writeBuilder.set("custom_col")).thenReturn(stringFieldBinder);
 
 		ValueBinder<WriteBuilder> booleanFieldBinder = mock(ValueBinder.class);
 		when(booleanFieldBinder.to((Boolean) any())).thenReturn(null);
-		when(writeBuilder.set(eq("booleanField"))).thenReturn(booleanFieldBinder);
+		when(writeBuilder.set("booleanField")).thenReturn(booleanFieldBinder);
 
 		this.spannerEntityWriter.write(t, writeBuilder::set,
 				new HashSet<>(Arrays.asList("id", "custom_col")));
 
-		verify(idBinder, times(1)).to(eq(t.id));
-		verify(stringFieldBinder, times(1)).to(eq(t.enumField.toString()));
+		verify(idBinder, times(1)).to(t.id);
+		verify(stringFieldBinder, times(1)).to(t.enumField.toString());
 		verifyNoInteractions(booleanFieldBinder);
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerMappingContextTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerMappingContextTests.java
@@ -27,7 +27,6 @@ import org.springframework.data.util.TypeInformation;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -67,7 +66,7 @@ public class SpannerMappingContextTests {
 
 		context.createPersistentEntity(ClassTypeInformation.from(Object.class));
 
-		verify(mockEntity, times(1)).setApplicationContext(eq(applicationContext));
+		verify(mockEntity, times(1)).setApplicationContext(applicationContext);
 	}
 
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
@@ -124,8 +124,8 @@ public class SpannerQueryLookupStrategyTests {
 			return param;
 		});
 
-		when(namedQueries.hasQuery(eq(queryName))).thenReturn(true);
-		when(namedQueries.getQuery(eq(queryName))).thenReturn(query);
+		when(namedQueries.hasQuery(queryName)).thenReturn(true);
+		when(namedQueries.getQuery(queryName)).thenReturn(query);
 
 		this.spannerQueryLookupStrategy.resolveQuery(null, null, null, namedQueries);
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryImplTests.java
@@ -149,7 +149,7 @@ public class SpannerRepositoryImplTests {
 	public void saveTest() {
 		Object ob = new Object();
 		assertThat(new SimpleSpannerRepository<Object, Key>(this.template, Object.class).save(ob)).isEqualTo(ob);
-		verify(this.template, times(1)).upsert(eq(ob));
+		verify(this.template, times(1)).upsert(ob);
 	}
 
 	@Test
@@ -160,16 +160,16 @@ public class SpannerRepositoryImplTests {
 				Object.class)
 				.saveAll(Arrays.asList(ob, ob2));
 		assertThat(ret).containsExactlyInAnyOrder(ob, ob2);
-		verify(this.template, times(1)).upsertAll(eq(Arrays.asList(ob, ob2)));
+		verify(this.template, times(1)).upsertAll(Arrays.asList(ob, ob2));
 	}
 
 	@Test
 	public void findByIdTest() {
 		Object ret = new Object();
-		when(this.entityProcessor.convertToKey(eq(A_KEY))).thenReturn(A_KEY);
-		when(this.template.read(eq(Object.class), eq(A_KEY))).thenReturn(ret);
+		when(this.entityProcessor.convertToKey(A_KEY)).thenReturn(A_KEY);
+		when(this.template.read(Object.class, A_KEY)).thenReturn(ret);
 		assertThat(new SimpleSpannerRepository<Object, Key>(this.template, Object.class).findById(A_KEY)).contains(ret);
-		verify(this.template, times(1)).read(eq(Object.class), eq(A_KEY));
+		verify(this.template, times(1)).read(Object.class, A_KEY);
 	}
 
 	@Test
@@ -182,23 +182,23 @@ public class SpannerRepositoryImplTests {
 
 	@Test
 	public void existsByIdTestFound() {
-		when(this.entityProcessor.convertToKey(eq(A_KEY))).thenReturn(A_KEY);
-		when(this.template.existsById(eq(Object.class), eq(A_KEY))).thenReturn(true);
+		when(this.entityProcessor.convertToKey(A_KEY)).thenReturn(A_KEY);
+		when(this.template.existsById(Object.class, A_KEY)).thenReturn(true);
 		assertThat(new SimpleSpannerRepository<Object, Key>(this.template, Object.class)
 				.existsById(A_KEY)).isTrue();
 	}
 
 	@Test
 	public void existsByIdTestNotFound() {
-		when(this.entityProcessor.convertToKey(eq(A_KEY))).thenReturn(A_KEY);
-		when(this.template.existsById(eq(Object.class), eq(A_KEY))).thenReturn(false);
+		when(this.entityProcessor.convertToKey(A_KEY)).thenReturn(A_KEY);
+		when(this.template.existsById(Object.class, A_KEY)).thenReturn(false);
 		assertThat(new SimpleSpannerRepository<Object, Key>(this.template, Object.class).existsById(A_KEY)).isFalse();
 	}
 
 	@Test
 	public void findAllTest() {
 		new SimpleSpannerRepository<Object, Key>(this.template, Object.class).findAll();
-		verify(this.template, times(1)).readAll(eq(Object.class));
+		verify(this.template, times(1)).readAll(Object.class);
 	}
 
 	@Test
@@ -237,8 +237,8 @@ public class SpannerRepositoryImplTests {
 	public void findAllByIdTest() {
 		List<Key> unconvertedKey = Arrays.asList(Key.of("key1"), Key.of("key2"));
 
-		when(this.entityProcessor.convertToKey(eq(Key.of("key1")))).thenReturn(Key.of("key1"));
-		when(this.entityProcessor.convertToKey(eq(Key.of("key2")))).thenReturn(Key.of("key2"));
+		when(this.entityProcessor.convertToKey(Key.of("key1"))).thenReturn(Key.of("key1"));
+		when(this.entityProcessor.convertToKey(Key.of("key2"))).thenReturn(Key.of("key2"));
 		when(this.template.read(eq(Object.class), (KeySet) any())).thenAnswer((invocation) -> {
 			KeySet keys = invocation.getArgument(1);
 			assertThat(keys.getKeys()).containsExactlyInAnyOrder(Key.of("key2"), Key.of("key1"));
@@ -252,29 +252,29 @@ public class SpannerRepositoryImplTests {
 	@Test
 	public void countTest() {
 		new SimpleSpannerRepository<Object, Key>(this.template, Object.class).count();
-		verify(this.template, times(1)).count(eq(Object.class));
+		verify(this.template, times(1)).count(Object.class);
 	}
 
 	@Test
 	public void deleteByIdTest() {
-		when(this.entityProcessor.convertToKey(eq(A_KEY))).thenReturn(A_KEY);
+		when(this.entityProcessor.convertToKey(A_KEY)).thenReturn(A_KEY);
 		new SimpleSpannerRepository<Object, Key>(this.template, Object.class)
 				.deleteById(A_KEY);
-		verify(this.template, times(1)).delete(eq(Object.class), eq(A_KEY));
-		verify(this.template, times(1)).delete(eq(Object.class), eq(A_KEY));
+		verify(this.template, times(1)).delete(Object.class, A_KEY);
+		verify(this.template, times(1)).delete(Object.class, A_KEY);
 	}
 
 	@Test
 	public void deleteTest() {
 		Object ob = new Object();
 		new SimpleSpannerRepository<Object, Key>(this.template, Object.class).delete(ob);
-		verify(this.template, times(1)).delete(eq(ob));
+		verify(this.template, times(1)).delete(ob);
 	}
 
 	@Test
 	public void deleteAllTest() {
 		new SimpleSpannerRepository<Object, Key>(this.template, Object.class).deleteAll();
-		verify(this.template, times(1)).delete(eq(Object.class), eq(KeySet.all()));
+		verify(this.template, times(1)).delete(Object.class, KeySet.all());
 	}
 
 	@Test

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -198,7 +198,7 @@ public class PubSubChannelProvisionerTests {
 	@Test
 	public void testProvisionConsumerDestination_concurrentTopicCreation() {
 		when(this.pubSubAdminMock.createTopic(any())).thenThrow(AlreadyExistsException.class);
-		when(this.pubSubAdminMock.getTopic(eq("already_existing_topic"))).thenReturn(null);
+		when(this.pubSubAdminMock.getTopic("already_existing_topic")).thenReturn(null);
 
 		// Ensure no exceptions occur if topic already exists on create call
 		assertThat(this.pubSubChannelProvisioner

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -125,8 +125,7 @@ public class PubSubMessageHandlerTests {
 		this.adapter.setPublishTimeoutExpression(timeout);
 
 		this.adapter.handleMessage(this.message);
-		verify(timeout, times(1)).getValue(
-				isNull(), eq(this.message), eq(Long.class));
+		verify(timeout, times(1)).getValue(isNull(), eq(this.message), eq(Long.class));
 	}
 
 	@Test
@@ -149,7 +148,7 @@ public class PubSubMessageHandlerTests {
 
 		assertThat(this.adapter.getPublishCallback()).isSameAs(callbackSpy);
 
-		verify(callbackSpy, times(1)).onSuccess(eq("benfica"));
+		verify(callbackSpy, times(1)).onSuccess("benfica");
 	}
 
 	@Test

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageTests.java
@@ -103,7 +103,7 @@ public class GoogleStorageTests {
 		BlobId validBlobId = BlobId.of("test-spring", "images/spring.png");
 		Blob mockedBlob = mock(Blob.class);
 		when(mockedBlob.getSize()).thenReturn(4096L);
-		when(this.mockStorage.get(eq(validBlobId))).thenReturn(mockedBlob);
+		when(this.mockStorage.get(validBlobId)).thenReturn(mockedBlob);
 
 		Assert.assertTrue(this.remoteResource.exists());
 		Assert.assertEquals(4096L, this.remoteResource.contentLength());
@@ -113,7 +113,7 @@ public class GoogleStorageTests {
 	public void testValidObjectWithUnderscore() throws Exception {
 		BlobId validBlobWithUnderscore = BlobId.of("test_spring", "images/spring.png");
 		Blob mockedBlob = mock(Blob.class);
-		when(mockStorage.get(eq(validBlobWithUnderscore))).thenReturn(mockedBlob);
+		when(mockStorage.get(validBlobWithUnderscore)).thenReturn(mockedBlob);
 
 		Assert.assertTrue(this.remoteResourceWithUnderscore.exists());
 	}
@@ -162,7 +162,7 @@ public class GoogleStorageTests {
 	public void testSpecifyPathCorrect() {
 		BlobId validBlobId = BlobId.of("test-spring", "images/spring.png");
 		Blob mockedBlob = mock(Blob.class);
-		when(this.mockStorage.get(eq(validBlobId))).thenReturn(mockedBlob);
+		when(this.mockStorage.get(validBlobId)).thenReturn(mockedBlob);
 
 		GoogleStorageResource googleStorageResource = new GoogleStorageResource(
 				this.mockStorage, "gs://test-spring/images/spring.png", false);

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/outbound/GcsMessageHandlerTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/outbound/GcsMessageHandlerTests.java
@@ -47,7 +47,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
@@ -84,7 +83,7 @@ public class GcsMessageHandlerTests {
 				BlobInfo.newBuilder(BlobId.of("testGcsBucket", "benfica.writing")).build();
 		WriteChannel writeChannel = mock(WriteChannel.class);
 		willAnswer((invocationOnMock) -> writeChannel).given(GCS)
-				.writer(eq(expectedCreateBlobInfo));
+				.writer(expectedCreateBlobInfo);
 		willAnswer((invocationOnMock) -> 10).given(writeChannel).write(isA(ByteBuffer.class));
 
 		CopyWriter copyWriter = mock(CopyWriter.class);
@@ -92,13 +91,13 @@ public class GcsMessageHandlerTests {
 		willAnswer((invocationOnMock) -> copyWriter).given(GCS).copy(isA(Storage.CopyRequest.class));
 
 		willAnswer((invocationOnMock) -> true).given(GCS)
-				.delete(eq(BlobId.of("testGcsBucket", "benfica.writing")));
+				.delete(BlobId.of("testGcsBucket", "benfica.writing"));
 
 		this.channel.send(new GenericMessage<Object>(testFile));
 
-		verify(GCS, times(1)).writer(eq(expectedCreateBlobInfo));
+		verify(GCS, times(1)).writer(expectedCreateBlobInfo);
 		verify(GCS, times(1)).copy(copyRequestCaptor.capture());
-		verify(GCS, times(1)).delete(eq(BlobId.of("testGcsBucket", "benfica.writing")));
+		verify(GCS, times(1)).delete(BlobId.of("testGcsBucket", "benfica.writing"));
 
 		Storage.CopyRequest expectedCopyRequest = copyRequestCaptor.getValue();
 		assertThat(expectedCopyRequest.getSource()).isEqualTo(BlobId.of("testGcsBucket", "benfica.writing"));


### PR DESCRIPTION
Not sure I got all of them, but I got a big chunk of them.

[Call to Mockito method "verify", "when" or "given" should be simplified](https://sonarcloud.io/organizations/googlecloudplatform/rules?open=java%3AS6068&rule_key=java%3AS6068)