### PR TITLE
Remove extra parentheses around single arg lambdas

### DIFF
--- a/docs/src/main/asciidoc/spring-stream.adoc
+++ b/docs/src/main/asciidoc/spring-stream.adoc
@@ -185,7 +185,7 @@ public class SinkExample {
         return args -> {
             // This will poll only once.
             // Add a loop or a scheduler to get more messages.
-            destIn.poll((message) -> System.out.println("Message retrieved: " + message));
+            destIn.poll(message -> System.out.println("Message retrieved: " + message));
         };
     }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/config/GoogleConfigPropertySourceLocator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/config/GoogleConfigPropertySourceLocator.java
@@ -103,7 +103,7 @@ public class GoogleConfigPropertySourceLocator implements PropertySourceLocator 
 		Map<String, List<String>> credentialHeaders = this.credentials.getRequestMetadata();
 		Assert.notNull(credentialHeaders, "No valid credential header(s) found");
 
-		credentialHeaders.forEach((key, values) -> values.forEach((value) -> headers.add(key, value)));
+		credentialHeaders.forEach((key, values) -> values.forEach(value -> headers.add(key, value)));
 
 		Assert.isTrue(headers.containsKey(AUTHORIZATION_HEADER), "Authorization header required");
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/core/environment/OnGcpEnvironmentCondition.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/core/environment/OnGcpEnvironmentCondition.java
@@ -63,7 +63,7 @@ public class OnGcpEnvironmentCondition extends SpringBootCondition {
 		Assert.notNull(environmentProvider, "GcpEnvironmentProvider not found in context.");
 		GcpEnvironment currentEnvironment = environmentProvider.getCurrentEnvironment();
 
-		if (Arrays.stream(targetEnvironments).noneMatch((env) -> env == currentEnvironment)) {
+		if (Arrays.stream(targetEnvironments).noneMatch(env -> env == currentEnvironment)) {
 			return new ConditionOutcome(false, "Application is not running on any of "
 					+ Arrays.stream(targetEnvironments)
 					.map(GcpEnvironment::toString)

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -260,7 +260,7 @@ public class GcpPubSubAutoConfiguration {
 		}
 
 		return ifNotNull(batching.getDelayThresholdSeconds(),
-					(x) -> builder.setDelayThreshold(Duration.ofSeconds(x)))
+					x -> builder.setDelayThreshold(Duration.ofSeconds(x)))
 				.apply(ifNotNull(batching.getElementCountThreshold(), builder::setElementCountThreshold)
 				.apply(ifNotNull(batching.getEnabled(), builder::setIsEnabled)
 				.apply(ifNotNull(batching.getRequestByteThreshold(), builder::setRequestByteThreshold)
@@ -277,18 +277,18 @@ public class GcpPubSubAutoConfiguration {
 		Builder builder = RetrySettings.newBuilder();
 
 		return ifNotNull(retryProperties.getInitialRetryDelaySeconds(),
-				(x) -> builder.setInitialRetryDelay(Duration.ofSeconds(x)))
+				x -> builder.setInitialRetryDelay(Duration.ofSeconds(x)))
 				.apply(ifNotNull(retryProperties.getInitialRpcTimeoutSeconds(),
-						(x) -> builder.setInitialRpcTimeout(Duration.ofSeconds(x)))
+						x -> builder.setInitialRpcTimeout(Duration.ofSeconds(x)))
 				.apply(ifNotNull(retryProperties.getJittered(), builder::setJittered)
 				.apply(ifNotNull(retryProperties.getMaxAttempts(), builder::setMaxAttempts)
 				.apply(ifNotNull(retryProperties.getMaxRetryDelaySeconds(),
-						(x) -> builder.setMaxRetryDelay(Duration.ofSeconds(x)))
+						x -> builder.setMaxRetryDelay(Duration.ofSeconds(x)))
 				.apply(ifNotNull(retryProperties.getMaxRpcTimeoutSeconds(),
-						(x) -> builder.setMaxRpcTimeout(Duration.ofSeconds(x)))
+						x -> builder.setMaxRpcTimeout(Duration.ofSeconds(x)))
 				.apply(ifNotNull(retryProperties.getRetryDelayMultiplier(), builder::setRetryDelayMultiplier)
 				.apply(ifNotNull(retryProperties.getTotalTimeoutSeconds(),
-						(x) -> builder.setTotalTimeout(Duration.ofSeconds(x)))
+						x -> builder.setTotalTimeout(Duration.ofSeconds(x)))
 				.apply(ifNotNull(retryProperties.getRpcTimeoutMultiplier(), builder::setRpcTimeoutMultiplier)
 				.apply(false))))))))) ? builder.build() : null;
 	}
@@ -303,7 +303,7 @@ public class GcpPubSubAutoConfiguration {
 	 * propety was set
 	 */
 	private <T> Function<Boolean, Boolean> ifNotNull(T prop, Consumer<T> consumer) {
-		return (next) -> {
+		return next -> {
 			boolean wasSet = next;
 			if (prop != null) {
 				consumer.accept(prop);

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/security/IapAuthenticationAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/security/IapAuthenticationAutoConfiguration.java
@@ -89,7 +89,7 @@ public class IapAuthenticationAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public BearerTokenResolver iatTokenResolver(IapAuthenticationProperties properties) {
-		return (r) -> r.getHeader(properties.getHeader());
+		return r -> r.getHeader(properties.getHeader());
 	}
 
 	@Bean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/SpannerKeyIdConverter.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/SpannerKeyIdConverter.java
@@ -82,7 +82,7 @@ public class SpannerKeyIdConverter implements BackendIdConverter {
 	public String toRequestId(Serializable source, Class<?> entityType) {
 		Key id = (Key) source;
 		StringJoiner stringJoiner = new StringJoiner(getUrlIdSeparator());
-		id.getParts().forEach((p) -> stringJoiner.add(p.toString()));
+		id.getParts().forEach(p -> stringJoiner.add(p.toString()));
 		return stringJoiner.toString();
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
@@ -45,7 +45,7 @@ public class GcpBigQueryAutoConfigurationTests {
 
 	@Test
 	public void testSettingBigQueryOptions() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			BigQueryOptions bigQueryOptions = context.getBean(BigQuery.class).getOptions();
 			assertThat(bigQueryOptions.getProjectId()).isEqualTo("test-project");
 			assertThat(bigQueryOptions.getCredentials()).isEqualTo(MOCK_CREDENTIALS);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/config/GcpConfigBootstrapConfigurationTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/config/GcpConfigBootstrapConfigurationTest.java
@@ -42,7 +42,7 @@ public class GcpConfigBootstrapConfigurationTest {
 	@Ignore
 	public void testConfigurationValueDefaultsAreAsExpected() {
 		this.contextRunner.withPropertyValues("spring.cloud.gcp.config.enabled=true")
-				.run((context) -> {
+				.run(context -> {
 					GcpConfigProperties config = context.getBean(GcpConfigProperties.class);
 					assertThat(config.getName()).isEqualTo("application");
 					assertThat(config.getProfile()).isEqualTo("default");
@@ -59,7 +59,7 @@ public class GcpConfigBootstrapConfigurationTest {
 				"spring.cloud.gcp.config.timeoutMillis=120000",
 				"spring.cloud.gcp.config.enabled=true",
 				"spring.cloud.gcp.config.project-id=pariah")
-				.run((context) -> {
+				.run(context -> {
 					GcpConfigProperties config = context.getBean(GcpConfigProperties.class);
 					assertThat(config.getName()).isEqualTo("myapp");
 					assertThat(config.getProfile()).isEqualTo("prod");
@@ -71,7 +71,7 @@ public class GcpConfigBootstrapConfigurationTest {
 
 	@Test
 	public void testConfigurationDisabled() {
-		this.contextRunner.run((context) ->
+		this.contextRunner.run(context ->
 				assertThatExceptionOfType(NoSuchBeanDefinitionException.class).isThrownBy(() ->
 						context.getBean(GcpConfigProperties.class)));
 	}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/core/GcpContextAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/core/GcpContextAutoConfigurationTests.java
@@ -49,7 +49,7 @@ public class GcpContextAutoConfigurationTests {
 	@Test
 	public void testGetProjectIdProvider_withGcpProperties() {
 		this.contextRunner.withPropertyValues("spring.cloud.gcp.projectId=tonberry")
-				.run((context) -> {
+				.run(context -> {
 					GcpProjectIdProvider projectIdProvider =
 							context.getBean(GcpProjectIdProvider.class);
 					assertThat(projectIdProvider.getProjectId()).isEqualTo("tonberry");
@@ -58,7 +58,7 @@ public class GcpContextAutoConfigurationTests {
 
 	@Test
 	public void testGetProjectIdProvider_withoutGcpProperties() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			GcpProjectIdProvider projectIdProvider =
 					context.getBean(GcpProjectIdProvider.class);
 			assertThat(projectIdProvider).isInstanceOf(DefaultGcpProjectIdProvider.class);
@@ -68,7 +68,7 @@ public class GcpContextAutoConfigurationTests {
 	@Test
 	public void testEnvironmentProvider() {
 		this.contextRunner
-				.run((context) -> {
+				.run(context -> {
 					GcpEnvironmentProvider environmentProvider = context.getBean(GcpEnvironmentProvider.class);
 					assertThat(environmentProvider).isNotNull();
 					assertThat(environmentProvider).isInstanceOf(DefaultGcpEnvironmentProvider.class);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
@@ -109,12 +109,12 @@ public class GcpDatastoreAutoConfigurationTests {
 
 	@Test
 	public void testDatastoreSimpleClient() {
-		this.contextRunner.run((context) -> assertThat(context.getBean(Datastore.class)).isNotNull());
+		this.contextRunner.run(context -> assertThat(context.getBean(Datastore.class)).isNotNull());
 	}
 
 	@Test
 	public void testDatastoreOptionsCorrectlySet() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			DatastoreOptions datastoreOptions = getDatastoreBean(context).getOptions();
 			assertThat(datastoreOptions.getProjectId()).isEqualTo("test-project");
 			assertThat(datastoreOptions.getNamespace()).isEqualTo("testNamespace");
@@ -124,7 +124,7 @@ public class GcpDatastoreAutoConfigurationTests {
 
 	@Test
 	public void testDatastoreEmulatorCredentialsConfig() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			CredentialsProvider defaultCredentialsProvider = context.getBean(CredentialsProvider.class);
 			assertThat(defaultCredentialsProvider).isNotInstanceOf(NoCredentialsProvider.class);
 
@@ -135,17 +135,17 @@ public class GcpDatastoreAutoConfigurationTests {
 
 	@Test
 	public void testDatastoreOperationsCreated() {
-		this.contextRunner.run((context) -> assertThat(context.getBean(DatastoreOperations.class)).isNotNull());
+		this.contextRunner.run(context -> assertThat(context.getBean(DatastoreOperations.class)).isNotNull());
 	}
 
 	@Test
 	public void testTestRepositoryCreated() {
-		this.contextRunner.run((context) -> assertThat(context.getBean(TestRepository.class)).isNotNull());
+		this.contextRunner.run(context -> assertThat(context.getBean(TestRepository.class)).isNotNull());
 	}
 
 	@Test
 	public void testIdConverterCreated() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			BackendIdConverter idConverter = context.getBean(BackendIdConverter.class);
 			assertThat(idConverter).isNotNull();
 			assertThat(idConverter).isInstanceOf(DatastoreKeyIdConverter.class);
@@ -154,7 +154,7 @@ public class GcpDatastoreAutoConfigurationTests {
 
 	@Test
 	public void datastoreTransactionManagerCreated() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			DatastoreTransactionManager transactionManager = context
 					.getBean(DatastoreTransactionManager.class);
 			assertThat(transactionManager).isNotNull();
@@ -165,7 +165,7 @@ public class GcpDatastoreAutoConfigurationTests {
 
 	@Test
 	public void testDatastoreHealthIndicatorNotCreated() {
-		this.contextRunner.run((context) -> assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+		this.contextRunner.run(context -> assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
 				.isThrownBy(() -> context.getBean(DatastoreHealthIndicator.class)));
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfigurationTests.java
@@ -44,7 +44,7 @@ public class GcpDatastoreEmulatorAutoConfigurationTests {
 						"spring.cloud.gcp.datastore.emulator.port=8182",
 						"spring.cloud.gcp.datastore.emulator.enabled=true",
 						"spring.cloud.gcp.datastore.emulator.consistency=0.8")
-				.run((context) -> {
+				.run(context -> {
 					LocalDatastoreHelper helper = context.getBean(LocalDatastoreHelper.class);
 					DatastoreOptions datastoreOptions = helper.getOptions();
 					assertThat(datastoreOptions.getHost()).isEqualTo("localhost:8182");
@@ -57,7 +57,7 @@ public class GcpDatastoreEmulatorAutoConfigurationTests {
 		new ApplicationContextRunner()
 				.withConfiguration(AutoConfigurations.of(
 						GcpDatastoreEmulatorAutoConfiguration.class))
-				.run((context) -> assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+				.run(context -> assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
 						.isThrownBy(() -> context.getBean(LocalDatastoreHelper.class)));
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/health/DatastoreHealthIndicatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/health/DatastoreHealthIndicatorAutoConfigurationTests.java
@@ -53,7 +53,7 @@ public class DatastoreHealthIndicatorAutoConfigurationTests {
 
 	@Test
 	public void testDatastoreHealthIndicatorCreated() {
-		this.contextRunner.run((context) -> assertThat(context.getBean(DatastoreHealthIndicator.class)).isNotNull());
+		this.contextRunner.run(context -> assertThat(context.getBean(DatastoreHealthIndicator.class)).isNotNull());
 	}
 
 	/**

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/it/GcpDatastoreEmulatorIntegrationTests.java
@@ -84,7 +84,7 @@ public class GcpDatastoreEmulatorIntegrationTests {
 						"spring.cloud.gcp.datastore.emulator.port=8181",
 						"spring.cloud.gcp.datastore.emulator.enabled=true",
 						"spring.cloud.gcp.datastore.emulator.consistency=0.9")
-				.run((context) -> {
+				.run(context -> {
 					DatastoreTemplate datastore = context.getBean(DatastoreTemplate.class);
 					Datastore datastoreClient = (Datastore) ((Supplier) context.getBean(context.getBeanNamesForType(
 							ResolvableType.forClassWithGenerics(Supplier.class, Datastore.class))[0])).get();

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreAutoConfigurationTests.java
@@ -51,7 +51,7 @@ public class GcpFirestoreAutoConfigurationTests {
 
 	@Test
 	public void testDatastoreOptionsCorrectlySet() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			FirestoreOptions datastoreOptions = context.getBean(Firestore.class).getOptions();
 			assertThat(datastoreOptions.getProjectId()).isEqualTo("test-project");
 		});
@@ -59,7 +59,7 @@ public class GcpFirestoreAutoConfigurationTests {
 
 	@Test
 	public void testTestRepositoryCreated() {
-		this.contextRunner.run((context) -> assertThat(context.getBean(FirestoreTestRepository.class)).isNotNull());
+		this.contextRunner.run(context -> assertThat(context.getBean(FirestoreTestRepository.class)).isNotNull());
 	}
 
 	@Test

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/FirestoreDocumentationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/FirestoreDocumentationIntegrationTests.java
@@ -53,7 +53,7 @@ public class FirestoreDocumentationIntegrationTests {
 
 	@Test
 	public void writeDocumentFromObject() throws ExecutionException, InterruptedException {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			Firestore firestore = context.getBean(Firestore.class);
 			FirestoreExample firestoreExample = new FirestoreExample(firestore);
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/logging/StackdriverLoggingAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/logging/StackdriverLoggingAutoConfigurationTests.java
@@ -53,7 +53,7 @@ public class StackdriverLoggingAutoConfigurationTests {
 	@Test
 	public void testDisabledConfiguration() {
 		this.contextRunner.withPropertyValues("spring.cloud.gcp.logging.enabled=false")
-				.run((context) -> assertThat(context.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class)).isEmpty());
+				.run(context -> assertThat(context.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class)).isEmpty());
 	}
 
 	@Test
@@ -63,7 +63,7 @@ public class StackdriverLoggingAutoConfigurationTests {
 						StackdriverLoggingAutoConfiguration.class,
 						GcpContextAutoConfiguration.class))
 				.withUserConfiguration(TestConfiguration.class)
-				.run((context) -> assertThat(context.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class)).isEmpty());
+				.run(context -> assertThat(context.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class)).isEmpty());
 	}
 
 	@Test
@@ -73,12 +73,12 @@ public class StackdriverLoggingAutoConfigurationTests {
 						StackdriverLoggingAutoConfiguration.class,
 						GcpContextAutoConfiguration.class))
 				.withUserConfiguration(TestConfiguration.class)
-				.run((context) -> assertThat(context.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class)).isEmpty());
+				.run(context -> assertThat(context.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class)).isEmpty());
 	}
 
 	@Test
 	public void testRegularConfiguration() {
-		this.contextRunner.run((context) -> assertThat(context.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class))
+		this.contextRunner.run(context -> assertThat(context.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class))
 				.hasSize(1));
 	}
 
@@ -88,7 +88,7 @@ public class StackdriverLoggingAutoConfigurationTests {
 				.withConfiguration(AutoConfigurations.of(StackdriverTraceAutoConfiguration.class,
 						BraveAutoConfiguration.class))
 				.withPropertyValues("spring.cloud.gcp.project-id=pop-1")
-				.run((context) -> assertThat(context.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class)).isEmpty());
+				.run(context -> assertThat(context.getBeansOfType(TraceIdLoggingWebMvcInterceptor.class)).isEmpty());
 	}
 
 	private static class TestConfiguration {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfigurationTests.java
@@ -90,7 +90,7 @@ public class GcpPubSubEmulatorAutoConfigurationTests {
 
 	@Test
 	public void testEmulatorConfig() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			CredentialsProvider defaultCredentialsProvider = context.getBean(CredentialsProvider.class);
 			assertThat(defaultCredentialsProvider).isNotInstanceOf(NoCredentialsProvider.class);
 
@@ -105,7 +105,7 @@ public class GcpPubSubEmulatorAutoConfigurationTests {
 
 	@Test
 	public void testSubscriberPullConfig() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			GcpPubSubProperties gcpPubSubProperties = context
 					.getBean(GcpPubSubProperties.class);
 			assertThat(gcpPubSubProperties.getSubscriber().getPullEndpoint()).isEqualTo("fake-endpoint");
@@ -118,7 +118,7 @@ public class GcpPubSubEmulatorAutoConfigurationTests {
 
 	@Test
 	public void testSubscriberRetrySettings() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			RetrySettings settings = context.getBean("subscriberRetrySettings",
 					RetrySettings.class);
 			assertThat(settings.getTotalTimeout()).isEqualTo(Duration.ofSeconds(1));
@@ -135,7 +135,7 @@ public class GcpPubSubEmulatorAutoConfigurationTests {
 
 	@Test
 	public void testPublisherRetrySettings() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			RetrySettings settings = context.getBean("publisherRetrySettings",
 					RetrySettings.class);
 			assertThat(settings.getTotalTimeout()).isEqualTo(Duration.ofSeconds(9));
@@ -152,7 +152,7 @@ public class GcpPubSubEmulatorAutoConfigurationTests {
 
 	@Test
 	public void testSubscriberFlowControlSettings() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			FlowControlSettings settings = context
 					.getBean("subscriberFlowControlSettings", FlowControlSettings.class);
 			assertThat(settings.getMaxOutstandingElementCount()).isEqualTo(17);
@@ -163,7 +163,7 @@ public class GcpPubSubEmulatorAutoConfigurationTests {
 
 	@Test
 	public void testPublisherBatchingSettings() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			BatchingSettings settings = context.getBean("publisherBatchSettings",
 					BatchingSettings.class);
 			assertThat(settings.getFlowControlSettings().getMaxOutstandingElementCount()).isEqualTo(19);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubChannelAdaptersIntegrationTests.java
@@ -131,7 +131,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 	public void sendAndReceiveMessageAsString() {
 		this.contextRunner
 				.withUserConfiguration(PollableConfiguration.class, CommonConfiguration.class)
-				.run((context) -> {
+				.run(context -> {
 			Map<String, Object> headers = new HashMap<>();
 			// Only String values for now..
 			headers.put("storm", "lift your skinny fists");
@@ -161,7 +161,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 	public void sendAndReceiveMessage() {
 		this.contextRunner
 				.withUserConfiguration(PollableConfiguration.class, CommonConfiguration.class)
-				.run((context) -> {
+				.run(context -> {
 				context.getBean("inputChannel", MessageChannel.class).send(
 						MessageBuilder.withPayload("I am a message (sendAndReceiveMessage).".getBytes()).build());
 
@@ -178,7 +178,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 	public void sendAndReceiveMessageManualAck() {
 		this.contextRunner
 				.withUserConfiguration(PollableConfiguration.class, CommonConfiguration.class)
-				.run((context) -> {
+				.run(context -> {
 
 				context.getBean(PubSubInboundChannelAdapter.class).setAckMode(AckMode.MANUAL);
 				context.getBean("inputChannel", MessageChannel.class).send(
@@ -217,7 +217,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 		this.contextRunner
 				.withUserConfiguration(SubscribableConfiguration.class, CommonConfiguration.class)
 				.withPropertyValues("spring.cloud.gcp.pubsub.subscriber.max-ack-extension-period=0")
-				.run((context) -> {
+				.run(context -> {
 				context.getBean(PubSubInboundChannelAdapter.class).setAckMode(AckMode.AUTO_ACK);
 				context.getBean("inputChannel", MessageChannel.class).send(
 						MessageBuilder.withPayload("This message is in trouble.".getBytes()).build());
@@ -253,7 +253,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 	public void sendAndReceiveMessageManualAckThroughAcknowledgementHeader() {
 		this.contextRunner
 				.withUserConfiguration(PollableConfiguration.class, CommonConfiguration.class)
-				.run((context) -> {
+				.run(context -> {
 				context.getBean(PubSubInboundChannelAdapter.class).setAckMode(AckMode.MANUAL);
 				context.getBean("inputChannel", MessageChannel.class).send(
 						MessageBuilder.withPayload("I am a message (sendAndReceiveMessageManualAckThroughAcknowledgementHeader).".getBytes()).build());
@@ -276,7 +276,7 @@ public class PubSubChannelAdaptersIntegrationTests {
 	public void sendAndReceiveMessagePublishCallback() {
 		this.contextRunner
 				.withUserConfiguration(PollableConfiguration.class, CommonConfiguration.class)
-				.run((context) -> {
+				.run(context -> {
 					ListenableFutureCallback<String> callbackSpy = Mockito.spy(
 						new ListenableFutureCallback<String>() {
 							@Override

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java
@@ -97,7 +97,7 @@ public class PubSubTemplateDocumentationIntegrationTests {
 	private void pubSubTest(PubSubTest pubSubTest, Class... configClass) {
 		ApplicationContextRunner contextRunner = configClass.length == 0 ? this.contextRunner
 				: this.contextRunner.withUserConfiguration(configClass[0]);
-		contextRunner.run((context) -> {
+		contextRunner.run(context -> {
 			PubSubAdmin pubSubAdmin = context.getBean(PubSubAdmin.class);
 			PubSubTemplate pubSubTemplate = context.getBean(PubSubTemplate.class);
 
@@ -163,7 +163,7 @@ public class PubSubTemplateDocumentationIntegrationTests {
 
 			Logger logger = new Logger();
 			//tag::subscribe[]
-			Subscriber subscriber = pubSubTemplate.subscribe(subscriptionName, (message) -> {
+			Subscriber subscriber = pubSubTemplate.subscribe(subscriptionName, message -> {
 				logger.info("Message received from " + subscriptionName + " subscription: "
 						+ message.getPubsubMessage().getData().toStringUtf8());
 				message.ack();

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateIntegrationTests.java
@@ -84,7 +84,7 @@ public class PubSubTemplateIntegrationTests {
 
 	@Test
 	public void testCreatePublishPullNextAndDelete() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			PubSubAdmin pubSubAdmin = context.getBean(PubSubAdmin.class);
 			PubSubTemplate pubSubTemplate = context.getBean(PubSubTemplate.class);
 
@@ -120,10 +120,10 @@ public class PubSubTemplateIntegrationTests {
 			assertThat(pubSubAdmin.getTopic(topicName)).isNotNull();
 			assertThat(pubSubAdmin.getSubscription(subscriptionName)).isNotNull();
 			assertThat(pubSubAdmin.listTopics().stream()
-					.filter((topic) -> topic.getName().endsWith(topicName)).toArray())
+					.filter(topic -> topic.getName().endsWith(topicName)).toArray())
 					.hasSize(1);
 			assertThat(pubSubAdmin.listSubscriptions().stream()
-					.filter((subscription) -> subscription.getName().endsWith(subscriptionName)).toArray())
+					.filter(subscription -> subscription.getName().endsWith(subscriptionName)).toArray())
 					.hasSize(1);
 			pubSubAdmin.deleteSubscription(subscriptionName);
 			pubSubAdmin.deleteTopic(topicName);
@@ -140,7 +140,7 @@ public class PubSubTemplateIntegrationTests {
 
 	@Test
 	public void testPullAndAck() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			PubSubAdmin pubSubAdmin = context.getBean(PubSubAdmin.class);
 			String topicName = "peel-the-paint" + UUID.randomUUID();
 			String subscriptionName = "i-lost-my-head" + UUID.randomUUID();
@@ -154,7 +154,7 @@ public class PubSubTemplateIntegrationTests {
 			futures.add(pubSubTemplate.publish(topicName, "message2"));
 			futures.add(pubSubTemplate.publish(topicName, "message3"));
 
-			futures.parallelStream().forEach((f) -> {
+			futures.parallelStream().forEach(f -> {
 				try {
 					f.get(5, TimeUnit.SECONDS);
 				}
@@ -170,13 +170,13 @@ public class PubSubTemplateIntegrationTests {
 				List<AcknowledgeablePubsubMessage> newMessages = pubSubTemplate.pull(subscriptionName, 4, false);
 				ackableMessages.addAll(newMessages);
 				messagesSet.addAll(newMessages.stream()
-						.map((message) -> message.getPubsubMessage().getData().toStringUtf8())
+						.map(message -> message.getPubsubMessage().getData().toStringUtf8())
 						.collect(Collectors.toList()));
 			}
 
 			assertThat(messagesSet.size()).as("check that we received all the messages").isEqualTo(3);
 
-			ackableMessages.forEach((message) -> {
+			ackableMessages.forEach(message -> {
 				try {
 					if (message.getPubsubMessage().getData().toStringUtf8().equals("message1")) {
 						message.ack().get(); // sync call
@@ -198,7 +198,7 @@ public class PubSubTemplateIntegrationTests {
 			while (messagesCount < 2 && tries > 0) {
 				Thread.sleep(100);
 				ackableMessages = pubSubTemplate.pull(subscriptionName, 4, true);
-				ackableMessages.forEach((m) -> m.ack());
+				ackableMessages.forEach(m -> m.ack());
 				messagesCount += ackableMessages.size();
 				tries--;
 			}
@@ -213,7 +213,7 @@ public class PubSubTemplateIntegrationTests {
 	public void testPubSubTemplateLoadsMessageConverter() {
 		this.contextRunner
 				.withUserConfiguration(JsonPayloadTestConfiguration.class)
-				.run((context) -> {
+				.run(context -> {
 					PubSubAdmin pubSubAdmin = context.getBean(PubSubAdmin.class);
 					PubSubTemplate pubSubTemplate = context.getBean(PubSubTemplate.class);
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/security/IapAuthenticationAutoConfigurationTests.java
@@ -126,7 +126,7 @@ public class IapAuthenticationAutoConfigurationTests {
 
 		this.contextRunner
 				.withPropertyValues("spring.cloud.gcp.security.iap.enabled=false")
-				.run((context) ->	context.getBean(JwtDecoder.class));
+				.run(context ->	context.getBean(JwtDecoder.class));
 	}
 
 	@Test
@@ -147,7 +147,7 @@ public class IapAuthenticationAutoConfigurationTests {
 
 		this.contextRunner
 				.withPropertyValues("spring.cloud.gcp.security.iap.audience=aud1, aud2")
-				.run((context) -> {
+				.run(context -> {
 					AudienceValidator validator
 							= context.getBean(AudienceValidator.class);
 					OAuth2TokenValidatorResult result = validator.validate(mockJwt);
@@ -160,7 +160,7 @@ public class IapAuthenticationAutoConfigurationTests {
 		this.contextRunner
 				.withUserConfiguration(UserConfiguration.class)
 				.withPropertyValues("spring.cloud.gcp.security.iap.audience=unused")
-				.run((context) -> {
+				.run(context -> {
 					JwtDecoder jwtDecoder =  context.getBean(JwtDecoder.class);
 					assertThat(jwtDecoder).isNotNull();
 					assertThat(jwtDecoder).isNotInstanceOf(NimbusJwtDecoder.class);
@@ -178,7 +178,7 @@ public class IapAuthenticationAutoConfigurationTests {
 		this.contextRunner
 				.withPropertyValues("spring.cloud.gcp.security.iap.header=some-other-header")
 				.withPropertyValues("spring.cloud.gcp.security.iap.audience=unused")
-				.run((context) -> {
+				.run(context -> {
 					when(this.mockNonIapRequest.getHeader("some-other-header")).thenReturn("other header jwt");
 
 					BearerTokenResolver resolver = context.getBean(BearerTokenResolver.class);
@@ -192,7 +192,7 @@ public class IapAuthenticationAutoConfigurationTests {
 	public void testContextFailsWhenAudienceValidatorNotAvailable() throws Exception {
 
 		this.contextRunner
-				.run((context) -> {
+				.run(context -> {
 					assertThat(context).getFailure()
 							.hasCauseInstanceOf(NoSuchBeanDefinitionException.class)
 							.hasMessageContaining("No qualifying bean of type 'com.google.cloud.spring.security.iap.AudienceProvider'");
@@ -206,7 +206,7 @@ public class IapAuthenticationAutoConfigurationTests {
 
 		this.contextRunner
 				.withUserConfiguration(FixedAudienceValidatorConfiguration.class)
-				.run((context) -> {
+				.run(context -> {
 					DelegatingOAuth2TokenValidator validator
 							= context.getBean("iapJwtDelegatingValidator", DelegatingOAuth2TokenValidator.class);
 					OAuth2TokenValidatorResult result = validator.validate(mockJwt);
@@ -224,7 +224,7 @@ public class IapAuthenticationAutoConfigurationTests {
 
 		this.contextRunner
 				.withUserConfiguration(FixedAudienceValidatorConfiguration.class)
-				.run((context) -> {
+				.run(context -> {
 					AudienceProvider audienceProvider = context.getBean(AudienceProvider.class);
 					assertThat(audienceProvider).isNotNull();
 					assertThat(audienceProvider).isInstanceOf(AppEngineAudienceProvider.class);
@@ -251,12 +251,12 @@ public class IapAuthenticationAutoConfigurationTests {
 
 		@Bean
 		public JwtDecoder jwtDecoder() {
-			return (s) -> mockJwt;
+			return s -> mockJwt;
 		}
 
 		@Bean
 		public BearerTokenResolver bearerTokenResolver() {
-			return (httpServletRequest) -> FAKE_USER_TOKEN;
+			return httpServletRequest -> FAKE_USER_TOKEN;
 		}
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfigurationTests.java
@@ -54,35 +54,35 @@ public class GcpSpannerAutoConfigurationTests {
 
 	@Test
 	public void testSpannerOperationsCreated() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			assertThat(context.getBean(SpannerOperations.class)).isNotNull();
 		});
 	}
 
 	@Test
 	public void testTestRepositoryCreated() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			assertThat(context.getBean(TestRepository.class)).isNotNull();
 		});
 	}
 
 	@Test
 	public void testDatabaseAdminClientCreated() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			assertThat(context.getBean(SpannerDatabaseAdminTemplate.class)).isNotNull();
 		});
 	}
 
 	@Test
 	public void testSchemaUtilsCreated() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			assertThat(context.getBean(SpannerSchemaUtils.class)).isNotNull();
 		});
 	}
 
 	@Test
 	public void testIdConverterCreated() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			BackendIdConverter idConverter = context.getBean(BackendIdConverter.class);
 			assertThat(idConverter).isNotNull();
 			assertThat(idConverter).isInstanceOf(SpannerKeyIdConverter.class);
@@ -91,7 +91,7 @@ public class GcpSpannerAutoConfigurationTests {
 
 	@Test
 	public void spannerTransactionManagerCreated() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			SpannerTransactionManager transactionManager = context
 					.getBean(SpannerTransactionManager.class);
 			assertThat(transactionManager).isNotNull();

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/sql/CloudSqlEnvironmentPostProcessorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/sql/CloudSqlEnvironmentPostProcessorTests.java
@@ -59,7 +59,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 		this.contextRunner.withPropertyValues(
 				"spring.cloud.gcp.sql.instance-connection-name=tubular-bells:singapore:test-instance",
 				"spring.datasource.password=")
-				.run((context) -> {
+				.run(context -> {
 					HikariDataSource dataSource =
 							(HikariDataSource) context.getBean(DataSource.class);
 					assertThat(dataSource.getDriverClassName()).matches("com.mysql.cj.jdbc.Driver");
@@ -78,7 +78,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 				"spring.cloud.gcp.sql.instance-connection-name=tubular-bells:singapore:test-instance",
 				"spring.datasource.password=",
 				"spring.datasource.url=jdbc:h2:mem:none;MODE=MySQL;DB_CLOSE_ON_EXIT=FALSE")
-				.run((context) -> {
+				.run(context -> {
 					HikariDataSource dataSource =
 							(HikariDataSource) context.getBean(DataSource.class);
 					assertThat(dataSource.getDriverClassName()).matches("com.mysql.cj.jdbc.Driver");
@@ -102,7 +102,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 				"spring.cloud.gcp.sql.instance-connection-name=tubular-bells:singapore:test-instance",
 				"spring.datasource.password=",
 				"spring.datasource.url=test-url")
-				.run((context) -> {
+				.run(context -> {
 					HikariDataSource dataSource =
 							(HikariDataSource) context.getBean(DataSource.class);
 					assertThat(dataSource.getDriverClassName()).matches("com.mysql.cj.jdbc.Driver");
@@ -124,7 +124,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 				"spring.datasource.password=")
 				.withSystemProperties(
 						"com.google.appengine.runtime.version=Google App Engine/Some Server")
-				.run((context) -> {
+				.run(context -> {
 					HikariDataSource dataSource =
 							(HikariDataSource) context.getBean(DataSource.class);
 					assertThat(getSpringDatasourceDriverClassName(context))
@@ -145,7 +145,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 		this.contextRunner.withPropertyValues("spring.datasource.username=watchmaker",
 				"spring.datasource.password=pass",
 				"spring.cloud.gcp.sql.instance-connection-name=proj:reg:test-instance")
-				.run((context) -> {
+				.run(context -> {
 					HikariDataSource dataSource =
 							(HikariDataSource) context.getBean(DataSource.class);
 					assertThat(getSpringDatasourceUrl(context)).isEqualTo(
@@ -163,7 +163,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 		this.contextRunner.withPropertyValues(
 				"spring.cloud.gcp.sql.instance-connection-name=proj:reg:test-instance",
 				"spring.datasource.driver-class-name=org.postgresql.Driver")
-				.run((context) -> {
+				.run(context -> {
 					HikariDataSource dataSource =
 							(HikariDataSource) context.getBean(DataSource.class);
 					assertThat(getSpringDatasourceUrl(context)).isEqualTo(
@@ -180,7 +180,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 				"spring.cloud.gcp.sql.instance-connection-name=proj:reg:test-instance",
 				"spring.datasource.hikari.connectionTestQuery=select 1",
 				"spring.datasource.hikari.maximum-pool-size=19")
-				.run((context) -> {
+				.run(context -> {
 					HikariDataSource dataSource =
 							(HikariDataSource) context.getBean(DataSource.class);
 					assertThat(getSpringDatasourceUrl(context)).isEqualTo(
@@ -197,7 +197,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 	public void testInstanceConnectionName() {
 		this.contextRunner.withPropertyValues(
 				"spring.cloud.gcp.sql.instance-connection-name=world:asia:japan")
-				.run((context) -> {
+				.run(context -> {
 					assertThat(getSpringDatasourceUrl(context)).isEqualTo(
 							"jdbc:mysql://google/test-database?"
 									+ "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
@@ -212,7 +212,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 				"spring.cloud.gcp.sql.instance-connection-name=tubular-bells:singapore:test-instance")
 				.withClassLoader(
 						new FilteredClassLoader("com.google.cloud.sql.mysql"))
-				.run((context) -> {
+				.run(context -> {
 					HikariDataSource dataSource =
 							(HikariDataSource) context.getBean(DataSource.class);
 					assertThat(getSpringDatasourceUrl(context)).isEqualTo(
@@ -230,7 +230,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 				"spring.cloud.gcp.sql.instance-connection-name=tubular-bells:singapore:test-instance")
 				.withClassLoader(
 						new FilteredClassLoader(EmbeddedDatabaseType.class, DataSource.class))
-				.run((context) -> {
+				.run(context -> {
 					assertThat(context.getBeanNamesForType(DataSource.class)).isEmpty();
 					assertThat(context.getBeanNamesForType(DataSourceProperties.class)).isEmpty();
 					assertThat(context.getBeanNamesForType(CloudSqlJdbcInfoProvider.class)).isEmpty();
@@ -242,7 +242,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 		this.contextRunner.withPropertyValues(
 				"spring.cloud.gcp.sql.instance-connection-name=world:asia:japan",
 				"spring.cloud.gcp.sql.ip-types=PRIVATE")
-				.run((context) -> {
+				.run(context -> {
 					DataSourceProperties dataSourceProperties =
 							context.getBean(DataSourceProperties.class);
 					assertThat(dataSourceProperties.getUrl()).contains(
@@ -255,7 +255,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 		this.contextRunner.withPropertyValues(
 				"spring.cloud.gcp.sql.instance-connection-name=world:asia:japan",
 				"spring.cloud.gcp.sql.database-name=${sm://my-db}")
-				.run((context) -> {
+				.run(context -> {
 					assertThat(context.getEnvironment().getPropertySources()
 							.get("CLOUD_SQL_DATA_SOURCE_URL")
 							.getProperty("spring.datasource.url"))
@@ -282,7 +282,7 @@ public class CloudSqlEnvironmentPostProcessorTests {
 					}
 				})
 				.withInitializer(configurableApplicationContext -> initializer.postProcessEnvironment(configurableApplicationContext.getEnvironment(), new SpringApplication()))
-				.run((context) -> {
+				.run(context -> {
 					assertThat(getSpringDatasourceUrl(context)).isNull();
 				});
 	}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfigurationTests.java
@@ -55,7 +55,7 @@ public class GcpStorageAutoConfigurationTests {
 
 	@Test
 	public void testValidObject() throws Exception {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			Resource resource = context.getBean("mockResource", Resource.class);
 			assertThat(resource.contentLength()).isEqualTo(4096);
 		});
@@ -64,7 +64,7 @@ public class GcpStorageAutoConfigurationTests {
 	@Test
 	public void testAutoCreateFilesTrueByDefault() throws IOException {
 		this.contextRunner
-			.run((context) -> {
+			.run(context -> {
 				Resource resource = context.getBean("mockResource", Resource.class);
 				assertThat(((GoogleStorageResource) resource).isAutoCreateFiles()).isTrue();
 			});
@@ -75,7 +75,7 @@ public class GcpStorageAutoConfigurationTests {
 
 		this.contextRunner
 			.withPropertyValues("spring.cloud.gcp.storage.auto-create-files=false")
-			.run((context) -> {
+			.run(context -> {
 				Resource resource = context.getBean("mockResource", Resource.class);
 				assertThat(((GoogleStorageResource) resource).isAutoCreateFiles()).isFalse();
 			});

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageDisableTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageDisableTests.java
@@ -42,7 +42,7 @@ public class GcpStorageDisableTests {
 
 	@Test
 	public void testStorageBeanIsNotProvided() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			Throwable thrown = catchThrowable(() -> context.getBean(Storage.class));
 			assertThat(thrown).isInstanceOf(NoSuchBeanDefinitionException.class);
 		});

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -98,7 +98,7 @@ public class StackdriverTraceAutoConfigurationTests {
 						StackdriverTraceAutoConfiguration.SPAN_HANDLER_BEAN_NAME,
 						SpanHandler.class,
 						() ->  SpanHandler.NOOP)
-				.run((context) -> {
+				.run(context -> {
 			assertThat(context.getBean(HttpRequestParser.class)).isNotNull();
 			assertThat(context.getBean(HttpTracingCustomizer.class)).isNotNull();
 			assertThat(context.getBean(StackdriverTraceAutoConfiguration.SENDER_BEAN_NAME, Sender.class)).isNotNull();
@@ -115,7 +115,7 @@ public class StackdriverTraceAutoConfigurationTests {
 						GcpContextAutoConfiguration.class,
 						RefreshAutoConfiguration.class))
 				.withUserConfiguration(MultipleSpanHandlersConfig.class)
-				.run((context) -> {
+				.run(context -> {
 			assertThat(context.getBean(HttpRequestParser.class)).isNotNull();
 			assertThat(context.getBean(HttpTracingCustomizer.class)).isNotNull();
 			assertThat(context.getBean(ManagedChannel.class)).isNotNull();
@@ -211,7 +211,7 @@ public class StackdriverTraceAutoConfigurationTests {
 			return () -> {
 				Credentials creds = mock(Credentials.class);
 				doAnswer((Answer<Void>)
-					(invocationOnMock) -> {
+					invocationOnMock -> {
 						RequestMetadataCallback callback =
 								(RequestMetadataCallback) invocationOnMock.getArguments()[2];
 						callback.onSuccess(Collections.emptyMap());
@@ -318,7 +318,7 @@ public class StackdriverTraceAutoConfigurationTests {
 			@Override
 			public void batchWriteSpans(BatchWriteSpansRequest request,
 					StreamObserver<Empty> responseObserver) {
-				request.getSpansList().forEach((span) -> this.traces.put(span.getSpanId(), span));
+				request.getSpansList().forEach(span -> this.traces.put(span.getSpanId(), span));
 				responseObserver.onNext(Empty.getDefaultInstance());
 				responseObserver.onCompleted();
 			}

--- a/spring-cloud-gcp-cloudfoundry/src/main/java/com/google/cloud/spring/cloudfoundry/GcpCloudFoundryEnvironmentPostProcessor.java
+++ b/spring-cloud-gcp-cloudfoundry/src/main/java/com/google/cloud/spring/cloudfoundry/GcpCloudFoundryEnvironmentPostProcessor.java
@@ -91,7 +91,7 @@ public class GcpCloudFoundryEnvironmentPostProcessor
 			}
 
 			servicesToMap.forEach(
-					(service) -> gcpCfServiceProperties.putAll(
+					service -> gcpCfServiceProperties.putAll(
 							retrieveCfProperties(
 									cfEnv,
 									service.getGcpServiceName(),

--- a/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/DefaultCredentialsProvider.java
+++ b/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/DefaultCredentialsProvider.java
@@ -134,7 +134,7 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
 	static List<String> resolveScopes(List<String> scopes) {
 		if (!ObjectUtils.isEmpty(scopes)) {
 			Set<String> resolvedScopes = new HashSet<>();
-			scopes.forEach((scope) -> {
+			scopes.forEach(scope -> {
 				if (DEFAULT_SCOPES_PLACEHOLDER.equals(scope)) {
 					resolvedScopes.addAll(CREDENTIALS_SCOPES_LIST);
 				}

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
@@ -209,7 +209,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 	@Override
 	public <T> void deleteAll(Iterable<T> entities) {
 		performDelete(StreamSupport.stream(entities.spliterator(), false)
-				.map((x) -> getKey(x, false)).toArray(Key[]::new), null, entities, null);
+				.map(x -> getKey(x, false)).toArray(Key[]::new), null, entities, null);
 	}
 
 	@Override
@@ -413,7 +413,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 		}
 		if (queryOptions.getSort() != null) {
 			queryOptions.getSort().stream()
-					.map((order) -> createOrderBy(persistentEntity, order))
+					.map(order -> createOrderBy(persistentEntity, order))
 					.forEachOrdered(builder::addOrderBy);
 		}
 	}
@@ -511,7 +511,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 	private List<Entity> getReferenceEntitiesForSave(Object entity, Builder builder, Set<Key> persistedEntities) {
 		DatastorePersistentEntity<?> datastorePersistentEntity = getPersistentEntity(entity.getClass());
 		List<Entity> entitiesToSave = new ArrayList<>();
-		datastorePersistentEntity.doWithAssociations((AssociationHandler) (association) -> {
+		datastorePersistentEntity.doWithAssociations((AssociationHandler) association -> {
 			PersistentProperty persistentProperty = association.getInverse();
 			PersistentPropertyAccessor accessor = datastorePersistentEntity.getPropertyAccessor(entity);
 			Object val = accessor.getProperty(persistentProperty);
@@ -526,7 +526,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 				Iterable<?> iterableVal = (Iterable<?>) ValueUtil.toListIfArray(val);
 				entitiesToSave.addAll(getEntitiesForSave(iterableVal, persistedEntities));
 				List<KeyValue> keyValues = StreamSupport.stream((iterableVal).spliterator(), false)
-						.map((o) -> KeyValue.of(this.getKey(o, false)))
+						.map(o -> KeyValue.of(this.getKey(o, false)))
 						.collect(Collectors.toList());
 				value = ListValue.of(keyValues);
 
@@ -575,7 +575,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 		}
 
 		Key key = getKey(entity, false);
-		if (key == null || key.getAncestors().stream().anyMatch((pe) -> pe.equals(ancestorPE))) {
+		if (key == null || key.getAncestors().stream().anyMatch(pe -> pe.equals(ancestorPE))) {
 			return;
 		}
 		throw new DatastoreDataException("Descendant object has a key without current ancestor");
@@ -615,7 +615,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 				.getPersistentEntity(entityClass);
 
 		return keys.stream()
-				.map((key) -> convertEntityResolveDescendantsAndReferences(entityClass,
+				.map(key -> convertEntityResolveDescendantsAndReferences(entityClass,
 				datastorePersistentEntity,
 				key,
 				context)).filter(Objects::nonNull)
@@ -651,7 +651,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 	private <T> void resolveReferenceProperties(DatastorePersistentEntity datastorePersistentEntity,
 			BaseEntity entity, T convertedObject, ReadContext context) {
 		datastorePersistentEntity.doWithAssociations(
-				(AssociationHandler) (association) -> {
+				(AssociationHandler) association -> {
 					DatastorePersistentProperty referenceProperty = (DatastorePersistentProperty) association
 							.getInverse();
 					String fieldName = referenceProperty.getFieldName();
@@ -729,7 +729,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 	private <T> void resolveDescendantProperties(DatastorePersistentEntity datastorePersistentEntity,
 			BaseEntity entity, T convertedObject, ReadContext context) {
 		datastorePersistentEntity
-				.doWithDescendantProperties((descendantPersistentProperty) -> {
+				.doWithDescendantProperties(descendantPersistentProperty -> {
 
 					Class descendantType = descendantPersistentProperty
 							.getComponentType();
@@ -784,7 +784,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 
 	private <T> Set<Key> getKeysFromIds(Iterable<?> ids, Class<T> entityClass) {
 		Set<Key> keys = new HashSet<>();
-		ids.forEach((x) -> keys.add(getKeyFromId(x, entityClass)));
+		ids.forEach(x -> keys.add(getKeyFromId(x, entityClass)));
 		return keys;
 	}
 
@@ -811,7 +811,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 
 		LinkedList<StructuredQuery.Filter> filters = new LinkedList<>();
 		NullHandler nullHandler = example.getMatcher().getNullHandler();
-		persistentEntity.doWithColumnBackedProperties((persistentProperty) -> {
+		persistentEntity.doWithColumnBackedProperties(persistentProperty -> {
 			if (!ignoredProperty(example, persistentProperty)) {
 				Value<?> value = getValue(example, probeEntity, persistentEntity, persistentProperty);
 				addFilter(nullHandler, filters, persistentProperty.getFieldName(), value);
@@ -895,7 +895,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 		}
 
 		Optional<String> path =
-				example.getMatcher().getIgnoredPaths().stream().filter((s) -> s.contains(".")).findFirst();
+				example.getMatcher().getIgnoredPaths().stream().filter(s -> s.contains(".")).findFirst();
 		if (path.isPresent()) {
 			throw new DatastoreDataException("Ignored paths deeper than 1 are not supported");
 		}

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/DatastoreNativeTypes.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/DatastoreNativeTypes.java
@@ -84,7 +84,7 @@ public abstract class DatastoreNativeTypes {
 		wrappers.put(LatLng.class, (Function<LatLng, Value<?>>) LatLngValue::of);
 		wrappers.put(Timestamp.class, (Function<Timestamp, Value<?>>) TimestampValue::of);
 		wrappers.put(String.class, (Function<String, Value<?>>) StringValue::of);
-		wrappers.put(Enum.class, (Function<Enum, Value<?>>) (x) -> StringValue.of(x.name()));
+		wrappers.put(Enum.class, (Function<Enum, Value<?>>) x -> StringValue.of(x.name()));
 		wrappers.put(Entity.class, (Function<Entity, Value<?>>) EntityValue::of);
 		wrappers.put(Key.class, (Function<Key, Value<?>>) KeyValue::of);
 
@@ -96,35 +96,35 @@ public abstract class DatastoreNativeTypes {
 		ID_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(String.class, Long.class)));
 
 		GQL_PARAM_BINDING_FUNC_MAP = new MapBuilder<Class<?>, Function<Builder, BiFunction<String, Object, Builder>>>()
-				.put(Cursor.class, (builder) -> (s, o) -> builder.setBinding(s, (Cursor) o))
-				.put(String.class, (builder) -> (s, o) -> builder.setBinding(s, (String) o))
+				.put(Cursor.class, builder -> (s, o) -> builder.setBinding(s, (Cursor) o))
+				.put(String.class, builder -> (s, o) -> builder.setBinding(s, (String) o))
 				.put(Enum.class,
-					(builder) -> (s, o) -> builder.setBinding(s, ((Enum) o).name()))
+					builder -> (s, o) -> builder.setBinding(s, ((Enum) o).name()))
 				.put(String[].class,
-					(builder) -> (s, o) -> builder.setBinding(s, (String[]) o))
-				.put(Long.class, (builder) -> (s, o) -> builder.setBinding(s, (Long) o))
-				.put(Long[].class, (builder) -> (s, o) -> builder.setBinding(s, Stream.of((Long[]) o)
+					builder -> (s, o) -> builder.setBinding(s, (String[]) o))
+				.put(Long.class, builder -> (s, o) -> builder.setBinding(s, (Long) o))
+				.put(Long[].class, builder -> (s, o) -> builder.setBinding(s, Stream.of((Long[]) o)
 					.mapToLong(Long::longValue).toArray()))
-				.put(long[].class, (builder) -> (s, o) -> builder.setBinding(s, (long[]) o))
-				.put(Double.class, (builder) -> (s, o) -> builder.setBinding(s, (Double) o))
-				.put(Double[].class, (builder) -> (s, o) -> builder.setBinding(s, Stream.of((Double[]) o)
+				.put(long[].class, builder -> (s, o) -> builder.setBinding(s, (long[]) o))
+				.put(Double.class, builder -> (s, o) -> builder.setBinding(s, (Double) o))
+				.put(Double[].class, builder -> (s, o) -> builder.setBinding(s, Stream.of((Double[]) o)
 					.mapToDouble(Double::doubleValue).toArray()))
 				.put(double[].class,
-					(builder) -> (s, o) -> builder.setBinding(s, (double[]) o))
+					builder -> (s, o) -> builder.setBinding(s, (double[]) o))
 				.put(Boolean.class,
-					(builder) -> (s, o) -> builder.setBinding(s, (Boolean) o))
-				.put(Boolean[].class, (builder) -> (s, o) -> builder.setBinding(s,
+					builder -> (s, o) -> builder.setBinding(s, (Boolean) o))
+				.put(Boolean[].class, builder -> (s, o) -> builder.setBinding(s,
 						wrapperToBooleanArray((Boolean[]) o)))
 				.put(boolean[].class,
-					(builder) -> (s, o) -> builder.setBinding(s, (boolean[]) o))
+					builder -> (s, o) -> builder.setBinding(s, (boolean[]) o))
 				.put(Timestamp.class,
-					(builder) -> (s, o) -> builder.setBinding(s, (Timestamp) o))
+					builder -> (s, o) -> builder.setBinding(s, (Timestamp) o))
 				.put(Timestamp[].class,
-					(builder) -> (s, o) -> builder.setBinding(s, (Timestamp[]) o))
-				.put(Key.class, (builder) -> (s, o) -> builder.setBinding(s, (Key) o))
-				.put(Key[].class, (builder) -> (s, o) -> builder.setBinding(s, (Key[]) o))
-				.put(Blob.class, (builder) -> (s, o) -> builder.setBinding(s, (Blob) o))
-				.put(Blob[].class, (builder) -> (s, o) -> builder.setBinding(s, (Blob[]) o))
+					builder -> (s, o) -> builder.setBinding(s, (Timestamp[]) o))
+				.put(Key.class, builder -> (s, o) -> builder.setBinding(s, (Key) o))
+				.put(Key[].class, builder -> (s, o) -> builder.setBinding(s, (Key[]) o))
+				.put(Blob.class, builder -> (s, o) -> builder.setBinding(s, (Blob) o))
+				.put(Blob[].class, builder -> (s, o) -> builder.setBinding(s, (Blob[]) o))
 				.build();
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverter.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverter.java
@@ -151,7 +151,7 @@ public class DefaultDatastoreEntityConverter implements DatastoreEntityConverter
 			instance = instantiator.createInstance(persistentEntity, parameterValueProvider);
 			PersistentPropertyAccessor accessor = persistentEntity.getPropertyAccessor(instance);
 
-			persistentEntity.doWithColumnBackedProperties((datastorePersistentProperty) -> {
+			persistentEntity.doWithColumnBackedProperties(datastorePersistentProperty -> {
 				// if a property is a constructor argument, it was already computed on instantiation
 				if (!persistentEntity.isConstructorArgument(datastorePersistentProperty)) {
 					Object value = propertyValueProvider

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
@@ -263,8 +263,7 @@ public class TwoStepsConversions implements ReadWriteConversions {
 		if (proppertyVal != null) {
 			switch (embeddedType) {
 			case EMBEDDED_MAP:
-				writeConverter = x -> convertOnWriteSingleEmbeddedMap(x, fieldName,
-						(TypeInformation) typeInformation.getMapValueType());
+				writeConverter = x -> convertOnWriteSingleEmbeddedMap(x, fieldName, typeInformation.getMapValueType());
 				break;
 			case EMBEDDED_ENTITY:
 				writeConverter = x -> convertOnWriteSingleEmbedded(x, fieldName);

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
@@ -263,11 +263,11 @@ public class TwoStepsConversions implements ReadWriteConversions {
 		if (proppertyVal != null) {
 			switch (embeddedType) {
 			case EMBEDDED_MAP:
-				writeConverter = (x) -> convertOnWriteSingleEmbeddedMap(x, fieldName,
+				writeConverter = x -> convertOnWriteSingleEmbeddedMap(x, fieldName,
 						(TypeInformation) typeInformation.getMapValueType());
 				break;
 			case EMBEDDED_ENTITY:
-				writeConverter = (x) -> convertOnWriteSingleEmbedded(x, fieldName);
+				writeConverter = x -> convertOnWriteSingleEmbedded(x, fieldName);
 				break;
 			case NOT_EMBEDDED:
 				writeConverter = this::convertOnWriteSingle;
@@ -317,7 +317,7 @@ public class TwoStepsConversions implements ReadWriteConversions {
 
 	private EntityValue convertOnWriteSingleEmbeddedMap(Object val, String kindName,
 			TypeInformation valueTypeInformation) {
-		return applyEntityValueBuilder(null, kindName, (builder) -> {
+		return applyEntityValueBuilder(null, kindName, builder -> {
 			Map map = (Map) val;
 			for (Object key : map.keySet()) {
 				String field = convertOnReadSingle(convertOnWriteSingle(key).get(),
@@ -332,7 +332,7 @@ public class TwoStepsConversions implements ReadWriteConversions {
 
 	private EntityValue convertOnWriteSingleEmbedded(Object val, String kindName) {
 		return applyEntityValueBuilder(val, kindName,
-				(builder) -> this.datastoreEntityConverter.write(val, builder), true);
+				builder -> this.datastoreEntityConverter.write(val, builder), true);
 	}
 
 	@Override
@@ -396,7 +396,7 @@ public class TwoStepsConversions implements ReadWriteConversions {
 			return Optional.of(inputType);
 		}
 		return DatastoreNativeTypes.DATASTORE_NATIVE_TYPES.stream()
-				.filter((simpleType) ->
+				.filter(simpleType ->
 						this.internalConversionService.canConvert(inputType, simpleType)
 								&& this.internalConversionService.canConvert(simpleType, inputType))
 				.findAny();

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastorePersistentEntityImpl.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastorePersistentEntityImpl.java
@@ -201,7 +201,7 @@ public class DatastorePersistentEntityImpl<T>
 	public void doWithColumnBackedProperties(
 			PropertyHandler<DatastorePersistentProperty> handler) {
 		doWithProperties(
-				(PropertyHandler<DatastorePersistentProperty>) (datastorePersistentProperty) -> {
+				(PropertyHandler<DatastorePersistentProperty>) datastorePersistentProperty -> {
 					if (datastorePersistentProperty.isColumnBacked()) {
 						handler.doWithPersistentProperty(datastorePersistentProperty);
 					}
@@ -212,7 +212,7 @@ public class DatastorePersistentEntityImpl<T>
 	public void doWithDescendantProperties(
 			PropertyHandler<DatastorePersistentProperty> handler) {
 		doWithProperties(
-				(PropertyHandler<DatastorePersistentProperty>) (datastorePersistentProperty) -> {
+				(PropertyHandler<DatastorePersistentProperty>) datastorePersistentProperty -> {
 					if (datastorePersistentProperty.isDescendants()) {
 						handler.doWithPersistentProperty(datastorePersistentProperty);
 					}

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastorePersistentPropertyImpl.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastorePersistentPropertyImpl.java
@@ -137,7 +137,7 @@ public class DatastorePersistentPropertyImpl
 	public Iterable<? extends TypeInformation<?>> getPersistentEntityTypes() {
 		return StreamUtils
 				.createStreamFromIterator(super.getPersistentEntityTypes().iterator())
-				.filter((typeInfo) -> typeInfo.getType().isAnnotationPresent(Entity.class))
+				.filter(typeInfo -> typeInfo.getType().isAnnotationPresent(Entity.class))
 				.collect(Collectors.toList());
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/AbstractDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/AbstractDatastoreQuery.java
@@ -67,7 +67,7 @@ public abstract class AbstractDatastoreQuery<T> implements RepositoryQuery {
 	 */
 	protected Object[] convertCollectionParamToCompatibleArray(List<?> param) {
 		List converted = param.stream()
-				.map((x) -> this.datastoreOperations.getDatastoreEntityConverter().getConversions().convertOnWriteSingle(x)
+				.map(x -> this.datastoreOperations.getDatastoreEntityConverter().getConversions().convertOnWriteSingle(x)
 						.get())
 				.collect(Collectors.toList());
 		return converted.toArray(

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQuery.java
@@ -337,7 +337,7 @@ public class PartTreeDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 
 	private void applySelectWithFilter(Object[] parameters, Builder builder) {
 		Iterator it = Arrays.asList(parameters).iterator();
-		Filter[] filters = this.filterParts.stream().map((part) -> {
+		Filter[] filters = this.filterParts.stream().map(part -> {
 			//build properties chain for nested properties
 			//if the property is not nested, the list would contain only one property
 			List<DatastorePersistentProperty> propertiesChain = getPropertiesChain(part);
@@ -470,7 +470,7 @@ public class PartTreeDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 				collector = Collectors.counting();
 			}
 			else if (PartTreeDatastoreQuery.this.tree.isExistsProjection()) {
-				collector = Collectors.collectingAndThen(Collectors.counting(), (count) -> count > 0);
+				collector = Collectors.collectingAndThen(Collectors.counting(), count -> count > 0);
 			}
 			return collector;
 		}

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepository.java
@@ -67,7 +67,7 @@ public class SimpleDatastoreRepository<T, ID> implements DatastoreRepository<T, 
 
 	@Override
 	public <A> A performTransaction(Function<DatastoreRepository<T, ID>, A> operations) {
-		return this.datastoreTemplate.performTransaction((template) -> operations
+		return this.datastoreTemplate.performTransaction(template -> operations
 				.apply(new SimpleDatastoreRepository<>(template, this.entityType)));
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplateTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplateTests.java
@@ -173,7 +173,7 @@ public class DatastoreTemplateTests {
 		// The readWriteConversions are only mocked for purposes of collection-conversion
 		// for
 		// descendants. no other conversions take place in the template.
-		doAnswer((invocation) -> new LinkedList<>(invocation.getArgument(0)))
+		doAnswer(invocation -> new LinkedList<>(invocation.getArgument(0)))
 				.when(this.readWriteConversions).convertOnRead(any(), any(), (Class) any());
 
 		this.ob1 = new TestEntity();
@@ -213,13 +213,13 @@ public class DatastoreTemplateTests {
 
 		// mocked query results for entities and child entities.
 		QueryResults childTestEntityQueryResults = mock(QueryResults.class);
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Arrays.asList(ce1).iterator().forEachRemaining(invocation.getArgument(0));
 			return null;
 		}).when(childTestEntityQueryResults).forEachRemaining(any());
 
 		QueryResults testEntityQueryResults = mock(QueryResults.class);
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Arrays.asList(this.e1, this.e2).iterator()
 					.forEachRemaining(invocation.getArgument(0));
 			return null;
@@ -244,14 +244,14 @@ public class DatastoreTemplateTests {
 		when(this.datastoreEntityConverter.read(eq(ChildEntity.class), same(ce1)))
 				.thenAnswer(invocationOnMock -> createChildEntity());
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			FullEntity.Builder builder = invocation.getArgument(1);
 			builder.set("color", "simple_test_color");
 			builder.set("int_field", 1);
 			return null;
 		}).when(this.datastoreEntityConverter).write(same(this.simpleTestEntity), any());
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			FullEntity.Builder builder = invocation.getArgument(1);
 			builder.set("color", NullValue.of());
 			builder.set("int_field", NullValue.of());
@@ -267,7 +267,7 @@ public class DatastoreTemplateTests {
 
 		// Because get() takes varags, there is difficulty in matching the single param
 		// case using just thenReturn.
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Object key = invocation.getArgument(0);
 			List<Entity> result = new ArrayList<>();
 			if (key instanceof Key) {
@@ -369,7 +369,7 @@ public class DatastoreTemplateTests {
 
 		DatastoreReaderWriter transactionContext = mock(DatastoreReaderWriter.class);
 
-		when(this.datastore.runInTransaction(any())).thenAnswer((invocation) -> {
+		when(this.datastore.runInTransaction(any())).thenAnswer(invocation -> {
 			TransactionCallable<String> callable = invocation.getArgument(0);
 			return callable.run(transactionContext);
 		});
@@ -379,7 +379,7 @@ public class DatastoreTemplateTests {
 		when(transactionContext.fetch(ArgumentMatchers.<Key[]>any())).thenReturn(e1);
 
 		String finalResult = this.datastoreTemplate
-				.performTransaction((datastoreOperations) -> {
+				.performTransaction(datastoreOperations -> {
 					datastoreOperations.save(this.ob2);
 					datastoreOperations.findById("ignored", TestEntity.class);
 					return "all done";
@@ -839,7 +839,7 @@ public class DatastoreTemplateTests {
 	private boolean nextPageTest(boolean hasNextPage) {
 		QueryResults<Key> queryResults = mock(QueryResults.class);
 		when(queryResults.getResultClass()).thenReturn((Class) Key.class);
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Arrays.asList(this.key1, this.key2).iterator()
 					.forEachRemaining(invocation.getArgument(0));
 			return null;
@@ -871,7 +871,7 @@ public class DatastoreTemplateTests {
 	public void countTest() {
 		QueryResults<Key> queryResults = mock(QueryResults.class);
 		when(queryResults.getResultClass()).thenReturn((Class) Key.class);
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Arrays.asList(this.key1, this.key2).iterator()
 					.forEachRemaining(invocation.getArgument(0));
 			return null;
@@ -944,7 +944,7 @@ public class DatastoreTemplateTests {
 	public void deleteAllTest() {
 		QueryResults<Key> queryResults = mock(QueryResults.class);
 		when(queryResults.getResultClass()).thenReturn((Class) Key.class);
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Arrays.asList(this.key1, this.key2).iterator()
 					.forEachRemaining(invocation.getArgument(0));
 			return null;
@@ -968,7 +968,7 @@ public class DatastoreTemplateTests {
 
 		InOrder inOrder = Mockito.inOrder(mockBeforePublisher, this.datastore, mockAfterPublisher);
 
-		doAnswer((invocationOnMock) -> {
+		doAnswer(invocationOnMock -> {
 			ApplicationEvent event = invocationOnMock.getArgument(0);
 			if (expectedBefore != null && event.getClass().equals(expectedBefore.getClass())) {
 				mockBeforePublisher.publishEvent(event);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/DatastoreTransactionTemplateTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/DatastoreTransactionTemplateTests.java
@@ -97,13 +97,13 @@ public class DatastoreTransactionTemplateTests {
 		when(this.objectToKeyFactory.allocateKeyForObject(any(), any()))
 				.thenReturn(this.key);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			List result = new ArrayList<>();
 			result.add(null);
 			return result;
 		}).when(this.transaction).fetch((Key[]) any());
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			List result = new ArrayList<>();
 			result.add(null);
 			return result;

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DatastoreServiceObjectToKeyFactoryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DatastoreServiceObjectToKeyFactoryTests.java
@@ -119,7 +119,7 @@ public class DatastoreServiceObjectToKeyFactoryTests {
 	public void allocateIdForObjectTest() {
 		TestEntityWithKeyId testEntityWithKeyId = new TestEntityWithKeyId();
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			IncompleteKey incompleteKey = (IncompleteKey) invocation.getArguments()[0];
 			long id = 123L;
 			if (incompleteKey.getAncestors().size() > 0) {

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
@@ -442,7 +442,7 @@ public class DefaultDatastoreEntityConverterTests {
 											@Override
 											public List<String> convert(ComparableBeanContextSupport bcs) {
 												List<String> list = new ArrayList<>();
-												bcs.iterator().forEachRemaining((s) -> list.add((String) s));
+												bcs.iterator().forEachRemaining(s -> list.add((String) s));
 												return list;
 											}
 										})),
@@ -716,7 +716,7 @@ public class DefaultDatastoreEntityConverterTests {
 		Entity entity = builder.build();
 
 		assertThat(entity.getList("listOfEmbeddedEntities").stream()
-				.map((val) -> ((BaseEntity<?>) val.get()).getString("stringField")).collect(Collectors.toList()))
+				.map(val -> ((BaseEntity<?>) val.get()).getString("stringField")).collect(Collectors.toList()))
 						.as("validate embedded entity").isEqualTo(Arrays.asList("item 0", "item 1"));
 
 		assertThat(entity.getEntity("embeddedEntityField").getString("stringField"))

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastorePersistentEntityImplTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastorePersistentEntityImplTests.java
@@ -125,7 +125,7 @@ public class DatastorePersistentEntityImplTests {
 		PersistentPropertyAccessor accessor = p.getPropertyAccessor(t);
 
 		p.doWithProperties(
-				(SimplePropertyHandler) (property) -> assertThat(accessor.getProperty(property)).isNotEqualTo("b"));
+				(SimplePropertyHandler) property -> assertThat(accessor.getProperty(property)).isNotEqualTo("b"));
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastorePersistentPropertyImplTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastorePersistentPropertyImplTests.java
@@ -50,7 +50,7 @@ public class DatastorePersistentPropertyImplTests {
 	public void propertiesTest() {
 		this.datastoreMappingContext.getPersistentEntity(TestEntity.class)
 				.doWithProperties(
-						(PropertyHandler<DatastorePersistentProperty>) (property) -> {
+						(PropertyHandler<DatastorePersistentProperty>) property -> {
 							if (property.isIdProperty()) {
 								assertThat(property.getFieldName()).isEqualTo("__key__");
 							}
@@ -88,7 +88,7 @@ public class DatastorePersistentPropertyImplTests {
 	@Test
 	public void testAssociations() {
 		this.datastoreMappingContext.getPersistentEntity(TestEntity.class)
-				.doWithProperties((PropertyHandler<DatastorePersistentProperty>) (prop) -> {
+				.doWithProperties((PropertyHandler<DatastorePersistentProperty>) prop -> {
 					assertThat(prop).isSameAs(
 							((DatastorePersistentPropertyImpl) prop).createAssociation().getInverse());
 					assertThat(((DatastorePersistentPropertyImpl) prop).createAssociation().getObverse()).isNull();

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
@@ -436,13 +436,13 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		assertThat(circles.getTotalElements()).isEqualTo(3L);
 		assertThat(circles.getTotalPages()).isEqualTo(2);
 		assertThat(circles.get().count()).isEqualTo(2L);
-		assertThat(circles.get().allMatch((e) -> e.getShape().equals(Shape.CIRCLE))).isTrue();
+		assertThat(circles.get().allMatch(e -> e.getShape().equals(Shape.CIRCLE))).isTrue();
 
 		Page<TestEntity> circlesNext = this.testEntityRepository.findByShape(Shape.CIRCLE, circles.nextPageable());
 		assertThat(circlesNext.getTotalElements()).isEqualTo(3L);
 		assertThat(circlesNext.getTotalPages()).isEqualTo(2);
 		assertThat(circlesNext.get().count()).isEqualTo(1L);
-		assertThat(circlesNext.get().allMatch((e) -> e.getShape().equals(Shape.CIRCLE))).isTrue();
+		assertThat(circlesNext.get().allMatch(e -> e.getShape().equals(Shape.CIRCLE))).isTrue();
 
 		assertThat(this.testEntityRepository.findByEnumQueryParam(Shape.SQUARE).stream()
 				.map(TestEntity::getId).collect(Collectors.toList())).contains(4L);
@@ -617,11 +617,11 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		AncestorEntity loadedEntity = this.datastoreTemplate.findById(ancestorEntity.id, AncestorEntity.class);
 		assertThat(loadedEntity).isEqualTo(ancestorEntity);
 
-		ancestorEntity.descendants.forEach((descendatEntry) -> descendatEntry.name = descendatEntry.name + " updated");
+		ancestorEntity.descendants.forEach(descendatEntry -> descendatEntry.name = descendatEntry.name + " updated");
 		this.datastoreTemplate.save(ancestorEntity);
 		waitUntilTrue(() ->
 				this.datastoreTemplate.findAll(AncestorEntity.DescendantEntry.class)
-						.stream().allMatch((descendatEntry) -> descendatEntry.name.contains("updated")));
+						.stream().allMatch(descendatEntry -> descendatEntry.name.contains("updated")));
 
 		AncestorEntity loadedEntityAfterUpdate =
 				this.datastoreTemplate.findById(ancestorEntity.id, AncestorEntity.class);
@@ -636,14 +636,14 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		assertThat(loadedParent).isEqualTo(parent);
 
 		parent.name = "parent updated";
-		parent.children.forEach((child) -> child.name = child.name + " updated");
+		parent.children.forEach(child -> child.name = child.name + " updated");
 		parent.sibling.name = "sibling updated";
 
 		this.datastoreTemplate.save(parent);
 
 		waitUntilTrue(() ->
 				this.datastoreTemplate.findAll(ReferenceEntry.class)
-						.stream().allMatch((entry) -> entry.name.contains("updated")));
+						.stream().allMatch(entry -> entry.name.contains("updated")));
 
 		ReferenceEntry loadedParentAfterUpdate = this.datastoreTemplate.findById(parent.id, ReferenceEntry.class);
 		assertThat(loadedParentAfterUpdate).isEqualTo(parent);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/DatastoreQueryLookupStrategyTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/DatastoreQueryLookupStrategyTests.java
@@ -81,7 +81,7 @@ public class DatastoreQueryLookupStrategyTests {
 				.thenReturn(parameters);
 
 		when(parameters.getNumberOfParameters()).thenReturn(1);
-		when(parameters.getParameter(anyInt())).thenAnswer((invocation) -> {
+		when(parameters.getParameter(anyInt())).thenAnswer(invocation -> {
 			Parameter param = mock(Parameter.class);
 			when(param.getName()).thenReturn(Optional.of("tag"));
 			Mockito.<Class>when(param.getType()).thenReturn(Object.class);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQueryTests.java
@@ -163,7 +163,7 @@ public class GqlDatastoreQueryTests {
 
 		GqlDatastoreQuery gqlDatastoreQuery = createQuery(gql, false, false);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			GqlQuery statement = invocation.getArgument(0);
 
 			assertThat(statement.getQueryString()).isEqualTo(entityResolvedGql);
@@ -225,7 +225,7 @@ public class GqlDatastoreQueryTests {
 
 		GqlDatastoreQuery gqlDatastoreQuery = createQuery(gql, false, false);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			GqlQuery statement = invocation.getArgument(0);
 
 			assertThat(statement.getQueryString()).isEqualTo("SELECT * FROM trades WHERE price=@price LIMIT @limit OFFSET @offset");
@@ -263,7 +263,7 @@ public class GqlDatastoreQueryTests {
 
 		GqlDatastoreQuery gqlDatastoreQuery = createQuery(gql, false, false);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			GqlQuery statement = invocation.getArgument(0);
 
 			assertThat(statement.getQueryString())
@@ -304,7 +304,7 @@ public class GqlDatastoreQueryTests {
 
 		Cursor cursor = Cursor.copyFrom("abc".getBytes());
 		List<Map> params = new ArrayList<>();
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			GqlQuery statement = invocation.getArgument(0);
 
 			assertThat(statement.getQueryString()).isEqualTo("SELECT * FROM trades WHERE price=@price LIMIT @limit OFFSET @offset");
@@ -318,7 +318,7 @@ public class GqlDatastoreQueryTests {
 		}).when(this.datastoreTemplate).queryKeysOrEntities(any(), eq(Trade.class));
 
 		doReturn(false).when(gqlDatastoreQuery).isNonEntityReturnedType(any());
-		doAnswer((invocation) -> invocation.getArgument(0)).when(gqlDatastoreQuery)
+		doAnswer(invocation -> invocation.getArgument(0)).when(gqlDatastoreQuery)
 				.processRawObjectForProjection(any());
 
 		Slice result = (Slice) gqlDatastoreQuery.execute(paramVals);
@@ -359,7 +359,7 @@ public class GqlDatastoreQueryTests {
 
 		Cursor cursor = Cursor.copyFrom("abc".getBytes());
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			GqlQuery statement = invocation.getArgument(0);
 
 			assertThat(statement.getQueryString().equals(gql) || statement.getQueryString().equals(expected))
@@ -382,7 +382,7 @@ public class GqlDatastoreQueryTests {
 		}).when(this.datastoreTemplate).queryKeysOrEntities(any(), eq(Trade.class));
 
 		doReturn(false).when(gqlDatastoreQuery).isNonEntityReturnedType(any());
-		doAnswer((invocation) -> invocation.getArgument(0)).when(gqlDatastoreQuery)
+		doAnswer(invocation -> invocation.getArgument(0)).when(gqlDatastoreQuery)
 				.processRawObjectForProjection(any());
 
 		Slice result = (Page) gqlDatastoreQuery.execute(paramVals);
@@ -419,7 +419,7 @@ public class GqlDatastoreQueryTests {
 
 		Cursor cursor = Cursor.copyFrom("abc".getBytes());
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			GqlQuery statement = invocation.getArgument(0);
 
 			assertThat(statement.getQueryString()).isEqualTo(expected);
@@ -433,7 +433,7 @@ public class GqlDatastoreQueryTests {
 		}).when(this.datastoreTemplate).queryKeysOrEntities(any(), eq(Trade.class));
 
 		doReturn(false).when(gqlDatastoreQuery).isNonEntityReturnedType(any());
-		doAnswer((invocation) -> invocation.getArgument(0)).when(gqlDatastoreQuery)
+		doAnswer(invocation -> invocation.getArgument(0)).when(gqlDatastoreQuery)
 				.processRawObjectForProjection(any());
 
 		Slice result = (Page) gqlDatastoreQuery.execute(paramVals);
@@ -454,7 +454,7 @@ public class GqlDatastoreQueryTests {
 				.thenReturn(parameters);
 
 		when(parameters.getNumberOfParameters()).thenReturn(paramNames.length);
-		when(parameters.getParameter(anyInt())).thenAnswer((invocation) -> {
+		when(parameters.getParameter(anyInt())).thenAnswer(invocation -> {
 			int index = invocation.getArgument(0);
 			Parameter param = mock(Parameter.class);
 			when(param.getName())

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
@@ -143,8 +143,8 @@ public class PartTreeDatastoreQueryTests {
 		PartTreeDatastoreQuery<Trade> spy = spy(tradePartTreeDatastoreQuery);
 		doReturn(isPageQuery).when(spy).isPageQuery();
 		doReturn(isSliceQuery).when(spy).isSliceQuery();
-		doAnswer((invocation) -> invocation.getArguments()[0]).when(spy).processRawObjectForProjection(any());
-		doAnswer((invocation) -> invocation.getArguments()[0]).when(spy).convertResultCollection(any(), isNotNull());
+		doAnswer(invocation -> invocation.getArguments()[0]).when(spy).processRawObjectForProjection(any());
+		doAnswer(invocation -> invocation.getArguments()[0]).when(spy).convertResultCollection(any(), isNotNull());
 
 		return spy;
 	}
@@ -167,7 +167,7 @@ public class PartTreeDatastoreQueryTests {
 				// this int param requires custom conversion
 				8, 3.33, "abc" };
 
-		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer(invocation -> {
 			EntityQuery statement = invocation.getArgument(0);
 
 			EntityQuery expected = StructuredQuery.newEntityQueryBuilder()
@@ -214,7 +214,7 @@ public class PartTreeDatastoreQueryTests {
 				// this int param requires custom conversion
 				8, 3.33, "abc" };
 
-		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer(invocation -> {
 			StructuredQuery statement = invocation.getArgument(0);
 
 			StructuredQuery expected = StructuredQuery.newProjectionEntityQueryBuilder()
@@ -249,7 +249,7 @@ public class PartTreeDatastoreQueryTests {
 
 		Object[] params = new Object[] { "BUY", "abcd", 8.88, 3.33, PageRequest.of(1, 444, Sort.Direction.ASC, "price") };
 
-		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer(invocation -> {
 			EntityQuery statement = invocation.getArgument(0);
 
 			EntityQuery expected = StructuredQuery.newEntityQueryBuilder()
@@ -280,7 +280,7 @@ public class PartTreeDatastoreQueryTests {
 
 		Object[] params = new Object[] { "BUY", "abcd", 8.88, 3.33, null};
 
-		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer(invocation -> {
 			EntityQuery statement = invocation.getArgument(0);
 
 			EntityQuery expected = StructuredQuery.newEntityQueryBuilder()
@@ -310,7 +310,7 @@ public class PartTreeDatastoreQueryTests {
 
 		Object[] params = new Object[] { "BUY", "abcd", 8.88, 3.33, Sort.by(Sort.Direction.ASC, "price") };
 
-		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer(invocation -> {
 			EntityQuery statement = invocation.getArgument(0);
 
 			EntityQuery expected = StructuredQuery.newEntityQueryBuilder()
@@ -339,7 +339,7 @@ public class PartTreeDatastoreQueryTests {
 
 		Object[] params = new Object[] { "BUY", "abcd", 8.88, 3.33, null };
 
-		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer(invocation -> {
 			EntityQuery statement = invocation.getArgument(0);
 
 			EntityQuery expected = StructuredQuery.newEntityQueryBuilder()
@@ -394,7 +394,7 @@ public class PartTreeDatastoreQueryTests {
 
 		Object[] params = new Object[] { "BUY", "abcd", 8.88, 3.33, PageRequest.of(1, 444, Sort.Direction.DESC, "id") };
 
-		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer(invocation -> {
 			EntityQuery statement = invocation.getArgument(0);
 
 			EntityQuery expected = StructuredQuery.newEntityQueryBuilder()
@@ -562,7 +562,7 @@ public class PartTreeDatastoreQueryTests {
 
 	private void preparePageResults(int offset, Integer limit, Cursor cursor,
 			List<Integer> pageResults, List<Integer> fullResults) {
-		when(this.datastoreTemplate.queryKeysOrEntities(isA(EntityQuery.class), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryKeysOrEntities(isA(EntityQuery.class), any())).thenAnswer(invocation -> {
 			EntityQuery statement = invocation.getArgument(0);
 			EntityQuery expected = StructuredQuery.newEntityQueryBuilder()
 					.setFilter(FILTER)
@@ -575,7 +575,7 @@ public class PartTreeDatastoreQueryTests {
 			return new DatastoreResultsIterable(pageResults.iterator(), Cursor.copyFrom("abc".getBytes()));
 		});
 
-		when(this.datastoreTemplate.queryKeysOrEntities(isA(KeyQuery.class), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryKeysOrEntities(isA(KeyQuery.class), any())).thenAnswer(invocation -> {
 			KeyQuery statement = invocation.getArgument(0);
 			KeyQuery expected = StructuredQuery.newKeyQueryBuilder()
 					.setFilter(FILTER)
@@ -590,7 +590,7 @@ public class PartTreeDatastoreQueryTests {
 	private void prepareSliceResults(int offset, Integer queryLimit, Boolean hasNext) {
 		Cursor cursor = Cursor.copyFrom("abc".getBytes());
 		List<Integer> datastoreMatchingRecords = Arrays.asList(3, 4, 5);
-		when(this.datastoreTemplate.queryEntitiesSlice(isA(EntityQuery.class), any(), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryEntitiesSlice(isA(EntityQuery.class), any(), any())).thenAnswer(invocation -> {
 			EntityQuery statement = invocation.getArgument(0);
 			EntityQuery expected = StructuredQuery.newEntityQueryBuilder()
 					.setFilter(FILTER)
@@ -660,7 +660,7 @@ public class PartTreeDatastoreQueryTests {
 	private void prepareDeleteResults(boolean isCollection) {
 		Cursor cursor = Cursor.copyFrom("abc".getBytes());
 		List<Integer> datastoreMatchingRecords = Arrays.asList(3, 4, 5);
-		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer(invocation -> {
 			StructuredQuery<?> statement = invocation.getArgument(0);
 			StructuredQuery.Builder builder = isCollection ? StructuredQuery.newEntityQueryBuilder()
 					: StructuredQuery.newKeyQueryBuilder();
@@ -750,7 +750,7 @@ public class PartTreeDatastoreQueryTests {
 
 		PartTreeDatastoreQuery spyQuery = this.partTreeDatastoreQuery;
 
-		doAnswer((invocation) -> invocation.getArgument(0)).when(spyQuery)
+		doAnswer(invocation -> invocation.getArgument(0)).when(spyQuery)
 				.processRawObjectForProjection(any());
 
 		Object[] params = new Object[] { "BUY", };
@@ -764,7 +764,7 @@ public class PartTreeDatastoreQueryTests {
 
 		PartTreeDatastoreQuery spyQuery = this.partTreeDatastoreQuery;
 
-		doAnswer((invocation) -> invocation.getArgument(0)).when(spyQuery)
+		doAnswer(invocation -> invocation.getArgument(0)).when(spyQuery)
 				.processRawObjectForProjection(any());
 
 		Object[] params = new Object[] { "BUY", };
@@ -779,7 +779,7 @@ public class PartTreeDatastoreQueryTests {
 
 		Object[] params = new Object[] { "BUY", };
 
-		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer(invocation -> {
 			EntityQuery statement = invocation.getArgument(0);
 
 			EntityQuery expected = StructuredQuery.newEntityQueryBuilder()
@@ -804,10 +804,10 @@ public class PartTreeDatastoreQueryTests {
 
 		Object[] params = new Object[] { "BUY", "id1"};
 		when(this.datastoreTemplate.createKey("trades", "id1"))
-				.thenAnswer((invocation) ->
+				.thenAnswer(invocation ->
 						Key.newBuilder("project", invocation.getArgument(0), invocation.getArgument(1)).build());
 
-			when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer((invocation) -> {
+			when(this.datastoreTemplate.queryKeysOrEntities(any(), any())).thenAnswer(invocation -> {
 			EntityQuery statement = invocation.getArgument(0);
 
 			EntityQuery expected = StructuredQuery.newEntityQueryBuilder()

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepositoryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepositoryTests.java
@@ -142,13 +142,13 @@ public class SimpleDatastoreRepositoryTests {
 
 	@Test
 	public void runTransactionCallableTest() {
-		when(this.datastoreTemplate.performTransaction(any())).thenAnswer((invocation) -> {
+		when(this.datastoreTemplate.performTransaction(any())).thenAnswer(invocation -> {
 			Function<DatastoreOperations, String> f = invocation.getArgument(0);
 			return f.apply(this.datastoreTemplate);
 		});
 
 		String result = new SimpleDatastoreRepository<Object, String>(this.datastoreTemplate, Object.class)
-				.performTransaction((repo) -> "test");
+				.performTransaction(repo -> "test");
 		assertThat(result).isEqualTo("test");
 	}
 
@@ -206,12 +206,12 @@ public class SimpleDatastoreRepositoryTests {
 		Example<Object> example = Example.of(new Object());
 		Sort sort = Sort.by("id");
 
-		doAnswer((invocationOnMock) -> new DatastoreResultsIterable(Arrays.asList(1, 2), null))
+		doAnswer(invocationOnMock -> new DatastoreResultsIterable(Arrays.asList(1, 2), null))
 				.when(this.datastoreTemplate).queryByExample(same(example),
 						eq(new DatastoreQueryOptions.Builder().setLimit(2).setOffset(2).setSort(sort)
 								.build()));
 
-		doAnswer((invocationOnMock) -> new DatastoreResultsIterable(Arrays.asList(1, 2, 3, 4, 5), null))
+		doAnswer(invocationOnMock -> new DatastoreResultsIterable(Arrays.asList(1, 2, 3, 4, 5), null))
 				.when(this.datastoreTemplate).keyQueryByExample(same(example), isNull());
 
 
@@ -231,18 +231,18 @@ public class SimpleDatastoreRepositoryTests {
 		Sort sort = Sort.by("id");
 		Cursor cursor = Cursor.copyFrom("abc".getBytes());
 
-		doAnswer((invocationOnMock) -> new DatastoreResultsIterable(Arrays.asList(1, 2), cursor))
+		doAnswer(invocationOnMock -> new DatastoreResultsIterable(Arrays.asList(1, 2), cursor))
 				.when(this.datastoreTemplate).queryByExample(same(example),
 						eq(new DatastoreQueryOptions.Builder().setLimit(2).setOffset(0).setSort(sort)
 								.build()));
 
-		doAnswer((invocationOnMock) -> new DatastoreResultsIterable(Arrays.asList(3, 4), null))
+		doAnswer(invocationOnMock -> new DatastoreResultsIterable(Arrays.asList(3, 4), null))
 				.when(this.datastoreTemplate).queryByExample(same(example),
 						eq(new DatastoreQueryOptions.Builder().setLimit(2).setOffset(2).setSort(sort).setCursor(cursor)
 								.build()));
 
 
-		doAnswer((invocationOnMock) -> new DatastoreResultsIterable(Arrays.asList(1, 2, 3, 4, 5), null))
+		doAnswer(invocationOnMock -> new DatastoreResultsIterable(Arrays.asList(1, 2, 3, 4, 5), null))
 				.when(this.datastoreTemplate).keyQueryByExample(same(example), isNull());
 
 
@@ -275,7 +275,7 @@ public class SimpleDatastoreRepositoryTests {
 	public void findOneByExample() {
 		Example<Object> example = Example.of(new Object());
 
-		doAnswer((invocationOnMock) -> new DatastoreResultsIterable(Arrays.asList(1), null))
+		doAnswer(invocationOnMock -> new DatastoreResultsIterable(Arrays.asList(1), null))
 				.when(this.datastoreTemplate).queryByExample(same(example),
 				eq(new DatastoreQueryOptions.Builder().setLimit(1).build()));
 
@@ -290,7 +290,7 @@ public class SimpleDatastoreRepositoryTests {
 	public void existsByExampleTrue() {
 		Example<Object> example2 = Example.of(new Object());
 
-		doAnswer((invocationOnMock) -> Arrays.asList(1))
+		doAnswer(invocationOnMock -> Arrays.asList(1))
 				.when(this.datastoreTemplate).keyQueryByExample(same(example2),
 						eq(new DatastoreQueryOptions.Builder().setLimit(1).build()));
 
@@ -304,7 +304,7 @@ public class SimpleDatastoreRepositoryTests {
 	public void existsByExampleFalse() {
 		Example<Object> example2 = Example.of(new Object());
 
-		doAnswer((invocationOnMock) -> Arrays.asList())
+		doAnswer(invocationOnMock -> Arrays.asList())
 				.when(this.datastoreTemplate).keyQueryByExample(same(example2),
 						eq(new DatastoreQueryOptions.Builder().setLimit(1).build()));
 
@@ -318,7 +318,7 @@ public class SimpleDatastoreRepositoryTests {
 	public void countByExample() {
 		Example<Object> example2 = Example.of(new Object());
 
-		doAnswer((invocationOnMock) -> Arrays.asList(1, 2, 3))
+		doAnswer(invocationOnMock -> Arrays.asList(1, 2, 3))
 				.when(this.datastoreTemplate).keyQueryByExample(same(example2), isNull());
 
 		assertThat(this.simpleDatastoreRepository.count(example2)).isEqualTo(3);
@@ -330,7 +330,7 @@ public class SimpleDatastoreRepositoryTests {
 	public void countByExampleZero() {
 		Example<Object> example1 = Example.of(new Object());
 
-		doAnswer((invocationOnMock) -> new ArrayList<>())
+		doAnswer(invocationOnMock -> new ArrayList<>())
 				.when(this.datastoreTemplate).keyQueryByExample(same(example1), isNull());
 
 		assertThat(this.simpleDatastoreRepository.count(example1)).isZero();

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/transaction/ReactiveFirestoreTransactionManager.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/transaction/ReactiveFirestoreTransactionManager.java
@@ -105,7 +105,7 @@ public class ReactiveFirestoreTransactionManager extends AbstractReactiveTransac
 
 			return ObservableReactiveUtil
 					.<CommitResponse>unaryCall(obs -> this.firestore.commit(builder.build(), obs))
-					.flatMap((response) -> {
+					.flatMap(response -> {
 								for (Object entity : resourceHolder.getEntities()) {
 									this.classMapper.setUpdateTime(entity, Timestamp.fromProto(response.getCommitTime()));
 								}

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerMutationFactoryImpl.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerMutationFactoryImpl.java
@@ -136,7 +136,7 @@ public class SpannerMutationFactoryImpl implements SpannerMutationFactory {
 		this.spannerEntityProcessor.write(object, writeBuilder::set, includeProperties);
 		mutations.add(writeBuilder.build());
 
-		persistentEntity.doWithInterleavedProperties((spannerPersistentProperty) -> {
+		persistentEntity.doWithInterleavedProperties(spannerPersistentProperty -> {
 			if (includeProperties == null
 					|| includeProperties.contains(spannerPersistentProperty.getName())) {
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerTemplate.java
@@ -124,11 +124,11 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 	}
 
 	protected ReadContext getReadContext() {
-		return doWithOrWithoutTransactionContext((x) -> x, this.databaseClientProvider.get()::singleUse);
+		return doWithOrWithoutTransactionContext(x -> x, this.databaseClientProvider.get()::singleUse);
 	}
 
 	protected ReadContext getReadContext(TimestampBound timestampBound) {
-		return doWithOrWithoutTransactionContext((x) -> x,
+		return doWithOrWithoutTransactionContext(x -> x,
 				() -> this.databaseClientProvider.get().singleUse(timestampBound));
 	}
 
@@ -144,7 +144,7 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 	public long executeDmlStatement(Statement statement) {
 		Assert.notNull(statement, "A non-null statement is required.");
 		maybeEmitEvent(new BeforeExecuteDmlEvent(statement));
-		long rowsAffected = doWithOrWithoutTransactionContext((x) -> x.executeUpdate(statement),
+		long rowsAffected = doWithOrWithoutTransactionContext(x -> x.executeUpdate(statement),
 				() -> this.databaseClientProvider.get().readWriteTransaction()
 						.run(transactionContext -> transactionContext.executeUpdate(statement)));
 		maybeEmitEvent(new AfterExecuteDmlEvent(statement, rowsAffected));
@@ -298,7 +298,7 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 	@Override
 	public void updateAll(Iterable<?> objects) {
 		applySaveMutations(() -> getMutationsForMultipleObjects(objects,
-				(x) -> this.mutationFactory.update(x, null)), objects, null);
+				x -> this.mutationFactory.update(x, null)), objects, null);
 	}
 
 	@Override
@@ -323,7 +323,7 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 	@Override
 	public void upsertAll(Iterable<?> objects) {
 		applySaveMutations(() -> getMutationsForMultipleObjects(objects,
-				(x) -> this.mutationFactory.upsert(x, null)), objects, null);
+				x -> this.mutationFactory.upsert(x, null)), objects, null);
 	}
 
 	@Override
@@ -398,7 +398,7 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 
 	@Override
 	public <T> T performReadWriteTransaction(Function<SpannerTemplate, T> operations) {
-		return doWithOrWithoutTransactionContext((x) -> {
+		return doWithOrWithoutTransactionContext(x -> {
 			throw new IllegalStateException("There is already declarative transaction open. " +
 					"Spanner does not support nested transactions");
 		}, () -> this.databaseClientProvider.get().readWriteTransaction()
@@ -423,7 +423,7 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 	@Override
 	public <T> T performReadOnlyTransaction(Function<SpannerTemplate, T> operations,
 			SpannerReadOptions readOptions) {
-		return doWithOrWithoutTransactionContext((x) -> {
+		return doWithOrWithoutTransactionContext(x -> {
 			throw new IllegalStateException("There is already declarative transaction open. " +
 					"Spanner does not support nested transactions");
 		}, () -> {
@@ -555,7 +555,7 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 
 	protected void applyMutations(Collection<Mutation> mutations) {
 		LOGGER.debug("Applying Mutation: " + mutations);
-		doWithOrWithoutTransactionContext((x) -> {
+		doWithOrWithoutTransactionContext(x -> {
 			x.buffer(mutations);
 			return null;
 		}, () -> {
@@ -593,7 +593,7 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 		PersistentPropertyAccessor<?> accessor = spannerPersistentEntity
 				.getPropertyAccessor(entity);
 		spannerPersistentEntity.doWithInterleavedProperties(
-				(spannerPersistentProperty) -> {
+				spannerPersistentProperty -> {
 					if (includeProperties != null && !includeProperties
 							.contains(spannerPersistentEntity.getName())) {
 						return;
@@ -623,7 +623,7 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 	private List<Mutation> getMutationsForMultipleObjects(Iterable<?> it,
 			Function<Object, Collection<Mutation>> individualEntityMutationFunc) {
 		return StreamSupport.stream(it.spliterator(), false)
-				.flatMap((x) -> individualEntityMutationFunc.apply(x).stream())
+				.flatMap(x -> individualEntityMutationFunc.apply(x).stream())
 				.collect(Collectors.toList());
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtils.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtils.java
@@ -232,7 +232,7 @@ public class SpannerSchemaUtils {
 			SpannerPersistentEntity<T> spannerPersistentEntity,
 			StringJoiner stringJoiner) {
 		spannerPersistentEntity.doWithColumnBackedProperties(
-				(spannerPersistentProperty) -> {
+				spannerPersistentProperty -> {
 					if (spannerPersistentProperty.isEmbedded()) {
 						addColumnDdlStrings(
 								this.mappingContext.getPersistentEntityOrFail(spannerPersistentProperty.getType()),
@@ -285,7 +285,7 @@ public class SpannerSchemaUtils {
 		SpannerPersistentEntity spannerPersistentEntity =
 				this.mappingContext.getPersistentEntityOrFail(entityClass);
 		spannerPersistentEntity.doWithInterleavedProperties(
-				(PropertyHandler<SpannerPersistentProperty>) (spannerPersistentProperty) ->
+				(PropertyHandler<SpannerPersistentProperty>) spannerPersistentProperty ->
 						getDdlStringForInterleavedHierarchy(
 						spannerPersistentEntity.tableName(),
 						spannerPersistentProperty.getColumnInnerType(), ddlStrings,

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConversionUtils.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConversionUtils.java
@@ -57,7 +57,7 @@ public final class ConversionUtils {
 	static <T> Iterable<T> convertIterable(
 			Iterable<Object> source, Class<T> targetType, SpannerCustomConverter converter) {
 		List<T> result = new ArrayList<>();
-		source.forEach((item) -> result.add(converter.convert(item, targetType)));
+		source.forEach(item -> result.add(converter.convert(item, targetType)));
 		return result;
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessor.java
@@ -107,7 +107,7 @@ public class ConverterAwareMappingSpannerEntityProcessor implements SpannerEntit
 				return originalType;
 			}
 			compatible = ConverterAwareMappingSpannerEntityWriter.findFirstCompatibleSpannerMultipleItemNativeType(
-					(spannerType) -> canHandlePropertyTypeForArrayRead(originalType, spannerType)
+					spannerType -> canHandlePropertyTypeForArrayRead(originalType, spannerType)
 							&& this.writeConverter.canConvert(originalType, spannerType));
 		}
 		else {
@@ -117,7 +117,7 @@ public class ConverterAwareMappingSpannerEntityProcessor implements SpannerEntit
 			}
 			compatible = ConverterAwareMappingSpannerEntityWriter
 					.findFirstCompatibleSpannerSingleItemNativeType(
-							(spannerType) -> canHandlePropertyTypeForSingularRead(originalType, spannerType)
+							spannerType -> canHandlePropertyTypeForSingularRead(originalType, spannerType)
 									&& this.writeConverter.canConvert(originalType, spannerType));
 		}
 		return compatible;

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReader.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReader.java
@@ -94,7 +94,7 @@ class ConverterAwareMappingSpannerEntityReader implements SpannerEntityReader {
 		PersistentPropertyAccessor accessor = persistentEntity.getPropertyAccessor(instance);
 
 		persistentEntity.doWithProperties(
-				(PropertyHandler<SpannerPersistentProperty>) (spannerPersistentProperty) -> {
+				(PropertyHandler<SpannerPersistentProperty>) spannerPersistentProperty -> {
 					if (spannerPersistentProperty.isEmbedded()) {
 						accessor.setProperty(spannerPersistentProperty,
 								read(spannerPersistentProperty.getType(), source,

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -147,7 +147,7 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 		PersistentPropertyAccessor accessor = persistentEntity
 				.getPropertyAccessor(source);
 		persistentEntity.doWithColumnBackedProperties(
-				(spannerPersistentProperty) -> {
+				spannerPersistentProperty -> {
 					if (spannerPersistentProperty.isEmbedded()) {
 						Object embeddedObject = accessor
 								.getProperty(spannerPersistentProperty);
@@ -279,7 +279,7 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 		 * both the this key conversion and the write converter to choose the same.
 		 */
 		Class<?> compatible = ConverterAwareMappingSpannerEntityWriter
-				.findFirstCompatibleSpannerSingleItemNativeType((spannerType) -> isValidSpannerKeyType(spannerType)
+				.findFirstCompatibleSpannerSingleItemNativeType(spannerType -> isValidSpannerKeyType(spannerType)
 						&& this.writeConverter.canConvert(object.getClass(), spannerType));
 
 		if (compatible == null) {

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/SpannerTypeMapper.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/SpannerTypeMapper.java
@@ -74,7 +74,7 @@ public final class SpannerTypeMapper {
 		SPANNER_SIMPLE_COLUMN_CODES_TO_JAVA_TYPE_MAPPING
 				.keySet()
 				.forEach(
-						(type) -> builderMap.put(SPANNER_SIMPLE_COLUMN_CODES_TO_JAVA_TYPE_MAPPING.get(type), type));
+						type -> builderMap.put(SPANNER_SIMPLE_COLUMN_CODES_TO_JAVA_TYPE_MAPPING.get(type), type));
 		builderMap.put(double.class, Code.FLOAT64);
 		builderMap.put(long.class, Code.INT64);
 		JAVA_TYPE_TO_SPANNER_SIMPLE_COLUMN_TYPE_MAPPING = Collections.unmodifiableMap(builderMap);
@@ -85,7 +85,7 @@ public final class SpannerTypeMapper {
 		SPANNER_ARRAY_COLUMN_CODES_TO_JAVA_TYPE_MAPPING
 				.keySet()
 				.forEach(
-						(type) -> builderMap.put(SPANNER_ARRAY_COLUMN_CODES_TO_JAVA_TYPE_MAPPING.get(type), type));
+						type -> builderMap.put(SPANNER_ARRAY_COLUMN_CODES_TO_JAVA_TYPE_MAPPING.get(type), type));
 		JAVA_TYPE_TO_SPANNER_ARRAY_COLUMN_TYPE_MAPPING = Collections.unmodifiableMap(builderMap);
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImpl.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImpl.java
@@ -196,7 +196,7 @@ public class SpannerPersistentEntityImpl<T>
 	public void doWithInterleavedProperties(
 			PropertyHandler<SpannerPersistentProperty> handler) {
 		doWithProperties(
-				(PropertyHandler<SpannerPersistentProperty>) (spannerPersistentProperty) -> {
+				(PropertyHandler<SpannerPersistentProperty>) spannerPersistentProperty -> {
 					if (spannerPersistentProperty.isInterleaved()) {
 						handler.doWithPersistentProperty(spannerPersistentProperty);
 					}
@@ -207,7 +207,7 @@ public class SpannerPersistentEntityImpl<T>
 	public void doWithColumnBackedProperties(
 			PropertyHandler<SpannerPersistentProperty> handler) {
 		doWithProperties(
-				(PropertyHandler<SpannerPersistentProperty>) (spannerPersistentProperty) -> {
+				(PropertyHandler<SpannerPersistentProperty>) spannerPersistentProperty -> {
 					if (!spannerPersistentProperty.isInterleaved()) {
 						handler.doWithPersistentProperty(spannerPersistentProperty);
 					}
@@ -228,7 +228,7 @@ public class SpannerPersistentEntityImpl<T>
 	}
 
 	private void verifyInterleavedProperties() {
-		doWithInterleavedProperties((spannerPersistentProperty) -> {
+		doWithInterleavedProperties(spannerPersistentProperty -> {
 			// getting the inner type will throw an exception if the property isn't a
 			// collection.
 			Class childType = spannerPersistentProperty.getColumnInnerType();
@@ -265,7 +265,7 @@ public class SpannerPersistentEntityImpl<T>
 	private void verifyEmbeddedColumnNameOverlap(Set<String> seen,
 			SpannerPersistentEntity<?> spannerPersistentEntity) {
 		spannerPersistentEntity.doWithColumnBackedProperties(
-				(spannerPersistentProperty) -> {
+				spannerPersistentProperty -> {
 					if (spannerPersistentProperty.isEmbedded()) {
 						if (ConversionUtils.isIterableNonByteArrayType(
 								spannerPersistentProperty.getType())) {

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentPropertyImpl.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentPropertyImpl.java
@@ -77,7 +77,7 @@ public class SpannerPersistentPropertyImpl
 	public Iterable<? extends TypeInformation<?>> getPersistentEntityTypes() {
 		return StreamUtils
 				.createStreamFromIterator(super.getPersistentEntityTypes().iterator())
-				.filter((typeInfo) -> typeInfo.getType().isAnnotationPresent(Table.class))
+				.filter(typeInfo -> typeInfo.getType().isAnnotationPresent(Table.class))
 				.collect(Collectors.toList());
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/AbstractSpannerQuery.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/AbstractSpannerQuery.java
@@ -77,7 +77,7 @@ abstract class AbstractSpannerQuery<T> implements RepositoryQuery {
 	Object convertToSimpleReturnType(List<?> results, Class<?> simpleConvertedType) {
 		return this.queryMethod.isCollectionQuery()
 				? results.stream()
-						.map((x) -> this.spannerTemplate.getSpannerEntityProcessor()
+						.map(x -> this.spannerTemplate.getSpannerEntityProcessor()
 								.getReadConverter().convert(x, simpleConvertedType))
 						.collect(Collectors.toList())
 				: this.spannerTemplate.getSpannerEntityProcessor().getReadConverter()

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/PartTreeSpannerQuery.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/PartTreeSpannerQuery.java
@@ -59,7 +59,7 @@ public class PartTreeSpannerQuery<T> extends AbstractSpannerQuery<T> {
 				parameters);
 		if (isCountOrExistsQuery()) {
 			return SpannerStatementQueryExecutor.executeQuery(
-					(struct) -> isCountQuery() ? struct.getLong(0) : struct.getBoolean(0),
+					struct -> isCountQuery() ? struct.getLong(0) : struct.getBoolean(0),
 					this.entityType, this.tree, paramAccessor, getQueryMethod().getMethod().getParameters(),
 					this.spannerTemplate,
 					this.spannerMappingContext);
@@ -74,7 +74,7 @@ public class PartTreeSpannerQuery<T> extends AbstractSpannerQuery<T> {
 	}
 
 	private Function<SpannerTemplate, List> getDeleteFunction(Object[] parameters) {
-		return (transactionTemplate) -> {
+		return transactionTemplate -> {
 			ParameterAccessor paramAccessor = new ParametersParameterAccessor(getQueryMethod().getParameters(),
 					parameters);
 			List<T> entitiesToDelete = SpannerStatementQueryExecutor

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryExecutor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryExecutor.java
@@ -480,7 +480,7 @@ public final class SpannerStatementQueryExecutor {
 		}
 		sql.append(" ORDER BY ");
 		StringJoiner sj = new StringJoiner(" , ");
-		sort.iterator().forEachRemaining((o) -> {
+		sort.iterator().forEachRemaining(o -> {
 			SpannerPersistentProperty property = persistentEntity.getPersistentProperty(o.getProperty());
 			String sortedPropertyName = (property != null) ? property.getColumnName() : o.getProperty();
 			String sortedProperty = o.isIgnoreCase() ? LOWER_LHS + sortedPropertyName + ")"
@@ -498,12 +498,12 @@ public final class SpannerStatementQueryExecutor {
 
 			StringJoiner orStrings = new StringJoiner(" OR ");
 
-			tree.iterator().forEachRemaining((orPart) -> {
+			tree.iterator().forEachRemaining(orPart -> {
 				String orString = "( ";
 
 				StringJoiner andStrings = new StringJoiner(AND);
 
-				orPart.forEach((part) -> {
+				orPart.forEach(part -> {
 					String segment = part.getProperty().getSegment();
 					String tag = "tag" + tags.size();
 					tags.add(tag);

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQuery.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQuery.java
@@ -77,7 +77,7 @@ public class SqlSpannerQuery<T> extends AbstractSpannerQuery<T> {
 
 	private final boolean isDml;
 
-	private final Function<Object, Struct> paramStructConvertFunc = (param) -> {
+	private final Function<Object, Struct> paramStructConvertFunc = param -> {
 		Builder builder = Struct.newBuilder();
 		this.spannerTemplate.getSpannerEntityProcessor().write(param, builder::set);
 		return builder.build();
@@ -234,7 +234,7 @@ public class SqlSpannerQuery<T> extends AbstractSpannerQuery<T> {
 
 		return (getReturnedSimpleConvertableItemType() != null)
 				? this.spannerTemplate.query(
-						(struct) -> new StructAccessor(struct).getSingleValue(0), statement,
+						struct -> new StructAccessor(struct).getSingleValue(0), statement,
 						spannerQueryOptions)
 				: this.spannerTemplate.query(this.entityType,
 						statement,

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
@@ -66,7 +66,7 @@ public class SimpleSpannerRepository<T, ID> implements SpannerRepository<T, ID> 
 			Function<SpannerRepository<T, ID>, A> operations) {
 		return this.spannerTemplate
 				.performReadOnlyTransaction(
-						(transactionSpannerOperations) -> operations
+						transactionSpannerOperations -> operations
 								.apply(new SimpleSpannerRepository<>(
 										transactionSpannerOperations, this.entityType)),
 						null);
@@ -76,7 +76,7 @@ public class SimpleSpannerRepository<T, ID> implements SpannerRepository<T, ID> 
 	public <A> A performReadWriteTransaction(
 			Function<SpannerRepository<T, ID>, A> operations) {
 		return this.spannerTemplate
-				.performReadWriteTransaction((transactionSpannerOperations) -> operations
+				.performReadWriteTransaction(transactionSpannerOperations -> operations
 						.apply(new SimpleSpannerRepository<>(transactionSpannerOperations,
 								this.entityType)));
 	}

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerMutationFactoryImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerMutationFactoryImplTests.java
@@ -146,7 +146,7 @@ public class SpannerMutationFactoryImplTests {
 
 	@Test
 	public void insertTest() {
-		executeWriteTest((t) -> this.spannerMutationFactory.insert(t), Op.INSERT);
+		executeWriteTest(t -> this.spannerMutationFactory.insert(t), Op.INSERT);
 	}
 
 	@Test
@@ -172,12 +172,12 @@ public class SpannerMutationFactoryImplTests {
 
 	@Test
 	public void updateTest() {
-		executeWriteTest((t) -> this.spannerMutationFactory.update(t, null), Op.UPDATE);
+		executeWriteTest(t -> this.spannerMutationFactory.update(t, null), Op.UPDATE);
 	}
 
 	@Test
 	public void upsertTest() {
-		executeWriteTest((t) -> this.spannerMutationFactory.upsert(t, null),
+		executeWriteTest(t -> this.spannerMutationFactory.upsert(t, null),
 				Op.INSERT_OR_UPDATE);
 	}
 
@@ -193,7 +193,7 @@ public class SpannerMutationFactoryImplTests {
 		assertThat(mutation.getTable()).isEqualTo("custom_test_table");
 		assertThat(mutation.getOperation()).isEqualTo(Op.DELETE);
 		List<String> keys = new ArrayList<>();
-		mutation.getKeySet().getKeys().forEach((key) -> {
+		mutation.getKeySet().getKeys().forEach(key -> {
 			keys.add((String) (key.getParts().iterator().next()));
 		});
 		assertThat(keys).containsExactlyInAnyOrder(t1.id, t2.id);
@@ -208,7 +208,7 @@ public class SpannerMutationFactoryImplTests {
 		assertThat(mutation.getTable()).isEqualTo("custom_test_table");
 		assertThat(mutation.getOperation()).isEqualTo(Op.DELETE);
 		List<String> keys = new ArrayList<>();
-		mutation.getKeySet().getKeys().forEach((key) -> {
+		mutation.getKeySet().getKeys().forEach(key -> {
 			keys.add((String) (key.getParts().iterator().next()));
 		});
 		assertThat(keys).containsExactlyInAnyOrder(t1.id);
@@ -222,7 +222,7 @@ public class SpannerMutationFactoryImplTests {
 		assertThat(mutation.getTable()).isEqualTo("custom_test_table");
 		assertThat(mutation.getOperation()).isEqualTo(Op.DELETE);
 		List<String> keys = new ArrayList<>();
-		mutation.getKeySet().getKeys().forEach((key) -> {
+		mutation.getKeySet().getKeys().forEach(key -> {
 			keys.add((String) (key.getParts().iterator().next()));
 		});
 		assertThat(keys).containsExactlyInAnyOrder("key1", "key2");
@@ -235,7 +235,7 @@ public class SpannerMutationFactoryImplTests {
 		assertThat(mutation.getTable()).isEqualTo("custom_test_table");
 		assertThat(mutation.getOperation()).isEqualTo(Op.DELETE);
 		List<String> keys = new ArrayList<>();
-		mutation.getKeySet().getKeys().forEach((k) -> {
+		mutation.getKeySet().getKeys().forEach(k -> {
 			keys.add((String) (k.getParts().iterator().next()));
 		});
 		assertThat(keys).containsExactlyInAnyOrder("key1");

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
@@ -173,7 +173,7 @@ public class SpannerTemplateTests {
 		TransactionRunner transactionRunner = mock(TransactionRunner.class);
 		when(this.databaseClient.readWriteTransaction()).thenReturn(transactionRunner);
 
-		when(transactionRunner.run(any())).thenAnswer((invocation) -> {
+		when(transactionRunner.run(any())).thenAnswer(invocation -> {
 			TransactionCallable transactionCallable = invocation.getArgument(0);
 			return transactionCallable.run(context);
 		});
@@ -203,7 +203,7 @@ public class SpannerTemplateTests {
 
 		TransactionContext transactionContext = mock(TransactionContext.class);
 
-		when(transactionRunner.run(any())).thenAnswer((invocation) -> {
+		when(transactionRunner.run(any())).thenAnswer(invocation -> {
 			TransactionCallable transactionCallable = invocation.getArgument(0);
 			return transactionCallable.run(transactionContext);
 		});
@@ -211,7 +211,7 @@ public class SpannerTemplateTests {
 		TestEntity t = new TestEntity();
 
 		String finalResult = this.spannerTemplate
-				.performReadWriteTransaction((spannerTemplate) -> {
+				.performReadWriteTransaction(spannerTemplate -> {
 					List<TestEntity> items = spannerTemplate.readAll(TestEntity.class);
 					spannerTemplate.update(t);
 					spannerTemplate.executeDmlStatement(DML);
@@ -267,7 +267,7 @@ public class SpannerTemplateTests {
 						.thenReturn(readOnlyTransaction);
 
 		String finalResult = this.spannerTemplate
-				.performReadOnlyTransaction((spannerOperations) -> {
+				.performReadOnlyTransaction(spannerOperations -> {
 					List<TestEntity> items = spannerOperations.readAll(TestEntity.class);
 					TestEntity item = spannerOperations.read(TestEntity.class,
 							Key.of("key"));
@@ -291,7 +291,7 @@ public class SpannerTemplateTests {
 						.thenReturn(readOnlyTransaction);
 
 		this.spannerTemplate
-				.performReadOnlyTransaction((spannerOperations) -> {
+				.performReadOnlyTransaction(spannerOperations -> {
 					spannerOperations.executeDmlStatement(Statement.of("fail"));
 					return null;
 				}, new SpannerReadOptions()
@@ -310,7 +310,7 @@ public class SpannerTemplateTests {
 						.thenReturn(readOnlyTransaction);
 
 		this.spannerTemplate
-				.performReadOnlyTransaction((spannerOperations) -> {
+				.performReadOnlyTransaction(spannerOperations -> {
 					spannerOperations.executePartitionedDmlStatement(Statement.of("fail"));
 					return null;
 				}, new SpannerReadOptions()
@@ -328,13 +328,13 @@ public class SpannerTemplateTests {
 
 		TransactionContext transactionContext = mock(TransactionContext.class);
 
-		when(transactionRunner.run(any())).thenAnswer((invocation) -> {
+		when(transactionRunner.run(any())).thenAnswer(invocation -> {
 			TransactionCallable transactionCallable = invocation.getArgument(0);
 			return transactionCallable.run(transactionContext);
 		});
 
 		this.spannerTemplate
-				.performReadWriteTransaction((spannerTemplate) -> {
+				.performReadWriteTransaction(spannerTemplate -> {
 					spannerTemplate.executePartitionedDmlStatement(Statement.of("DML statement here"));
 					return "all done";
 				});
@@ -870,7 +870,7 @@ public class SpannerTemplateTests {
 
 		InOrder inOrder = Mockito.inOrder(mockBeforePublisher, this.databaseClient, mockAfterPublisher);
 
-		doAnswer((invocationOnMock) -> {
+		doAnswer(invocationOnMock -> {
 			ApplicationEvent event = invocationOnMock.getArgument(0);
 			if (expectedBefore != null && event.getClass().equals(expectedBefore.getClass())) {
 				mockBeforePublisher.publishEvent(event);

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTransactionManagerTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTransactionManagerTests.java
@@ -108,7 +108,7 @@ public class SpannerTemplateTransactionManagerTests {
 		when(this.databaseClient.singleUse()).thenReturn(this.readContext);
 		this.transactionManager = Mockito.spy(TransactionManager.class);
 		Mockito.doAnswer(
-				(invocation) -> {
+				invocation -> {
 					this.transactionState.set(TransactionManager.TransactionState.STARTED);
 					return this.transactionContext;
 				})
@@ -116,7 +116,7 @@ public class SpannerTemplateTransactionManagerTests {
 				.begin();
 
 		Mockito.doAnswer(
-				(invocation) -> {
+				invocation -> {
 					this.transactionState.set(
 							TransactionManager.TransactionState.ROLLED_BACK);
 					return null;
@@ -124,14 +124,14 @@ public class SpannerTemplateTransactionManagerTests {
 				.when(this.transactionManager)
 				.rollback();
 		Mockito.doAnswer(
-				(invocation) -> {
+				invocation -> {
 					this.transactionState.set(
 							TransactionManager.TransactionState.COMMITTED);
 					return null;
 				})
 				.when(this.transactionManager)
 				.commit();
-		Mockito.doAnswer((invocation) -> this.transactionState.get())
+		Mockito.doAnswer(invocation -> this.transactionState.get())
 				.when(this.transactionManager)
 				.getState();
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerDatabaseAdminTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerDatabaseAdminTemplateTests.java
@@ -94,9 +94,9 @@ public class SpannerDatabaseAdminTemplateTests {
 		MockResults mockResults = new MockResults();
 		mockResults.structs = Arrays.asList(s1, s2, s3, s4);
 		ResultSet results = mock(ResultSet.class);
-		when(results.next()).thenAnswer((invocation) -> mockResults.next());
+		when(results.next()).thenAnswer(invocation -> mockResults.next());
 		when(results.getCurrentRowAsStruct())
-				.thenAnswer((invocation) -> mockResults.getCurrent());
+				.thenAnswer(invocation -> mockResults.getCurrent());
 		when(this.databaseClient.singleUse()).thenReturn(readContext);
 		when(readContext.executeQuery(any())).thenReturn(results);
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
@@ -257,9 +257,9 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 		mockResults.structs = Arrays.asList(struct1, struct2);
 
 		ResultSet results = mock(ResultSet.class);
-		when(results.next()).thenAnswer((invocation) -> mockResults.next());
+		when(results.next()).thenAnswer(invocation -> mockResults.next());
 		when(results.getCurrentRowAsStruct())
-				.thenAnswer((invocation) -> mockResults.getCurrent());
+				.thenAnswer(invocation -> mockResults.getCurrent());
 
 		List<TestEntity> entities = this.spannerEntityProcessor.mapToList(results,
 				TestEntity.class);
@@ -332,9 +332,9 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 		mockResults.structs = Arrays.asList(struct1, struct2);
 
 		ResultSet results = mock(ResultSet.class);
-		when(results.next()).thenAnswer((invocation) -> mockResults.next());
+		when(results.next()).thenAnswer(invocation -> mockResults.next());
 		when(results.getCurrentRowAsStruct())
-				.thenAnswer((invocation) -> mockResults.getCurrent());
+				.thenAnswer(invocation -> mockResults.getCurrent());
 
 		List<TestEntity> entities = this.spannerEntityProcessor.mapToList(results,
 				TestEntity.class, "id", "custom_col");

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/it/SpannerTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/it/SpannerTemplateIntegrationTests.java
@@ -108,7 +108,7 @@ public class SpannerTemplateIntegrationTests extends AbstractSpannerIntegrationT
 	@Test
 	public void readWriteTransactionTest() {
 		Trade trade = Trade.aTrade();
-		this.spannerOperations.performReadWriteTransaction((transactionOperations) -> {
+		this.spannerOperations.performReadWriteTransaction(transactionOperations -> {
 
 			long beforeCount = transactionOperations.count(Trade.class);
 			transactionOperations.insert(trade);
@@ -130,7 +130,7 @@ public class SpannerTemplateIntegrationTests extends AbstractSpannerIntegrationT
 		this.expectedEx.expectMessage("A read-only transaction template cannot perform mutations.");
 
 		Trade trade = Trade.aTrade();
-		this.spannerOperations.performReadOnlyTransaction((transactionOperations) -> {
+		this.spannerOperations.performReadOnlyTransaction(transactionOperations -> {
 			// cannot do mutate in a read-only transaction
 			transactionOperations.insert(trade);
 			return null;

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImplTests.java
@@ -206,7 +206,7 @@ public class SpannerPersistentEntityImplTests {
 				.getPersistentEntity(TestEntity.class);
 		PersistentPropertyAccessor accessor = p.getPropertyAccessor(t);
 		p.doWithProperties(
-				(SimplePropertyHandler) (property) -> assertThat(accessor.getProperty(property)).isNotEqualTo("b"));
+				(SimplePropertyHandler) property -> assertThat(accessor.getProperty(property)).isNotEqualTo("b"));
 	}
 
 	@Test
@@ -309,7 +309,7 @@ public class SpannerPersistentEntityImplTests {
 		PropertyHandler<SpannerPersistentProperty> mockHandler = mock(PropertyHandler.class);
 		SpannerPersistentEntity spannerPersistentEntity =
 				this.spannerMappingContext.getPersistentEntity(ParentInRelationship.class);
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			String colName = ((SpannerPersistentProperty) invocation.getArgument(0))
 					.getName();
 			assertThat(colName.equals("childrenA") || colName.equals("childrenB")).isTrue();

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentPropertyImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentPropertyImplTests.java
@@ -87,7 +87,7 @@ public class SpannerPersistentPropertyImplTests {
 	@Test
 	public void testAssociations() {
 		new SpannerMappingContext().getPersistentEntity(TestEntity.class)
-				.doWithProperties((PropertyHandler<SpannerPersistentProperty>) (prop) -> {
+				.doWithProperties((PropertyHandler<SpannerPersistentProperty>) prop -> {
 					assertThat(((SpannerPersistentPropertyImpl) prop).createAssociation().getInverse()).isSameAs(prop);
 					assertThat(((SpannerPersistentPropertyImpl) prop).createAssociation()
 							.getObverse()).isNull();
@@ -104,14 +104,14 @@ public class SpannerPersistentPropertyImplTests {
 	public void testNoPojoIdProperties() {
 		new SpannerMappingContext().getPersistentEntity(TestEntity.class)
 				.doWithProperties(
-						(PropertyHandler<SpannerPersistentProperty>) (prop) -> assertThat(prop.isIdProperty()).isFalse());
+						(PropertyHandler<SpannerPersistentProperty>) prop -> assertThat(prop.isIdProperty()).isFalse());
 	}
 
 	@Test
 	public void testIgnoredProperty() {
 		new SpannerMappingContext().getPersistentEntity(TestEntity.class)
 				.doWithProperties(
-						(PropertyHandler<SpannerPersistentProperty>) (prop) -> assertThat(prop.getColumnName())
+						(PropertyHandler<SpannerPersistentProperty>) prop -> assertThat(prop.getColumnName())
 								.isNotEqualTo("not_mapped"));
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -271,11 +271,11 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 		assertThat(customSortedTrades.get(0).getId()).isLessThan(customSortedTrades.get(1).getId());
 
 		this.tradeRepository.findBySymbolLike("%BCD")
-				.forEach((x) -> assertThat(x.getSymbol()).isEqualTo("ABCD"));
+				.forEach(x -> assertThat(x.getSymbol()).isEqualTo("ABCD"));
 		assertThat(this.tradeRepository.findBySymbolNotLike("%BCD")).isEmpty();
 
 		this.tradeRepository.findBySymbolContains("BCD")
-				.forEach((x) -> assertThat(x.getSymbol()).isEqualTo("ABCD"));
+				.forEach(x -> assertThat(x.getSymbol()).isEqualTo("ABCD"));
 		assertThat(this.tradeRepository.findBySymbolNotContains("BCD")).isEmpty();
 
 		assertThat(this.tradeRepository

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
@@ -115,7 +115,7 @@ public class SpannerQueryLookupStrategyTests {
 		// @formatter:off
 
 		when(parameters.getNumberOfParameters()).thenReturn(1);
-		when(parameters.getParameter(anyInt())).thenAnswer((invocation) -> {
+		when(parameters.getParameter(anyInt())).thenAnswer(invocation -> {
 			Parameter param = mock(Parameter.class);
 			when(param.getName()).thenReturn(Optional.of("tag"));
 			// @formatter:off

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
@@ -113,7 +113,7 @@ public class SpannerStatementQueryTests {
 				"ignored", "blahblah", "ignored", "ignored", 1.11, 2.22, Arrays.asList(1, 2), BigDecimal.ONE };
 
 		when(this.spannerTemplate.query((Class<Object>) any(), any(), any()))
-				.thenAnswer((invocation) -> {
+				.thenAnswer(invocation -> {
 					Statement statement = invocation.getArgument(1);
 
 					String expectedQuery =
@@ -188,7 +188,7 @@ public class SpannerStatementQueryTests {
 		doReturn(new DefaultParameters(method)).when(this.queryMethod).getParameters();
 
 		when(this.spannerTemplate.query((Function<Struct, Object>) any(), any(), any()))
-				.thenAnswer((invocation) -> {
+				.thenAnswer(invocation -> {
 					Statement statement = invocation.getArgument(1);
 
 					String expectedSql = "SELECT EXISTS"
@@ -264,7 +264,7 @@ public class SpannerStatementQueryTests {
 		doReturn(new DefaultParameters(method)).when(this.queryMethod).getParameters();
 
 		when(this.spannerTemplate.query((Class) any(), any(), any()))
-				.thenAnswer((invocation) -> {
+				.thenAnswer(invocation -> {
 					Statement statement = invocation.getArgument(1);
 
 					assertThat(statement.getSql()).isEqualTo(expectedSql);

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
@@ -149,7 +149,7 @@ public class SqlSpannerQueryTests {
 
 		SqlSpannerQuery sqlSpannerQuery = createQuery(sql, toReturn, false);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Statement statement = invocation.getArgument(0);
 			SpannerQueryOptions queryOptions = invocation.getArgument(1);
 			assertThat(queryOptions.isAllowPartialRead()).isTrue();
@@ -199,7 +199,7 @@ public class SqlSpannerQueryTests {
 
 		SqlSpannerQuery sqlSpannerQuery = createQuery(sql, Child.class, false);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Statement statement = invocation.getArgument(0);
 			SpannerQueryOptions queryOptions = invocation.getArgument(1);
 			assertThat(queryOptions.isAllowPartialRead()).isTrue();
@@ -255,7 +255,7 @@ public class SqlSpannerQueryTests {
 
 		SqlSpannerQuery sqlSpannerQuery = createQuery(sql, Child.class, false);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Statement statement = invocation.getArgument(0);
 			SpannerQueryOptions queryOptions = invocation.getArgument(1);
 			assertThat(queryOptions.isAllowPartialRead()).isTrue();
@@ -312,7 +312,7 @@ public class SqlSpannerQueryTests {
 
 		SqlSpannerQuery sqlSpannerQuery = createQuery(sql, Child.class, false);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Statement statement = invocation.getArgument(0);
 			SpannerQueryOptions queryOptions = invocation.getArgument(1);
 			assertThat(queryOptions.isAllowPartialRead()).isTrue();
@@ -391,7 +391,7 @@ public class SqlSpannerQueryTests {
 
 		SqlSpannerQuery sqlSpannerQuery = createQuery(sql, Trade.class, false);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Statement statement = invocation.getArgument(0);
 			SpannerQueryOptions queryOptions = invocation.getArgument(1);
 			assertThat(queryOptions.isAllowPartialRead()).isTrue();
@@ -439,7 +439,7 @@ public class SqlSpannerQueryTests {
 		TransactionRunner transactionRunner = mock(TransactionRunner.class);
 		when(this.databaseClient.readWriteTransaction()).thenReturn(transactionRunner);
 
-		when(transactionRunner.run(any())).thenAnswer((invocation) -> {
+		when(transactionRunner.run(any())).thenAnswer(invocation -> {
 			TransactionRunner.TransactionCallable transactionCallable = invocation.getArgument(0);
 			return transactionCallable.run(context);
 		});
@@ -484,7 +484,7 @@ public class SqlSpannerQueryTests {
 
 		SqlSpannerQuery sqlSpannerQuery = createQuery(sql, long.class, false);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Statement statement = invocation.getArgument(0);
 			SpannerQueryOptions queryOptions = invocation.getArgument(1);
 			assertThat(queryOptions.isAllowPartialRead()).isTrue();

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryImplTests.java
@@ -204,7 +204,7 @@ public class SpannerRepositoryImplTests {
 	@Test
 	public void findAllSortTest() {
 		Sort sort = mock(Sort.class);
-		when(this.template.queryAll(eq(Object.class), any())).thenAnswer((invocation) -> {
+		when(this.template.queryAll(eq(Object.class), any())).thenAnswer(invocation -> {
 			SpannerPageableQueryOptions spannerQueryOptions = invocation.getArgument(1);
 			assertThat(spannerQueryOptions.getSort()).isSameAs(sort);
 			return null;
@@ -221,7 +221,7 @@ public class SpannerRepositoryImplTests {
 		when(pageable.getSort()).thenReturn(sort);
 		when(pageable.getOffset()).thenReturn(3L);
 		when(pageable.getPageSize()).thenReturn(5);
-		when(this.template.queryAll(eq(Object.class), any())).thenAnswer((invocation) -> {
+		when(this.template.queryAll(eq(Object.class), any())).thenAnswer(invocation -> {
 			SpannerPageableQueryOptions spannerQueryOptions = invocation.getArgument(1);
 			assertThat(spannerQueryOptions.getSort()).isSameAs(sort);
 			assertThat(spannerQueryOptions.getOffset()).isEqualTo(3);
@@ -239,7 +239,7 @@ public class SpannerRepositoryImplTests {
 
 		when(this.entityProcessor.convertToKey(Key.of("key1"))).thenReturn(Key.of("key1"));
 		when(this.entityProcessor.convertToKey(Key.of("key2"))).thenReturn(Key.of("key2"));
-		when(this.template.read(eq(Object.class), (KeySet) any())).thenAnswer((invocation) -> {
+		when(this.template.read(eq(Object.class), (KeySet) any())).thenAnswer(invocation -> {
 			KeySet keys = invocation.getArgument(1);
 			assertThat(keys.getKeys()).containsExactlyInAnyOrder(Key.of("key2"), Key.of("key1"));
 			return null;
@@ -280,27 +280,27 @@ public class SpannerRepositoryImplTests {
 	@Test
 	public void readOnlyTransactionTest() {
 		when(this.template.performReadOnlyTransaction(any(), any()))
-				.thenAnswer((invocation) -> {
+				.thenAnswer(invocation -> {
 					Function<SpannerTemplate, String> f = invocation.getArgument(0);
 					return f.apply(this.template);
 				});
 
 		Object object =
 				new SimpleSpannerRepository<Object, Key>(this.template, Object.class)
-						.performReadOnlyTransaction((repo) -> "test");
+						.performReadOnlyTransaction(repo -> "test");
 		assertThat(object).isEqualTo("test");
 	}
 
 	@Test
 	public void readWriteTransactionTest() {
-		when(this.template.performReadWriteTransaction(any())).thenAnswer((invocation) -> {
+		when(this.template.performReadWriteTransaction(any())).thenAnswer(invocation -> {
 			Function<SpannerTemplate, String> f = invocation.getArgument(0);
 			return f.apply(this.template);
 		});
 
 		Object object =
 				new SimpleSpannerRepository<Object, Key>(this.template, Object.class)
-						.performReadWriteTransaction((repo) -> "test");
+						.performReadWriteTransaction(repo -> "test");
 		assertThat(object).isEqualTo("test");
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubEmulator.java
@@ -136,9 +136,9 @@ public class PubSubEmulator extends ExternalResource {
 
 				try (BufferedReader br = new BufferedReader(new InputStreamReader(psProcess.getInputStream()))) {
 					br.lines()
-							.filter((psLine) -> psLine.contains(hostPortParams))
-							.map((psLine) -> new StringTokenizer(psLine).nextToken())
-							.forEach((p) -> {
+							.filter(psLine -> psLine.contains(hostPortParams))
+							.map(psLine -> new StringTokenizer(psLine).nextToken())
+							.forEach(p -> {
 								LOGGER.info("Found emulator process to kill: " + p);
 								this.killProcess(p);
 								foundEmulatorProcess.set(true);
@@ -238,8 +238,8 @@ public class PubSubEmulator extends ExternalResource {
 
 			if (key != null) {
 				Optional<Path> configFilePath = key.pollEvents().stream()
-						.map((event) -> (Path) event.context())
-						.filter((path) -> ENV_FILE_NAME.equals(path.toString()))
+						.map(event -> (Path) event.context())
+						.filter(path -> ENV_FILE_NAME.equals(path.toString()))
 						.findAny();
 				if (configFilePath.isPresent()) {
 					return;

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -73,7 +73,7 @@ public class PubSubChannelProvisionerTests {
 	@Before
 	public void setup() {
 		when(this.pubSubAdminMock.getSubscription(any())).thenReturn(null);
-		doAnswer((invocation) ->
+		doAnswer(invocation ->
 			Subscription.newBuilder()
 					.setName("projects/test-project/subscriptions/" + invocation.getArgument(0))
 					.setTopic(invocation.getArgument(1, String.class).startsWith("projects/") ?
@@ -81,7 +81,7 @@ public class PubSubChannelProvisionerTests {
 							"projects/test-project/topics/" + invocation.getArgument(1))
 					.build()
 		).when(this.pubSubAdminMock).createSubscription(any(), any());
-		doAnswer((invocation) ->
+		doAnswer(invocation ->
 				Topic.newBuilder().setName("projects/test-project/topics/" + invocation.getArgument(0)).build()
 		).when(this.pubSubAdminMock).getTopic(any());
 		when(this.properties.getExtension()).thenReturn(this.pubSubConsumerProperties);

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberTemplate.java
@@ -239,7 +239,7 @@ public class PubSubSubscriberTemplate
 	private List<AcknowledgeablePubsubMessage> toAcknowledgeablePubsubMessageList(List<ReceivedMessage> messages,
 			String subscriptionId) {
 		return messages.stream()
-				.map((message) -> new PulledAcknowledgeablePubsubMessage(
+				.map(message -> new PulledAcknowledgeablePubsubMessage(
 						PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionId,
 								this.subscriberFactory.getProjectId()),
 						message.getMessage(),
@@ -282,7 +282,7 @@ public class PubSubSubscriberTemplate
 
 	private <T> List<ConvertedAcknowledgeablePubsubMessage<T>> toConvertedAcknowledgeablePubsubMessages(Class<T> payloadType, List<AcknowledgeablePubsubMessage> ackableMessages) {
 		return ackableMessages.stream().map(
-				(m) -> new ConvertedPulledAcknowledgeablePubsubMessage<>(m,
+				m -> new ConvertedPulledAcknowledgeablePubsubMessage<>(m,
 						this.pubSubMessageConverter.fromPubSubMessage(m.getPubsubMessage(), payloadType))
 		).collect(Collectors.toList());
 	}

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/PubSubHeaderMapper.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/PubSubHeaderMapper.java
@@ -95,10 +95,10 @@ public class PubSubHeaderMapper implements HeaderMapper<Map<String, String>> {
 	public void fromHeaders(MessageHeaders messageHeaders,
 			final Map<String, String> pubsubMessageHeaders) {
 		messageHeaders.entrySet().stream()
-				.filter((entry) -> Boolean.TRUE.equals(
+				.filter(entry -> Boolean.TRUE.equals(
 						PatternMatchUtils.smartMatch(entry.getKey(),
 								this.outboundHeaderPatterns)))
-				.forEach((entry) -> pubsubMessageHeaders.put(
+				.forEach(entry -> pubsubMessageHeaders.put(
 						entry.getKey(), entry.getValue().toString()));
 	}
 
@@ -112,7 +112,7 @@ public class PubSubHeaderMapper implements HeaderMapper<Map<String, String>> {
 	@Override
 	public Map<String, Object> toHeaders(Map<String, String> pubsubMessageHeaders) {
 		return pubsubMessageHeaders.entrySet().stream()
-				.filter((entry) -> Boolean.TRUE.equals(
+				.filter(entry -> Boolean.TRUE.equals(
 						PatternMatchUtils.smartMatch(entry.getKey(),
 								this.inboundHeaderPatterns)))
 				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/reactive/PubSubReactiveFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/reactive/PubSubReactiveFactory.java
@@ -105,7 +105,7 @@ public final class PubSubReactiveFactory {
 	public Flux<AcknowledgeablePubsubMessage> poll(String subscriptionName, long pollingPeriodMs) {
 
 		return Flux.create(sink ->
-			sink.onRequest((numRequested) -> {
+			sink.onRequest(numRequested -> {
 				if (numRequested == Long.MAX_VALUE) {
 					pollingPull(subscriptionName, pollingPeriodMs, sink);
 				}

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactory.java
@@ -125,7 +125,7 @@ public class DefaultPublisherFactory implements PublisherFactory {
 
 	@Override
 	public Publisher createPublisher(String topic) {
-		return this.publishers.computeIfAbsent(topic, (key) -> {
+		return this.publishers.computeIfAbsent(topic, key -> {
 			try {
 				Publisher.Builder publisherBuilder =
 						Publisher.newBuilder(PubSubTopicUtils.toTopicName(topic, this.projectId));

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubTemplateTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubTemplateTests.java
@@ -155,7 +155,7 @@ public class PubSubTemplateTests {
 		allowedPayload.value = 12345;
 		PubSubPublisherTemplate pubSubPublisherTemplate = spy(createPublisherTemplate());
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			PubsubMessage message = invocation.getArgument(1);
 			assertThat(message.getData().toStringUtf8())
 					.isEqualTo("{\"@class\":"
@@ -176,7 +176,7 @@ public class PubSubTemplateTests {
 
 		this.pubSubTemplate.publish("testTopic", "jaguar god", headers);
 
-		verify(this.mockPublisher).publish(argThat((message) ->
+		verify(this.mockPublisher).publish(argThat(message ->
 				message.getAttributesMap().get("emperor of sand").equals("sultan's curse") &&
 				message.getAttributesMap().get("remission").equals("elephant man")));
 	}
@@ -214,7 +214,7 @@ public class PubSubTemplateTests {
 	@Test
 	public void testSubscribe() {
 		Subscriber subscriber = this.pubSubTemplate.subscribe("testSubscription",
-				(message) -> { });
+				message -> { });
 		assertThat(subscriber).isEqualTo(this.mockSubscriber);
 		verify(this.mockSubscriber, times(1)).startAsync();
 	}

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberTemplateTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberTemplateTests.java
@@ -143,19 +143,19 @@ public class PubSubSubscriberTemplateTests {
 
 		// for subscribe with MessageReceiver
 		when(this.subscriberFactory.createSubscriber(any(String.class), any(MessageReceiver.class)))
-				.then((invocation) -> {
+				.then(invocation -> {
 					this.messageReceiver = invocation.getArgument(1);
 					return this.subscriber;
 				});
 
-		when(this.subscriber.startAsync()).then((invocation) -> {
+		when(this.subscriber.startAsync()).then(invocation -> {
 			this.messageReceiver.receiveMessage(this.pubsubMessage, this.ackReplyConsumer);
 			return null;
 		});
 
 		// for pull
 		when(this.subscriberFactory.createPullRequest(any(String.class), any(Integer.class), any(Boolean.class)))
-				.then((invocation) -> PullRequest.newBuilder().setSubscription(invocation.getArgument(0)).build());
+				.then(invocation -> PullRequest.newBuilder().setSubscription(invocation.getArgument(0)).build());
 
 		when(this.subscriberStub.acknowledgeCallable()).thenReturn(this.ackCallable);
 		when(this.subscriberStub.modifyAckDeadlineCallable()).thenReturn(this.modifyAckDeadlineCallable);
@@ -164,7 +164,7 @@ public class PubSubSubscriberTemplateTests {
 
 		when(this.modifyAckDeadlineCallable.futureCall(any(ModifyAckDeadlineRequest.class))).thenReturn(this.ackApiFuture);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Runnable runnable = invocation.getArgument(0);
 			runnable.run();
 			return null;
@@ -178,7 +178,7 @@ public class PubSubSubscriberTemplateTests {
 		// for pull future
 		when(this.pullCallable.futureCall(any(PullRequest.class))).thenReturn(this.pullApiFuture);
 
-		doAnswer((invocation) -> {
+		doAnswer(invocation -> {
 			Runnable runnable = invocation.getArgument(0);
 			runnable.run();
 			return null;

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -99,7 +99,7 @@ public class PubSubInboundChannelAdapterTests {
 		when(mockAcknowledgeableMessage.getPayload()).thenReturn("Test message payload.");
 
 		when(this.mockPubSubSubscriberOperations.subscribeAndConvert(
-				anyString(), any(Consumer.class), any(Class.class))).then((invocationOnMock) -> {
+				anyString(), any(Consumer.class), any(Class.class))).then(invocationOnMock -> {
 					Consumer<ConvertedBasicAcknowledgeablePubsubMessage> messageConsumer =
 							invocationOnMock.getArgument(1);
 					messageConsumer.accept(mockAcknowledgeableMessage);

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubMessageSourceTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubMessageSourceTests.java
@@ -187,7 +187,7 @@ public class PubSubMessageSourceTests {
 		pubSubMessageSource.setPayloadType(String.class);
 		pubSubMessageSource.setAckMode(AckMode.AUTO);
 		MessageSourcePollingTemplate poller = new MessageSourcePollingTemplate(pubSubMessageSource);
-		poller.poll((message) -> {
+		poller.poll(message -> {
 			assertThat(message).isNotNull();
 
 			assertThat(message.getPayload()).isEqualTo("msg1");
@@ -206,7 +206,7 @@ public class PubSubMessageSourceTests {
 		pubSubMessageSource.setPayloadType(String.class);
 		pubSubMessageSource.setAckMode(AckMode.AUTO_ACK);
 		MessageSourcePollingTemplate poller = new MessageSourcePollingTemplate(pubSubMessageSource);
-		poller.poll((message) -> {
+		poller.poll(message -> {
 			assertThat(message).isNotNull();
 
 			assertThat(message.getPayload()).isEqualTo("msg1");
@@ -224,7 +224,7 @@ public class PubSubMessageSourceTests {
 		pubSubMessageSource.setPayloadType(String.class);
 
 		MessageSourcePollingTemplate poller = new MessageSourcePollingTemplate(pubSubMessageSource);
-		poller.poll((message) -> {
+		poller.poll(message -> {
 			assertThat(message).isNotNull();
 
 			assertThat(message.getPayload()).isEqualTo("msg1");
@@ -244,7 +244,7 @@ public class PubSubMessageSourceTests {
 		pubSubMessageSource.setAckMode(AckMode.AUTO);
 		MessageSourcePollingTemplate poller = new MessageSourcePollingTemplate(pubSubMessageSource);
 		assertThatThrownBy(() -> {
-			poller.poll((message) -> {
+			poller.poll(message -> {
 				throw new RuntimeException("Nope.");
 			});
 		}).isInstanceOf(MessageHandlingException.class).hasMessageContaining("Nope.");
@@ -262,7 +262,7 @@ public class PubSubMessageSourceTests {
 		pubSubMessageSource.setAckMode(AckMode.AUTO_ACK);
 		MessageSourcePollingTemplate poller = new MessageSourcePollingTemplate(pubSubMessageSource);
 		assertThatThrownBy(() -> {
-			poller.poll((message) -> {
+			poller.poll(message -> {
 				throw new RuntimeException("Nope.");
 			});
 		}).isInstanceOf(MessageHandlingException.class).hasMessageContaining("Nope.");

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/converter/SimplePubSubMessageConverterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/converter/SimplePubSubMessageConverterTests.java
@@ -55,7 +55,7 @@ public class SimplePubSubMessageConverterTests {
 
 	@Test
 	public void testToString() {
-		doToTestForType(String.class, (a) -> a);
+		doToTestForType(String.class, a -> a);
 	}
 
 	@Test
@@ -65,7 +65,7 @@ public class SimplePubSubMessageConverterTests {
 
 	@Test
 	public void testToByteString() {
-		doToTestForType(ByteString.class, (a) -> new String(a.toByteArray()));
+		doToTestForType(ByteString.class, a -> new String(a.toByteArray()));
 	}
 
 	@Test
@@ -75,7 +75,7 @@ public class SimplePubSubMessageConverterTests {
 
 	@Test
 	public void testToByteArray() {
-		doToTestForType(byte[].class, (a) -> new String(a));
+		doToTestForType(byte[].class, a -> new String(a));
 	}
 
 	@Test
@@ -85,7 +85,7 @@ public class SimplePubSubMessageConverterTests {
 
 	@Test
 	public void testToByteBuffer() {
-		doToTestForType(ByteBuffer.class, (a) -> new String(a.array()));
+		doToTestForType(ByteBuffer.class, a -> new String(a.array()));
 	}
 
 	@Test
@@ -99,7 +99,7 @@ public class SimplePubSubMessageConverterTests {
 		this.expectedException.expect(PubSubMessageConversionException.class);
 		this.expectedException.expectMessage("Unable to convert Pub/Sub message to " +
 				"payload of type java.lang.Integer.");
-		doToTestForType(Integer.class, (a) -> toString());
+		doToTestForType(Integer.class, a -> toString());
 
 	}
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/DatastoreRepositoryExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/DatastoreRepositoryExample.java
@@ -55,7 +55,7 @@ public class DatastoreRepositoryExample {
 
 	@Bean
 	public CommandLineRunner commandLineRunner() {
-		return (args) -> {
+		return args -> {
 			System.out.println("Remove all records from 'singers' kind");
 			this.singerRepository.deleteAll();
 
@@ -97,7 +97,7 @@ public class DatastoreRepositoryExample {
 		// / family is strongly consistent.
 		this.singerRepository
 				.findAllById(Arrays.asList("singer1", "singer2", "singer3"))
-				.forEach((x) -> System.out.println("retrieved singer: " + x));
+				.forEach(x -> System.out.println("retrieved singer: " + x));
 
 		//Query by example: find all singers with the last name "Doe"
 		Iterable<Singer> singers = this.singerRepository.findAll(
@@ -133,7 +133,7 @@ public class DatastoreRepositoryExample {
 		// SingerRepository.
 		// The following call also performs the creation and saving of relationships
 		// in a single transaction.
-		this.singerRepository.performTransaction((transactionRepository) -> {
+		this.singerRepository.performTransaction(transactionRepository -> {
 			singerB.setFirstBand(band3);
 			singerB.setBands(Arrays.asList(band3, band2));
 			singerB.setPersonalInstruments(new HashSet<>(Arrays

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/Singer.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/Singer.java
@@ -156,12 +156,12 @@ public class Singer {
 				+ this.firstName + '\'' + ", lastName='" + this.lastName + '\''
 				+ ", albums=" + this.albums + ", firstBand=" + this.firstBand + ", bands="
 				+ ((this.bands == null) ? ""
-						: Strings.join(this.bands.stream().map((x) -> x.getName())
+						: Strings.join(this.bands.stream().map(x -> x.getName())
 								.collect(Collectors.toList()), ','))
 				+ ", personalInstruments="
 				+ ((this.personalInstruments == null) ? ""
 						: Strings.join(this.personalInstruments.stream()
-								.map((x) -> x.getType()).collect(Collectors.toList()), ','))
+								.map(x -> x.getType()).collect(Collectors.toList()), ','))
 				+ '}';
 	}
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/test/java/com/example/DatastoreSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/test/java/com/example/DatastoreSampleApplicationIntegrationTests.java
@@ -236,7 +236,7 @@ public class DatastoreSampleApplicationIntegrationTests {
 		List<Map<String, Object>> singerMaps = (List<Map<String, Object>>) ((Map<String, Object>) parsedResponse
 				.get("_embedded")).get("singers");
 
-		return singerMaps.stream().map((som) -> new Singer(null,
+		return singerMaps.stream().map(som -> new Singer(null,
 				(String) som.get("firstName"), (String) som.get("lastName"), null))
 				.collect(Collectors.toList());
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/main/java/com/example/DemoApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/main/java/com/example/DemoApplication.java
@@ -42,7 +42,7 @@ public class DemoApplication {
 
 	@Bean
 	public CommandLineRunner houses(HouseRepository houseRepository) {
-		return (args) -> {
+		return args -> {
 			houseRepository.deleteAll();
 
 			Stream.of(new House("111 8th Av., NYC"),
@@ -52,7 +52,7 @@ public class DemoApplication {
 					.forEach(houseRepository::save);
 
 			LOGGER.info("Number of houses is " + houseRepository.count());
-			houseRepository.findAll().forEach((house) -> LOGGER.info(house.getAddress()));
+			houseRepository.findAll().forEach(house -> LOGGER.info(house.getAddress()));
 		};
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/MultipleDataModuleExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/MultipleDataModuleExample.java
@@ -44,7 +44,7 @@ public class MultipleDataModuleExample {
 
 	@Bean
 	ApplicationRunner applicationRunner() {
-		return (args) -> {
+		return args -> {
 
 			System.out.println("Deleting all entities.");
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/main/java/com/example/SpannerExampleDriver.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/main/java/com/example/SpannerExampleDriver.java
@@ -52,7 +52,7 @@ public class SpannerExampleDriver {
 	@Bean
 	@Profile("!test")
 	ApplicationRunner applicationRunner() {
-		return (args) -> {
+		return args -> {
 			if (!args.containsOption("spanner_repository") && !args.containsOption("spanner_template")) {
 				throw new IllegalArgumentException("To run the Spanner example, please specify "
 						+ " -Dspring-boot.run.arguments=--spanner_repository to run the Spanner repository"

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/main/java/com/example/SpannerRepositoryExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/main/java/com/example/SpannerRepositoryExample.java
@@ -102,7 +102,7 @@ public class SpannerRepositoryExample {
 
 		LOGGER.info("A query method can also select properties in entities:");
 		this.tradeRepository.getTradeIds("BUY").stream()
-				.forEach((x) -> LOGGER.info(x));
+				.forEach(x -> LOGGER.info(x));
 
 		LOGGER.info("Try http://localhost:8080/trades in the browser to see all trades.");
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerRepositoryIntegrationTests.java
@@ -141,13 +141,13 @@ public class SpannerRepositoryIntegrationTests {
 
 		this.spannerRepositoryExample.runExample();
 		List<String> traderIds = new ArrayList<>();
-		this.traderRepository.findAll().forEach((t) -> traderIds.add(t.getTraderId()));
+		this.traderRepository.findAll().forEach(t -> traderIds.add(t.getTraderId()));
 		assertThat(traderIds).containsExactlyInAnyOrder("demo_trader1", "demo_trader2", "demo_trader3");
 
 		assertThat(this.tradeRepository.findAll()).hasSize(8);
 
 		Set<String> tradeSpannerKeys = new HashSet<>();
-		this.tradeRepository.findAll().forEach((t) -> tradeSpannerKeys.add(this.spannerSchemaUtils.getKey(t).toString()));
+		this.tradeRepository.findAll().forEach(t -> tradeSpannerKeys.add(this.spannerSchemaUtils.getKey(t).toString()));
 
 		assertThat(tradeSpannerKeys).containsExactlyInAnyOrder(
 				"[demo_trader1,1]",

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-sample/src/test/java/com/example/SpannerTemplateIntegrationTests.java
@@ -81,7 +81,7 @@ public class SpannerTemplateIntegrationTests {
 
 		Set<String> tradeSpannerKeys = this.spannerOperations.readAll(Trade.class)
 				.stream()
-				.map((t) -> this.spannerSchemaUtils.getKey(t).toString())
+				.map(t -> this.spannerSchemaUtils.getKey(t).toString())
 				.collect(Collectors.toSet());
 
 		assertThat(tradeSpannerKeys).containsExactlyInAnyOrder(

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/src/test/java/com/example/SenderIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/src/test/java/com/example/SenderIntegrationTest.java
@@ -83,7 +83,7 @@ public class SenderIntegrationTest {
 			messages.forEach(BasicAcknowledgeablePubsubMessage::ack);
 
 			if (messages.stream()
-					.anyMatch((m) -> m.getPubsubMessage().getData().toStringUtf8().startsWith(message))) {
+					.anyMatch(m -> m.getPubsubMessage().getData().toStringUtf8().startsWith(message))) {
 				messageReceived = true;
 				break;
 			}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/main/java/com/example/GcsSpringIntegrationApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/main/java/com/example/GcsSpringIntegrationApplication.java
@@ -105,7 +105,7 @@ public class GcsSpringIntegrationApplication {
 	@Bean
 	@ServiceActivator(inputChannel = "new-file-channel")
 	public MessageHandler handleNewFileFromSynchronizer() {
-		return (message) -> {
+		return message -> {
 			File file = (File) message.getPayload();
 			LOGGER.info("File " + file.getName() + " received by the non-streaming inbound "
 					+ "channel adapter.");
@@ -140,7 +140,7 @@ public class GcsSpringIntegrationApplication {
 		outboundChannelAdapter.setRemoteDirectoryExpression(
 				new ValueExpression<>(this.gcsWriteBucket));
 		outboundChannelAdapter
-				.setFileNameGenerator((message) -> message.getHeaders().get(FileHeaders.REMOTE_FILE, String.class));
+				.setFileNameGenerator(message -> message.getHeaders().get(FileHeaders.REMOTE_FILE, String.class));
 
 		return outboundChannelAdapter;
 	}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/test/java/com/example/GcsSpringIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/test/java/com/example/GcsSpringIntegrationTests.java
@@ -112,7 +112,7 @@ public class GcsSpringIntegrationTests {
 
 					List<String> blobNamesInOutputBucket = new ArrayList<>();
 					this.storage.list(this.cloudOutputBucket).iterateAll()
-							.forEach((b) -> blobNamesInOutputBucket.add(b.getName()));
+							.forEach(b -> blobNamesInOutputBucket.add(b.getName()));
 
 					assertThat(blobNamesInOutputBucket).contains(TEST_FILE_NAME);
 				});

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/src/test/java/com.example/LoggingSampleApplicationIntegrationTests.java
@@ -106,12 +106,12 @@ public class LoggingSampleApplicationIntegrationTests {
 					Page<LogEntry> logEntryPage = this.logClient.listLogEntries(
 							Logging.EntryListOption.filter(logFilter));
 					List<LogEntry> logEntries = new ArrayList<>();
-					logEntryPage.iterateAll().forEach((le) -> {
+					logEntryPage.iterateAll().forEach(le -> {
 						logEntries.add(le);
 					});
 
 					List<String> logContents = logEntries.stream()
-							.map((logEntry) -> (String) ((JsonPayload) logEntry.getPayload())
+							.map(logEntry -> (String) ((JsonPayload) logEntry.getPayload())
 									.getDataAsMap().get("message"))
 							.collect(Collectors.toList());
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/main/java/com/example/WebController.java
@@ -135,7 +135,7 @@ public class WebController {
 
 	@GetMapping("/subscribe")
 	public RedirectView subscribe(@RequestParam("subscription") String subscriptionName) {
-		Subscriber subscriber = this.pubSubTemplate.subscribe(subscriptionName, (message) -> {
+		Subscriber subscriber = this.pubSubTemplate.subscribe(subscriptionName, message -> {
 			LOGGER.info("Message received from " + subscriptionName + " subscription: "
 					+ message.getPubsubMessage().getData().toStringUtf8());
 			message.ack();

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/src/test/java/com/example/PubSubSampleApplicationIntegrationTests.java
@@ -216,7 +216,7 @@ public class PubSubSampleApplicationIntegrationTests {
 
 		PullResponse pullResponse = subscriptionAdminClient.getStub().pullCallable().call(pullRequest);
 		return pullResponse.getReceivedMessagesList().stream()
-				.map((message) -> message.getMessage().getData().toStringUtf8())
+				.map(message -> message.getMessage().getData().toStringUtf8())
 				.collect(Collectors.toList());
 	}
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-sample/src/main/java/com/example/WebController.java
@@ -41,7 +41,7 @@ public class WebController {
 	@GetMapping("/getTuples")
 	public List<String> getTuples() {
 		return this.jdbcTemplate.queryForList("SELECT * FROM users").stream()
-				.map((m) -> m.values().toString())
+				.map(m -> m.values().toString())
 				.collect(Collectors.toList());
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/src/main/java/com/example/WebController.java
@@ -40,7 +40,7 @@ public class WebController {
 	@GetMapping("/getTuples")
 	public List<String> getTuples() {
 		return this.jdbcTemplate.queryForList("SELECT * FROM users").stream()
-				.map((m) -> m.values().toString())
+				.map(m -> m.values().toString())
 				.collect(Collectors.toList());
 	}
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
@@ -159,7 +159,7 @@ public class TraceSampleApplicationIntegrationTests {
 			List<LogEntry> logEntries = new ArrayList<>();
 			log.debug("Finding logs with filter: " + logFilter);
 			this.logClient.listLogEntries(Logging.EntryListOption.filter(logFilter)).iterateAll()
-					.forEach((le) -> {
+					.forEach(le -> {
 						logEntries.add(le);
 						log.debug("Found log entry: " + le.toString());
 
@@ -176,7 +176,7 @@ public class TraceSampleApplicationIntegrationTests {
 
 
 			List<String> logContents = logEntries.stream()
-					.map((logEntry) -> (String) ((JsonPayload) logEntry.getPayload())
+					.map(logEntry -> (String) ((JsonPayload) logEntry.getPayload())
 							.getDataAsMap().get("message"))
 					.collect(Collectors.toList());
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/test/java/com/example/VisionApiSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/src/test/java/com/example/VisionApiSampleApplicationIntegrationTests.java
@@ -65,7 +65,7 @@ public class VisionApiSampleApplicationIntegrationTests {
 	@Test
 	public void testExtractTextFromImage() throws Exception {
 		this.mockMvc.perform(get(TEXT_IMAGE_URL))
-				.andDo((response) -> {
+				.andDo(response -> {
 					ModelAndView result = response.getModelAndView();
 					String textFromImage = ((String) result.getModelMap().get("text")).trim();
 					assertThat(textFromImage).isEqualTo("STOP");
@@ -75,7 +75,7 @@ public class VisionApiSampleApplicationIntegrationTests {
 	@Test
 	public void testClassifyImageLabels() throws Exception {
 		this.mockMvc.perform(get(LABEL_IMAGE_URL))
-				.andDo((response) -> {
+				.andDo(response -> {
 					ModelAndView result = response.getModelAndView();
 					List<EntityAnnotation> annotations = (List<EntityAnnotation>) result.getModelMap().get("annotations");
 

--- a/spring-cloud-gcp-security-iap/src/test/java/com/google/cloud/spring/security/iap/AudienceValidatorTests.java
+++ b/spring-cloud-gcp-security-iap/src/test/java/com/google/cloud/spring/security/iap/AudienceValidatorTests.java
@@ -63,7 +63,7 @@ public class AudienceValidatorTests {
 		Jwt mockJwt = Mockito.mock(Jwt.class);
 		when(mockJwt.getAudience()).thenReturn(Arrays.asList("cats"));
 
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			AudienceValidator validator = context.getBean(AudienceValidator.class);
 			assertThat(validator.validate(mockJwt).hasErrors()).isFalse();
 		});
@@ -74,7 +74,7 @@ public class AudienceValidatorTests {
 		Jwt mockJwt = Mockito.mock(Jwt.class);
 		when(mockJwt.getAudience()).thenReturn(Arrays.asList("dogs"));
 
-		this.contextRunner.run((context) -> {
+		this.contextRunner.run(context -> {
 			AudienceValidator validator = context.getBean(AudienceValidator.class);
 			assertThat(validator.validate(mockJwt).hasErrors()).isTrue();
 		});

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/inbound/GcsInboundFileSynchronizerTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/inbound/GcsInboundFileSynchronizerTests.java
@@ -72,7 +72,7 @@ public class GcsInboundFileSynchronizerTests {
 		if (Files.exists(testDirectory)) {
 			if (Files.isDirectory(testDirectory)) {
 				try (Stream<Path> files = Files.list(testDirectory)) {
-					files.forEach((path) -> {
+					files.forEach(path -> {
 						try {
 							Files.delete(path);
 						}
@@ -129,15 +129,15 @@ public class GcsInboundFileSynchronizerTests {
 			Blob blob1 = mock(Blob.class);
 			Blob blob2 = mock(Blob.class);
 
-			willAnswer((invocation) -> "legend of heroes").given(blob1).getName();
-			willAnswer((invocation) -> "trails in the sky").given(blob2).getName();
+			willAnswer(invocation -> "legend of heroes").given(blob1).getName();
+			willAnswer(invocation -> "trails in the sky").given(blob2).getName();
 
-			willAnswer((invocation) -> "estelle".getBytes()).given(gcsMock)
+			willAnswer(invocation -> "estelle".getBytes()).given(gcsMock)
 					.readAllBytes(eq("test-bucket"), eq("legend of heroes"));
-			willAnswer((invocation) -> "joshua".getBytes()).given(gcsMock)
+			willAnswer(invocation -> "joshua".getBytes()).given(gcsMock)
 					.readAllBytes(eq("test-bucket"), eq("trails in the sky"));
 
-			willAnswer((invocation) -> new PageImpl<>(null, null,
+			willAnswer(invocation -> new PageImpl<>(null, null,
 					Stream.of(blob1, blob2)
 							.collect(Collectors.toList())))
 					.given(gcsMock).list("test-bucket");

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/inbound/GcsStreamingMessageSourceTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/inbound/GcsStreamingMessageSourceTests.java
@@ -108,8 +108,8 @@ public class GcsStreamingMessageSourceTests {
 
 	private static Blob createBlob(String bucket, String name) {
 		Blob blob = mock(Blob.class);
-		willAnswer((invocationOnMock) -> bucket).given(blob).getBucket();
-		willAnswer((invocationOnMock) -> name).given(blob).getName();
+		willAnswer(invocationOnMock -> bucket).given(blob).getBucket();
+		willAnswer(invocationOnMock -> name).given(blob).getName();
 		return blob;
 	}
 
@@ -124,7 +124,7 @@ public class GcsStreamingMessageSourceTests {
 		public Storage gcsClient() {
 			Storage gcs = mock(Storage.class);
 
-			willAnswer((invocationOnMock) ->
+			willAnswer(invocationOnMock ->
 				new PageImpl<>(null, null,
 						Stream.of(
 								createBlob("gcsbucket", "gamma"),
@@ -133,11 +133,11 @@ public class GcsStreamingMessageSourceTests {
 								.collect(Collectors.toList())))
 					.given(gcs).list(eq("gcsbucket"));
 
-			willAnswer((invocationOnMock) -> mock(ReadChannel.class))
+			willAnswer(invocationOnMock -> mock(ReadChannel.class))
 					.given(gcs).reader(eq("gcsbucket"), eq("alpha/alpha"));
-			willAnswer((invocationOnMock) -> mock(ReadChannel.class))
+			willAnswer(invocationOnMock -> mock(ReadChannel.class))
 					.given(gcs).reader(eq("gcsbucket"), eq("beta"));
-			willAnswer((invocationOnMock) -> mock(ReadChannel.class))
+			willAnswer(invocationOnMock -> mock(ReadChannel.class))
 					.given(gcs).reader(eq("gcsbucket"), eq("gamma"));
 
 			return gcs;

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/outbound/GcsMessageHandlerTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/outbound/GcsMessageHandlerTests.java
@@ -82,15 +82,15 @@ public class GcsMessageHandlerTests {
 		BlobInfo expectedCreateBlobInfo =
 				BlobInfo.newBuilder(BlobId.of("testGcsBucket", "benfica.writing")).build();
 		WriteChannel writeChannel = mock(WriteChannel.class);
-		willAnswer((invocationOnMock) -> writeChannel).given(GCS)
+		willAnswer(invocationOnMock -> writeChannel).given(GCS)
 				.writer(expectedCreateBlobInfo);
-		willAnswer((invocationOnMock) -> 10).given(writeChannel).write(isA(ByteBuffer.class));
+		willAnswer(invocationOnMock -> 10).given(writeChannel).write(isA(ByteBuffer.class));
 
 		CopyWriter copyWriter = mock(CopyWriter.class);
 		ArgumentCaptor<Storage.CopyRequest> copyRequestCaptor = ArgumentCaptor.forClass(Storage.CopyRequest.class);
-		willAnswer((invocationOnMock) -> copyWriter).given(GCS).copy(isA(Storage.CopyRequest.class));
+		willAnswer(invocationOnMock -> copyWriter).given(GCS).copy(isA(Storage.CopyRequest.class));
 
-		willAnswer((invocationOnMock) -> true).given(GCS)
+		willAnswer(invocationOnMock -> true).given(GCS)
 				.delete(BlobId.of("testGcsBucket", "benfica.writing"));
 
 		this.channel.send(new GenericMessage<Object>(testFile));

--- a/spring-cloud-gcp-vision/src/main/java/com/google/cloud/spring/vision/CloudVisionTemplate.java
+++ b/spring-cloud-gcp-vision/src/main/java/com/google/cloud/spring/vision/CloudVisionTemplate.java
@@ -125,7 +125,7 @@ public class CloudVisionTemplate {
 		Image image = Image.newBuilder().setContent(imgBytes).build();
 
 		List<Feature> featureList = Arrays.stream(featureTypes)
-				.map((featureType) -> Feature.newBuilder().setType(featureType).build())
+				.map(featureType -> Feature.newBuilder().setType(featureType).build())
 				.collect(Collectors.toList());
 
 		BatchAnnotateImagesRequest request = BatchAnnotateImagesRequest.newBuilder()


### PR DESCRIPTION
Gnarly regex that I'm not proud of (I am a bit!)

Find: `\(([^\s^,^(.]+?)\) ->`
Replace: `$1 ->`

Breakdown - Lazily capture the contents of a set of parentheses that don't contain a space or a comma, but have at least once character (i.e. not `(foo, bar) ->`,  `(Foo foo) ->`, nor `() ->`). Took a couple of tries but I think I found more than even SonarCloud identified (I don't think SC applies this rule to tests).