### PR TITLE
Rename generic types to single letters to comply with convention

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastorePersistentEntityInformation.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastorePersistentEntityInformation.java
@@ -22,12 +22,12 @@ import org.springframework.data.repository.core.support.AbstractEntityInformatio
  * Holds ID type information about a Datastore persistent entity.
  *
  * @param <T> the type of the persistent entity
- * @param <ID> the ID type of the persistent entity
+ * @param <I> the ID type of the persistent entity
  * @author Chengyuan Zhao
  * @since 1.1
  */
-public class DatastorePersistentEntityInformation<T, ID>
-		extends AbstractEntityInformation<T, ID> {
+public class DatastorePersistentEntityInformation<T, I>
+		extends AbstractEntityInformation<T, I> {
 
 	private final DatastorePersistentEntity<T> persistentEntity;
 
@@ -43,13 +43,13 @@ public class DatastorePersistentEntityInformation<T, ID>
 	}
 
 	@Override
-	public ID getId(T entity) {
-		return (ID) this.persistentEntity.getPropertyAccessor(entity)
+	public I getId(T entity) {
+		return (I) this.persistentEntity.getPropertyAccessor(entity)
 				.getProperty(this.persistentEntity.getIdProperty());
 	}
 
 	@Override
-	public Class<ID> getIdType() {
-		return (Class<ID>) this.persistentEntity.getIdPropertyOrFail().getType();
+	public Class<I> getIdType() {
+		return (Class<I>) this.persistentEntity.getIdPropertyOrFail().getType();
 	}
 }

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/DatastoreRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/DatastoreRepository.java
@@ -25,13 +25,13 @@ import org.springframework.data.repository.query.QueryByExampleExecutor;
  * A {@link PagingAndSortingRepository} that provides Datastore-specific functionality.
  *
  * @param <T> the type of the domain object
- * @param <ID> the type of the ID property in the domain object
+ * @param <I> the type of the ID property in the domain object
  *
  * @author Chengyuan Zhao
  *
  * @since 1.1
  */
-public interface DatastoreRepository<T, ID> extends PagingAndSortingRepository<T, ID>, QueryByExampleExecutor<T> {
+public interface DatastoreRepository<T, I> extends PagingAndSortingRepository<T, I>, QueryByExampleExecutor<T> {
 
 	/**
 	 * Performs multiple read and write operations in a single transaction.
@@ -40,5 +40,5 @@ public interface DatastoreRepository<T, ID> extends PagingAndSortingRepository<T
 	 * @param <A> the final return type of the operations.
 	 * @return the final result of the transaction.
 	 */
-	<A> A performTransaction(Function<DatastoreRepository<T, ID>, A> operations);
+	<A> A performTransaction(Function<DatastoreRepository<T, I>, A> operations);
 }

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/DatastoreRepositoryFactory.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/DatastoreRepositoryFactory.java
@@ -79,7 +79,7 @@ public class DatastoreRepositoryFactory extends RepositoryFactorySupport
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <T, ID> EntityInformation<T, ID> getEntityInformation(Class<T> domainClass) {
+	public <T, I> EntityInformation<T, I> getEntityInformation(Class<T> domainClass) {
 		DatastorePersistentEntity entity = this.datastoreMappingContext
 				.getPersistentEntity(domainClass);
 

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/DatastoreRepositoryFactoryBean.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/DatastoreRepositoryFactoryBean.java
@@ -29,13 +29,13 @@ import org.springframework.data.repository.core.support.RepositoryFactorySupport
 /**
  * Factory bean for creating factories that create Datastore repositories.
  * @param <S> the type of the entities
- * @param <ID> the id type of the entities
+ * @param <I> the id type of the entities
  * @author Chengyuan Zhao
  *
  * @since 1.1
  */
-public class DatastoreRepositoryFactoryBean<S, ID>
-		extends RepositoryFactoryBeanSupport<DatastoreRepository<S, ID>, S, ID>
+public class DatastoreRepositoryFactoryBean<S, I>
+		extends RepositoryFactoryBeanSupport<DatastoreRepository<S, I>, S, I>
 		implements ApplicationContextAware {
 
 	private DatastoreMappingContext datastoreMappingContext;
@@ -51,7 +51,7 @@ public class DatastoreRepositoryFactoryBean<S, ID>
 	 * @param repositoryInterface must not be {@literal null}.
 	 */
 	DatastoreRepositoryFactoryBean(
-			Class<DatastoreRepository<S, ID>> repositoryInterface) {
+			Class<DatastoreRepository<S, I>> repositoryInterface) {
 		super(repositoryInterface);
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepository.java
@@ -46,12 +46,12 @@ import org.springframework.util.Assert;
 /**
  * Implementation of {@link DatastoreRepository}.
  * @param <T> the type of the entities
- * @param <ID> the id type of the entities
+ * @param <I> the id type of the entities
  * @author Chengyuan Zhao
  *
  * @since 1.1
  */
-public class SimpleDatastoreRepository<T, ID> implements DatastoreRepository<T, ID> {
+public class SimpleDatastoreRepository<T, I> implements DatastoreRepository<T, I> {
 
 	private final DatastoreOperations datastoreTemplate;
 
@@ -66,7 +66,7 @@ public class SimpleDatastoreRepository<T, ID> implements DatastoreRepository<T, 
 	}
 
 	@Override
-	public <A> A performTransaction(Function<DatastoreRepository<T, ID>, A> operations) {
+	public <A> A performTransaction(Function<DatastoreRepository<T, I>, A> operations) {
 		return this.datastoreTemplate.performTransaction(template -> operations
 				.apply(new SimpleDatastoreRepository<>(template, this.entityType)));
 	}
@@ -108,12 +108,12 @@ public class SimpleDatastoreRepository<T, ID> implements DatastoreRepository<T, 
 	}
 
 	@Override
-	public Optional<T> findById(ID id) {
+	public Optional<T> findById(I id) {
 		return Optional.ofNullable(this.datastoreTemplate.findById(id, this.entityType));
 	}
 
 	@Override
-	public boolean existsById(ID id) {
+	public boolean existsById(I id) {
 		return this.datastoreTemplate.existsById(id, this.entityType);
 	}
 
@@ -123,7 +123,7 @@ public class SimpleDatastoreRepository<T, ID> implements DatastoreRepository<T, 
 	}
 
 	@Override
-	public Iterable<T> findAllById(Iterable<ID> ids) {
+	public Iterable<T> findAllById(Iterable<I> ids) {
 		return this.datastoreTemplate.findAllById(ids, this.entityType);
 	}
 
@@ -133,7 +133,7 @@ public class SimpleDatastoreRepository<T, ID> implements DatastoreRepository<T, 
 	}
 
 	@Override
-	public void deleteById(ID id) {
+	public void deleteById(I id) {
 		this.datastoreTemplate.deleteById(id, this.entityType);
 	}
 

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/repository/support/FirestoreRepositoryFactoryBean.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/repository/support/FirestoreRepositoryFactoryBean.java
@@ -26,15 +26,15 @@ import org.springframework.data.repository.core.support.RepositoryFactorySupport
 /**
  * The bean to create Firestore repository factories.
  * @param <S> the entity type of the repository
- * @param <ID> the id type of the entity
+ * @param <I> the id type of the entity
  * @param <T> the repository type
  *
  * @author Chengyuan Zhao
  *
  * @since 1.2
  */
-public class FirestoreRepositoryFactoryBean<T extends Repository<S, ID>, S, ID> extends
-		RepositoryFactoryBeanSupport<T, S, ID> {
+public class FirestoreRepositoryFactoryBean<T extends Repository<S, I>, S, I> extends
+		RepositoryFactoryBeanSupport<T, S, I> {
 
 	private FirestoreTemplate firestoreTemplate;
 

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/repository/support/ReactiveFirestoreRepositoryFactory.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/repository/support/ReactiveFirestoreRepositoryFactory.java
@@ -57,8 +57,8 @@ public class ReactiveFirestoreRepositoryFactory extends ReactiveRepositoryFactor
 	}
 
 	@Override
-	public <T, ID> EntityInformation<T, ID> getEntityInformation(Class<T> aClass) {
-		return (EntityInformation<T, ID>) new FirestorePersistentEntityInformation<T>(
+	public <T, I> EntityInformation<T, I> getEntityInformation(Class<T> aClass) {
+		return (EntityInformation<T, I>) new FirestorePersistentEntityInformation<T>(
 				(FirestorePersistentEntity<T>) this.firestoreMappingContext.getPersistentEntity(aClass));
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/SpannerRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/SpannerRepository.java
@@ -26,14 +26,14 @@ import org.springframework.data.repository.PagingAndSortingRepository;
  * A Spring Data repository for Cloud Spanner with specific features.
  *
  * @param <T> the entity type of the repository
- * @param <ID> the id type of the entity
+ * @param <I> the id type of the entity
  *
  * @author Ray Tsang
  * @author Chengyuan Zhao
  *
  * @since 1.1
  */
-public interface SpannerRepository<T, ID> extends PagingAndSortingRepository<T, ID> {
+public interface SpannerRepository<T, I> extends PagingAndSortingRepository<T, I> {
 
 	/**
 	 * Gets a {@link SpannerOperations}, which allows more-direct access to Google Cloud Spanner
@@ -49,7 +49,7 @@ public interface SpannerRepository<T, ID> extends PagingAndSortingRepository<T, 
 	 * @param <A> the final return type of the operations.
 	 * @return the final result of the transaction.
 	 */
-	<A> A performReadWriteTransaction(Function<SpannerRepository<T, ID>, A> operations);
+	<A> A performReadWriteTransaction(Function<SpannerRepository<T, I>, A> operations);
 
 	/**
 	 * Performs multiple read-only operations in a single transaction.
@@ -58,5 +58,5 @@ public interface SpannerRepository<T, ID> extends PagingAndSortingRepository<T, 
 	 * @param <A> the final return type of the operations.
 	 * @return the final result of the transaction.
 	 */
-	<A> A performReadOnlyTransaction(Function<SpannerRepository<T, ID>, A> operations);
+	<A> A performReadOnlyTransaction(Function<SpannerRepository<T, I>, A> operations);
 }

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryFactory.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryFactory.java
@@ -81,7 +81,7 @@ public class SpannerRepositoryFactory extends RepositoryFactorySupport
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <T, ID> EntityInformation<T, ID> getEntityInformation(Class<T> domainClass) {
+	public <T, I> EntityInformation<T, I> getEntityInformation(Class<T> domainClass) {
 		SpannerPersistentEntity<T> entity = (SpannerPersistentEntity<T>) this.spannerMappingContext
 				.getPersistentEntity(domainClass);
 
@@ -91,7 +91,7 @@ public class SpannerRepositoryFactory extends RepositoryFactorySupport
 					domainClass.getName()));
 		}
 
-		return (EntityInformation<T, ID>) new SpannerPersistentEntityInformation<>(
+		return (EntityInformation<T, I>) new SpannerPersistentEntityInformation<>(
 				entity);
 	}
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryFactoryBean.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryFactoryBean.java
@@ -30,15 +30,15 @@ import org.springframework.data.repository.core.support.RepositoryFactorySupport
  * Spanner Repository Factory Bean used to create factories that ultimately create repository implementations.
  *
  * @param <S> the entity type of the repository
- * @param <ID> the id type of the entity
+ * @param <I> the id type of the entity
  * @param <T> the repository type
  * @author Ray Tsang
  * @author Chengyuan Zhao
  *
  * @since 1.1
  */
-public class SpannerRepositoryFactoryBean<T extends Repository<S, ID>, S, ID> extends
-		RepositoryFactoryBeanSupport<T, S, ID> implements
+public class SpannerRepositoryFactoryBean<T extends Repository<S, I>, S, I> extends
+		RepositoryFactoryBeanSupport<T, S, I> implements
 		ApplicationContextAware {
 
 	private SpannerMappingContext spannerMappingContext;


### PR DESCRIPTION
[Type parameter names should comply with a naming convention](https://sonarcloud.io/organizations/googlecloudplatform/rules?open=java%3AS119&rule_key=java%3AS119)