### PR TITLE
Make various fields transient

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTransactionManager.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTransactionManager.java
@@ -42,7 +42,7 @@ public class DatastoreTransactionManager extends AbstractPlatformTransactionMana
 			.setReadOnly(TransactionOptions.ReadOnly.newBuilder().build())
 			.build();
 
-	private final Supplier<Datastore> datastore;
+	private transient final Supplier<Datastore> datastore;
 
 	public DatastoreTransactionManager(final Supplier<Datastore> datastore) {
 		this.datastore = datastore;

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/event/DeleteEvent.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/event/DeleteEvent.java
@@ -31,11 +31,11 @@ import org.springframework.context.ApplicationEvent;
  */
 public class DeleteEvent extends ApplicationEvent {
 
-	private final Optional<Class> targetEntityClass;
+	private transient final Optional<Class> targetEntityClass;
 
-	private final Optional<Iterable> targetIds;
+	private transient final Optional<Iterable> targetIds;
 
-	private final Optional<Iterable> targetEntities;
+	private transient final Optional<Iterable> targetEntities;
 
 	/**
 	 * Constructor.

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/transaction/ReactiveFirestoreTransactionManager.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/transaction/ReactiveFirestoreTransactionManager.java
@@ -49,11 +49,11 @@ import org.springframework.util.Assert;
  */
 public class ReactiveFirestoreTransactionManager extends AbstractReactiveTransactionManager {
 
-	private final FirestoreGrpc.FirestoreStub firestore;
+	private transient final FirestoreGrpc.FirestoreStub firestore;
 
 	private final String databasePath;
 
-	private FirestoreClassMapper classMapper;
+	private transient final FirestoreClassMapper classMapper;
 
 	/**
 	 * Constructor for ReactiveFirestoreTransactionManager.

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerTransactionManager.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerTransactionManager.java
@@ -57,7 +57,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  * @since 1.1
  */
 public class SpannerTransactionManager extends AbstractPlatformTransactionManager {
-	private final Supplier<DatabaseClient> databaseClientProvider;
+	private transient final Supplier<DatabaseClient> databaseClientProvider;
 
 	public SpannerTransactionManager(final Supplier databaseClientProvider) {
 		this.databaseClientProvider = databaseClientProvider;

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/event/MutationEvent.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/event/MutationEvent.java
@@ -30,7 +30,7 @@ import org.springframework.context.ApplicationEvent;
  */
 public class MutationEvent extends ApplicationEvent {
 
-	private final Iterable targetEntities;
+	private transient final Iterable<?> targetEntities;
 
 	/**
 	 * Constructor.
@@ -38,7 +38,7 @@ public class MutationEvent extends ApplicationEvent {
 	 * @param targetEntities the target entities that need to be mutated. This may be
 	 *     {@code null} depending on the type of delete request.
 	 */
-	public MutationEvent(List<Mutation> source, Iterable targetEntities) {
+	public MutationEvent(List<Mutation> source, Iterable<?> targetEntities) {
 		super(source);
 		this.targetEntities = targetEntities;
 	}


### PR DESCRIPTION
I'm not 100% sure on this one, but it's my understanding that `Serializable` objects must have all of their non-`transient` fields also be `Serializable`, and if they can't/aren't, they are marked `transient` and thus ignored. 

Since many of these objects are java language constructs (`Supplier`, `Optional`) or from dependent libraries (stubs), there's not much we can do to make the objects `Serializable`, thus I've marked them `transient`