### PR TITLE
Break up the monster Spanner integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
 								<headerLocation>checkstyle-header.txt</headerLocation>
 								<propertyExpansion>
 									checkstyle.build.directory=${project.build.directory}
-									checkstyle.suppressions.file=https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/main/spring-cloud-build-tools/src/checkstyle/checkstyle-suppressions.xml
+									checkstyle.suppressions.file=https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-build-tools/src/checkstyle/checkstyle-suppressions.xml
 									checkstyle.additional.suppressions.file=${maven.multiModuleProjectDirectory}/src/checkstyle/checkstyle-suppressions.xml
 								</propertyExpansion>
 								<consoleOutput>true</consoleOutput>

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
@@ -458,7 +458,7 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		assertThat(this.testEntityRepository.countBySize(1L)).isZero();
 
 		//test saveAll for iterable
-		Iterable<TestEntity> testEntities = () -> this.allTestEntities.iterator();
+		Iterable<TestEntity> testEntities = this.allTestEntities::iterator;
 		this.testEntityRepository.saveAll(testEntities);
 
 		this.millisWaited = Math.max(this.millisWaited,

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -39,6 +39,7 @@ import com.google.cloud.spring.data.spanner.test.domain.SymbolAction;
 import com.google.cloud.spring.data.spanner.test.domain.Trade;
 import com.google.cloud.spring.data.spanner.test.domain.TradeProjection;
 import com.google.cloud.spring.data.spanner.test.domain.TradeRepository;
+import com.google.common.collect.Iterables;
 import org.assertj.core.util.Sets;
 import org.junit.After;
 import org.junit.Before;
@@ -110,81 +111,108 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 	}
 
 	@Test
-	public void queryMethodsTest() {
+	public void queryMethodsTest_simple() {
 		final int subTrades = 42;
 		Trade trade = Trade.aTrade(null, subTrades);
 		this.spannerOperations.insert(trade);
 
+		Optional<Trade> fetchedTrade = tradeRepository.fetchById(trade.getId());
+		assertThat(fetchedTrade)
+				.isPresent().get()
+				.hasFieldOrPropertyWithValue("bigDecimalField", trade.getBigDecimalField())
+				.hasFieldOrPropertyWithValue("bigDecimals", trade.getBigDecimals());
+
 		final String identifier = trade.getTradeDetail().getId();
 		final String traderId = trade.getTraderId();
 
-		Optional<Trade> fetchedTrade = tradeRepository.fetchById(trade.getId());
-		assertThat(fetchedTrade.get().getBigDecimalField()).isEqualTo(trade.getBigDecimalField());
-		assertThat(fetchedTrade.get().getBigDecimals()).isEqualTo(trade.getBigDecimals());
+		assertThat(subTradeRepository.countBy(identifier, traderId)).isEqualTo(subTrades);
 
-		long count = subTradeRepository.countBy(identifier, traderId);
-		assertThat(count)
-				.isEqualTo(subTrades);
-
-		List<SubTrade> list = subTradeRepository.getList(
-				identifier, traderId, Sort.by(Order.desc("subTradeId")));
-		assertThat(list)
-				.hasSize(subTrades);
-		assertThat(list.get(subTrades - 1))
+		List<SubTrade> list = subTradeRepository.getList(identifier, traderId, Sort.by(Order.desc("subTradeId")));
+		assertThat(list).hasSize(subTrades)
+				.last()
 				.satisfies(s -> assertThat(s.getSubTradeId()).isEqualTo("subTrade0"));
 
 		List<SubTrade> page = subTradeRepository.getPage(
 				identifier, traderId, PageRequest.of(0, 1024, Sort.by(Order.asc("subTradeId"))));
-		assertThat(page)
-				.hasSize(subTrades);
-		assertThat(page.get(0))
+		assertThat(page).hasSize(subTrades)
+				.first()
 				.satisfies(s -> assertThat(s.getSubTradeId()).isEqualTo("subTrade0"));
+	}
 
-		this.tradeRepository.deleteAll();
+	@Test
+	public void queryMethodsTest_updateActionTradeById() {
+		List<Trade> trader1BuyTrades = insertTrades("trader1", "BUY", 3);
 
+		Trade buyTrade1 = trader1BuyTrades.get(0);
+		this.tradeRepository.updateActionTradeById(buyTrade1.getId(), "invalid action");
+		assertThat(this.tradeRepository.findById(this.spannerSchemaUtils.getKey(buyTrade1)))
+				.isPresent().get()
+				.extracting(Trade::getAction)
+				.isEqualTo("invalid action");
+
+		this.tradeRepository.updateActionTradeById(buyTrade1.getId(), "BUY");
+		assertThat(this.tradeRepository.findById(this.spannerSchemaUtils.getKey(buyTrade1)))
+				.isPresent().get()
+				.extracting(Trade::getAction)
+				.isEqualTo("BUY");
+	}
+
+	@Test
+	public void queryMethodsTest_BoundParameters() {
+		insertTrades("trader1", "BUY", 3);
+		insertTrades("trader1", "SELL", 2);
+		insertTrades("trader2", "SELL", 3);
+
+		assertThat(this.tradeRepository.count()).isEqualTo(8L);
+
+		assertThat(this.tradeRepository.countByActionIn(Arrays.asList("BUY", "SELL"))).isEqualTo(8L);
+		assertThat(this.tradeRepository.countByActionIn(Collections.singletonList("BUY"))).isEqualTo(3L);
+		assertThat(this.tradeRepository.countByActionIn(Collections.singletonList("SELL"))).isEqualTo(5L);
+		assertThat(this.tradeRepository.countWithInQuery(Arrays.asList("BUY", "SELL"))).isEqualTo(8L);
+		assertThat(this.tradeRepository.countWithInQuery(Collections.singletonList("BUY"))).isEqualTo(3L);
+		assertThat(this.tradeRepository.countWithInQuery(Collections.singletonList("SELL"))).isEqualTo(5L);
+		assertThat(this.tradeRepository.findByActionIn(Sets.newHashSet(Arrays.asList("BUY", "SELL")))).hasSize(8);
+		assertThat(this.tradeRepository.findByActionIn(Collections.singleton("BUY"))).hasSize(3);
+		assertThat(this.tradeRepository.findByActionIn(Collections.singleton("SELL"))).hasSize(5);
+	}
+
+	@Test
+	public void queryMethodsTest_deleteByAction() {
+		insertTrades("trader1", "BUY", 3);
+		insertTrades("trader1", "SELL", 2);
+		insertTrades("trader2", "SELL", 3);
+
+		assertThat(this.tradeRepository.deleteByAction("BUY")).isEqualTo(3);
+		assertThat(this.tradeRepository.count()).isEqualTo(5L);
+	}
+
+	@Test
+	public void queryMethodsTest_deleteBySymbol() {
+		insertTrades("trader1", "SELL", 2);
+		insertTrades("trader2", "SELL", 3);
+
+		assertThat(this.tradeRepository.deleteBySymbol("ABCD")).hasSize(5);
+		assertThat(this.tradeRepository.count()).isZero();
+	}
+
+	@Test
+	public void queryMethodsTest_deleteBySymbolAndAction() {
+		insertTrades("trader1", "SELL", 2);
+		insertTrades("trader2", "SELL", 3);
+
+		assertThat(this.tradeRepository.count()).isEqualTo(5L);
+		this.tradeRepository.deleteBySymbolAndAction("ABCD", "SELL");
+		assertThat(this.tradeRepository.count()).isZero();
+	}
+
+	@Test
+	public void queryMethodsTest_readsAndCounts() {
 		List<Trade> trader1BuyTrades = insertTrades("trader1", "BUY", 3);
 		List<Trade> trader1SellTrades = insertTrades("trader1", "SELL", 2);
 		List<Trade> trader2Trades = insertTrades("trader2", "SELL", 3);
 
-		List<Trade> allTrades = new ArrayList<>();
-		allTrades.addAll(trader1BuyTrades);
-		allTrades.addAll(trader1SellTrades);
-		allTrades.addAll(trader2Trades);
-
-		Trade buyTrade1 = trader1BuyTrades.get(0);
-		this.tradeRepository.updateActionTradeById(buyTrade1.getId(), "invalid action");
-		assertThat(this.tradeRepository.findById(this.spannerSchemaUtils.getKey(buyTrade1)).get().getAction())
-				.isEqualTo("invalid action");
-		this.tradeRepository.updateActionTradeById(buyTrade1.getId(), "BUY");
-		assertThat(this.tradeRepository.findById(this.spannerSchemaUtils.getKey(buyTrade1)).get().getAction())
-				.isEqualTo("BUY");
-
-		assertThat(this.tradeRepository.count()).isEqualTo(8L);
-
-		arrayParameterBindTest();
-
-		assertThat(this.tradeRepository.deleteByAction("BUY")).isEqualTo(3);
-
-		assertThat(this.tradeRepository.count()).isEqualTo(5L);
-
-		List<Trade> deletedBySymbol = this.tradeRepository.deleteBySymbol("ABCD");
-
-		assertThat(deletedBySymbol).hasSize(5);
-
-		assertThat(this.tradeRepository.count()).isZero();
-
-		this.tradeRepository.saveAll(deletedBySymbol);
-
-		assertThat(this.tradeRepository.count()).isEqualTo(5L);
-
-		this.tradeRepository.deleteBySymbolAndAction("ABCD", "SELL");
-
-		assertThat(this.tradeRepository.count()).isZero();
-
-		this.tradeRepository.saveAll(allTrades);
-
-		List<Trade> allTradesRetrieved = this.spannerOperations.readAll(Trade.class);
-		assertThat(allTradesRetrieved).containsExactlyInAnyOrderElementsOf(allTrades);
+		Iterable<Trade> allTrades = Iterables.concat(trader1BuyTrades, trader1SellTrades, trader2Trades);
+		assertThat(this.spannerOperations.readAll(Trade.class)).containsExactlyInAnyOrderElementsOf(allTrades);
 
 		assertThat(this.tradeRepository.countByAction("BUY")).isEqualTo(3);
 		assertThat(this.tradeRepository.countByActionQuery("BUY")).isEqualTo(3);
@@ -195,17 +223,19 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 		assertThat(this.tradeRepository.getFirstString("BUY")).isEqualTo("BUY");
 		assertThat(this.tradeRepository.getFirstStringList("BUY"))
 				.containsExactlyInAnyOrder("BUY", "BUY", "BUY");
+	}
 
-		List<Trade> trader2TradesRetrieved = this.tradeRepository
-				.findByTraderId("trader2");
+	@Test
+	public void queryMethodsTest_Trader2() {
+		List<Trade> trader2Trades = insertTrades("trader2", "SELL", 3);
+
+		List<Trade> trader2TradesRetrieved = this.tradeRepository.findByTraderId("trader2");
 		assertThat(trader2TradesRetrieved).containsExactlyInAnyOrderElementsOf(trader2Trades);
 
-		assertThat(this.tradeRepository
-				.findByTraderId("trader2", PageRequest.of(0, 2, Sort.by("tradeTime"))))
+		assertThat(this.tradeRepository.findByTraderId("trader2", PageRequest.of(0, 2, Sort.by("tradeTime"))))
 				.containsExactlyInAnyOrder(trader2Trades.get(0), trader2Trades.get(1));
 
-		assertThat(this.tradeRepository
-				.findByTraderId("trader2", PageRequest.of(1, 2, Sort.by("tradeTime"))))
+		assertThat(this.tradeRepository.findByTraderId("trader2", PageRequest.of(1, 2, Sort.by("tradeTime"))))
 				.containsExactlyInAnyOrder(trader2Trades.get(2));
 
 		assertThat(this.tradeRepository
@@ -227,14 +257,25 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 		assertThat(this.tradeRepository
 				.findTop2ByTraderIdOrderByTradeTimeAsc("trader2", PageRequest.of(0, 1, Sort.by(Direction.DESC, "tradeTime"))))
 				.containsExactlyInAnyOrder(trader2Trades.get(2));
+	}
 
-		List<TradeProjection> tradeProjectionsRetrieved = this.tradeRepository
-				.findByActionIgnoreCase("bUy");
+	@Test
+	public void queryMethodsTest_caseSensitive() {
+		insertTrades("trader1", "BUY", 3);
+
+		List<TradeProjection> tradeProjectionsRetrieved = this.tradeRepository.findByActionIgnoreCase("bUy");
 		assertThat(tradeProjectionsRetrieved).hasSize(3);
 		for (TradeProjection tradeProjection : tradeProjectionsRetrieved) {
 			assertThat(tradeProjection.getAction()).isEqualTo("BUY");
 			assertThat(tradeProjection.getSymbolAndAction()).isEqualTo("ABCD BUY");
 		}
+	}
+
+	@Test
+	public void queryMethodsTest_sortingAndPaging() {
+		List<Trade> trader1BuyTrades = insertTrades("trader1", "BUY", 3);
+		insertTrades("trader1", "SELL", 2);
+		insertTrades("trader2", "SELL", 3);
 
 		List<Trade> tradesReceivedPage0 = this.tradeRepository
 				.findAll(PageRequest.of(0, 3, Sort.by(Order.asc("id"))))
@@ -263,12 +304,24 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 		assertThat(buyTradesRetrieved).containsExactlyInAnyOrderElementsOf(trader1BuyTrades);
 		assertThat(buyTradesRetrieved.get(0).getId()).isGreaterThan(buyTradesRetrieved.get(1).getId());
 		assertThat(buyTradesRetrieved.get(1).getId()).isGreaterThan(buyTradesRetrieved.get(2).getId());
+	}
+
+	@Test
+	public void queryMethodsTest_CustomSort() {
+		insertTrades("trader1", "BUY", 3);
+		insertTrades("trader1", "SELL", 2);
+		insertTrades("trader2", "SELL", 3);
 
 		List<Trade> customSortedTrades = this.tradeRepository.sortedTrades(PageRequest
 				.of(2, 2, org.springframework.data.domain.Sort.by(Order.asc("id"))));
 
 		assertThat(customSortedTrades).hasSize(2);
 		assertThat(customSortedTrades.get(0).getId()).isLessThan(customSortedTrades.get(1).getId());
+	}
+
+	@Test
+	public void queryMethodsTest_Wildcards() {
+		insertTrades("trader1", "BUY", 3);
 
 		this.tradeRepository.findBySymbolLike("%BCD")
 				.forEach(x -> assertThat(x.getSymbol()).isEqualTo("ABCD"));
@@ -278,45 +331,63 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 				.forEach(x -> assertThat(x.getSymbol()).isEqualTo("ABCD"));
 		assertThat(this.tradeRepository.findBySymbolNotContains("BCD")).isEmpty();
 
-		assertThat(this.tradeRepository
-				.findBySymbolAndActionPojo(new SymbolAction("ABCD", "BUY"))).hasSize(3);
+		assertThat(this.tradeRepository.findBySymbolAndActionPojo(new SymbolAction("ABCD", "BUY"))).hasSize(3);
 		assertThat(this.tradeRepository.findBySymbolAndActionStruct(Struct.newBuilder()
-						.set("symbol").to("ABCD").set("action").to("BUY").build())
-				).hasSize(3);
+				.set("symbol").to("ABCD").set("action").to("BUY").build())
+		).hasSize(3);
+	}
 
-		// testing setting some columns to null.
+	@Test
+	public void queryMethodsTest_NullColumns() {
+		insertTrades("trader1", "BUY", 3);
+
 		Trade someTrade = this.tradeRepository.findBySymbolContains("ABCD").get(0);
 		assertThat(someTrade.getExecutionTimes()).isNotNull();
 		assertThat(someTrade.getSymbol()).isNotNull();
 		someTrade.setExecutionTimes(null);
 		someTrade.setSymbol(null);
 		this.tradeRepository.save(someTrade);
-		someTrade = this.tradeRepository.findById(this.spannerSchemaUtils.getKey(someTrade)).get();
+		someTrade = this.tradeRepository.findById(this.spannerSchemaUtils.getKey(someTrade))
+				.orElseThrow(() -> new AssertionError("did not find expected trade"));
 		assertThat(someTrade.getExecutionTimes()).isNull();
 		assertThat(someTrade.getSymbol()).isNull();
+	}
+
+	@Test
+	public void queryMethodsTest_ParentChildOperations() {
+		insertTrades("trader1", "BUY", 3);
+
+		Trade someTrade = this.tradeRepository.findBySymbolContains("ABCD").get(0);
 
 		// testing parent-child relationships
 		assertThat(someTrade.getSubTrades()).isEmpty();
-		SubTrade subTrade1 = new SubTrade(someTrade.getTradeDetail().getId(),
-				someTrade.getTraderId(), "subTrade1");
-		SubTrade subTrade2 = new SubTrade(someTrade.getTradeDetail().getId(),
-				someTrade.getTraderId(), "subTrade2");
-		SubTradeComponent subTradeComponent11 = new SubTradeComponent(
-				someTrade.getTradeDetail().getId(), someTrade.getTraderId(), "subTrade1",
-				"11a", "11b");
+		SubTrade subTrade1 = new SubTrade(someTrade.getTradeDetail().getId(), someTrade.getTraderId(), "subTrade1");
+		SubTrade subTrade2 = new SubTrade(someTrade.getTradeDetail().getId(), someTrade.getTraderId(), "subTrade2");
+
+
+		SubTradeComponent subTradeComponent11 = new SubTradeComponent(someTrade.getTradeDetail().getId(),
+				someTrade.getTraderId(),
+				"subTrade1",
+				"11a",
+				"11b");
 		subTradeComponent11.setCommitTimestamp(Timestamp.ofTimeMicroseconds(11));
-		SubTradeComponent subTradeComponent21 = new SubTradeComponent(
-				someTrade.getTradeDetail().getId(), someTrade.getTraderId(), "subTrade2",
-				"21a", "21b");
+
+		SubTradeComponent subTradeComponent21 = new SubTradeComponent(someTrade.getTradeDetail().getId(),
+				someTrade.getTraderId(),
+				"subTrade2",
+				"21a",
+				"21b");
 		subTradeComponent21.setCommitTimestamp(Timestamp.ofTimeMicroseconds(21));
-		SubTradeComponent subTradeComponent22 = new SubTradeComponent(
-				someTrade.getTradeDetail().getId(), someTrade.getTraderId(), "subTrade2",
-				"22a", "22b");
+
+		SubTradeComponent subTradeComponent22 = new SubTradeComponent(someTrade.getTradeDetail().getId(),
+				someTrade.getTraderId(),
+				"subTrade2",
+				"22a",
+				"22b");
 		subTradeComponent22.setCommitTimestamp(Timestamp.ofTimeMicroseconds(22));
 
-		subTrade1.setSubTradeComponentList(Arrays.asList(subTradeComponent11));
-		subTrade2.setSubTradeComponentList(
-				Arrays.asList(subTradeComponent21, subTradeComponent22));
+		subTrade1.setSubTradeComponentList(Collections.singletonList(subTradeComponent11));
+		subTrade2.setSubTradeComponentList(Arrays.asList(subTradeComponent21, subTradeComponent22));
 		someTrade.setSubTrades(Arrays.asList(subTrade1, subTrade2));
 
 		this.tradeRepository.save(someTrade);
@@ -324,59 +395,84 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 		assertThat(this.subTradeRepository.count()).isEqualTo(2);
 		assertThat(this.subTradeComponentRepository.count()).isEqualTo(3);
 
-		// test eager-fetch in @Query
+		Iterable<SubTradeComponent> subTradeComponents = this.subTradeComponentRepository.findAll();
+		Timestamp expectedTS = subTradeComponents.iterator().next().getCommitTimestamp();
+
+		assertThat(subTradeComponents)
+				.hasSize(3)
+				.extracting(SubTradeComponent::getCommitTimestamp)
+				.allSatisfy(ts ->
+						assertThat(ts)
+								.isEqualTo(expectedTS)
+								.isGreaterThan(Timestamp.ofTimeMicroseconds(22))
+				);
+
+		this.subTradeRepository.deleteById(this.spannerSchemaUtils.getKey(subTrade1));
+		assertThat(this.subTradeComponentRepository.count()).isEqualTo(2);
+
+		someTrade = this.tradeRepository.findById(this.spannerSchemaUtils.getKey(someTrade))
+				.orElseThrow(() -> new AssertionError("did not find expected trade"));
+		assertThat(someTrade.getSubTrades())
+				.hasSize(1)
+				.first()
+				.hasFieldOrPropertyWithValue("subTradeId", "subTrade2")
+				.extracting(SubTrade::getSubTradeComponentList)
+				.asList()
+				.hasSize(2);
+
+		this.tradeRepository.delete(someTrade);
+
+		assertThat(this.subTradeComponentRepository.count()).isZero();
+		assertThat(this.subTradeRepository.count()).isZero();
+	}
+
+	@Test
+	public void queryMethodsTest_EagerFetch() {
 		Mockito.clearInvocations(spannerTemplate);
-		final Trade aTrade = someTrade;
+
+		final Trade aTrade = Trade.aTrade("trader1", 0, 0);
+		aTrade.setAction("BUY");
+		aTrade.setSymbol("ABCD");
+		this.tradeRepository.save(aTrade);
+
 		assertThat(tradeRepository.fetchById(aTrade.getId()))
 				.isNotEmpty()
 				.hasValueSatisfying(t -> assertThat(t.getId()).isEqualTo(aTrade.getId()))
 				.hasValueSatisfying(t -> assertThat(t.getTraderId()).isEqualTo(aTrade.getTraderId()))
 				.hasValueSatisfying(t -> assertThat(t.getSymbol()).isEqualTo(aTrade.getSymbol()))
 				.hasValueSatisfying(t -> assertThat(t.getSubTrades()).hasSize(aTrade.getSubTrades().size()));
-		Mockito.verify(spannerTemplate, Mockito.times(1))
-				.executeQuery(any(Statement.class), any());
+		Mockito.verify(spannerTemplate, Mockito.times(1)).executeQuery(any(Statement.class), any());
 		Mockito.verify(spannerTemplate, Mockito.times(1))
 				.query(eq(Trade.class), any(Statement.class), any(SpannerQueryOptions.class));
+	}
 
-		List<SubTradeComponent> subTradeComponents = (List) this.subTradeComponentRepository.findAll();
+	@Test
+	public void queryMethodsTest_SoftDelete() {
+		Trade someTrade = insertTrade("trader1", "BUY", 1);
+		SubTrade subTrade1 = new SubTrade(someTrade.getTradeDetail().getId(), someTrade.getTraderId(), "subTrade1");
+		SubTrade subTrade2 = new SubTrade(someTrade.getTradeDetail().getId(), someTrade.getTraderId(), "subTrade2");
+		someTrade.setSubTrades(Arrays.asList(subTrade1, subTrade2));
+		this.tradeRepository.save(someTrade);
 
-		assertThat(subTradeComponents.get(0).getCommitTimestamp())
-				.isEqualTo(subTradeComponents.get(1).getCommitTimestamp());
-		assertThat(subTradeComponents.get(0).getCommitTimestamp())
-				.isEqualTo(subTradeComponents.get(2).getCommitTimestamp());
-		assertThat(subTradeComponents.get(0).getCommitTimestamp()).isGreaterThan(Timestamp.ofTimeMicroseconds(22));
-
-		this.subTradeRepository.deleteById(this.spannerSchemaUtils.getKey(subTrade1));
-		assertThat(this.subTradeComponentRepository.count()).isEqualTo(2);
-
-		someTrade = this.tradeRepository
-				.findById(this.spannerSchemaUtils.getKey(someTrade)).get();
-		assertThat(someTrade.getSubTrades()).hasSize(1);
-		assertThat(someTrade.getSubTrades().get(0).getSubTradeId()).isEqualTo("subTrade2");
-		assertThat(someTrade.getSubTrades().get(0).getSubTradeComponentList()).hasSize(2);
-
-		this.tradeRepository.delete(someTrade);
-
-		assertThat(this.subTradeComponentRepository.count()).isZero();
-		assertThat(this.subTradeRepository.count()).isZero();
-
-		this.tradeRepository.deleteAll();
-		this.tradeRepositoryTransactionalService.testTransactionalAnnotation(3);
 		assertThat(this.tradeRepository.count()).isEqualTo(1L);
 
-		List<Trade> trades = (List) tradeRepository.findAll();
-		someTrade = trades.get(0);
-		assertThat(someTrade.getSubTrades()).hasSize(3);
-		SubTrade someSubTrade = trades.get(0).getSubTrades().get(0);
-		someSubTrade.setDisabled(true); // a soft-delete
-		subTradeRepository.save(someSubTrade);
-
-		someTrade = this.tradeRepository
-				.findById(this.spannerSchemaUtils.getKey(someTrade)).get();
-		assertThat(someTrade.getSubTrades())
-				.doesNotContain(someSubTrade) // "someSubTrade" was soft-deleted
+		assertThat(tradeRepository.findAll())
+				.isNotNull()
+				.hasSize(1)
+				.first()
+				.extracting(Trade::getSubTrades)
+				.asList()
 				.hasSize(2);
 
+
+		subTrade1.setDisabled(true); // a soft-delete
+		subTradeRepository.save(subTrade1);
+
+		Trade gotTrade = this.tradeRepository.findById(this.spannerSchemaUtils.getKey(someTrade))
+				.orElseThrow(() -> new AssertionError("did not find expected trade"));
+		assertThat(gotTrade.getSubTrades())
+				.doesNotContain(subTrade1) // "subTrade1" was soft-deleted
+				.hasSize(1);
 	}
 
 	@Test
@@ -400,6 +496,12 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 	}
 
 	@Test
+	public void testTransaction() {
+		this.tradeRepositoryTransactionalService.testTransactionalAnnotation(2);
+		assertThat(this.tradeRepository.count()).isEqualTo(1L);
+	}
+
+	@Test
 	public void testTransactionRolledBack() {
 		assertThat(this.tradeRepository.count()).isZero();
 		try {
@@ -411,28 +513,20 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 		assertThat(this.tradeRepository.count()).isZero();
 	}
 
-	private void arrayParameterBindTest() {
-		assertThat(this.tradeRepository.countByActionIn(Arrays.asList("BUY", "SELL"))).isEqualTo(8L);
-		assertThat(this.tradeRepository.countByActionIn(Collections.singletonList("BUY"))).isEqualTo(3L);
-		assertThat(this.tradeRepository.countByActionIn(Collections.singletonList("SELL"))).isEqualTo(5L);
-		assertThat(this.tradeRepository.countWithInQuery(Arrays.asList("BUY", "SELL"))).isEqualTo(8L);
-		assertThat(this.tradeRepository.countWithInQuery(Collections.singletonList("BUY"))).isEqualTo(3L);
-		assertThat(this.tradeRepository.countWithInQuery(Collections.singletonList("SELL"))).isEqualTo(5L);
-		assertThat(this.tradeRepository.findByActionIn(Sets.newHashSet(Arrays.asList("BUY", "SELL")))).hasSize(8);
-		assertThat(this.tradeRepository.findByActionIn(Collections.singleton("BUY"))).hasSize(3);
-		assertThat(this.tradeRepository.findByActionIn(Collections.singleton("SELL"))).hasSize(5);
-	}
-
 	private List<Trade> insertTrades(String traderId, String action, int numTrades) {
 		List<Trade> trades = new ArrayList<>();
 		for (int i = 0; i < numTrades; i++) {
-			Trade t = Trade.aTrade(traderId, 0, i);
-			t.setAction(action);
-			t.setSymbol("ABCD");
-			trades.add(t);
-			this.spannerOperations.insert(t);
+			trades.add(insertTrade(traderId, action, i));
 		}
 		return trades;
+	}
+
+	private Trade insertTrade(String traderId, String action, int tradeTime) {
+		Trade t = Trade.aTrade(traderId, 0, tradeTime);
+		t.setAction(action);
+		t.setSymbol("ABCD");
+		this.spannerOperations.insert(t);
+		return t;
 	}
 
 	/**

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/IntegrationTestConfiguration.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/IntegrationTestConfiguration.java
@@ -179,6 +179,6 @@ public class IntegrationTestConfiguration {
 
 	@Bean
 	String tableNameSuffix() {
-		return this.TABLE_SUFFIX;
+		return TABLE_SUFFIX;
 	}
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/SpannerTestExecutionListener.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/SpannerTestExecutionListener.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.data.spanner.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.cloud.spring.data.spanner.core.admin.SpannerDatabaseAdminTemplate;
+import com.google.cloud.spring.data.spanner.core.admin.SpannerSchemaUtils;
+import com.google.cloud.spring.data.spanner.test.domain.CommitTimestamps;
+import com.google.cloud.spring.data.spanner.test.domain.Trade;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.awaitility.Duration;
+
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestExecutionListener;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class SpannerTestExecutionListener implements TestExecutionListener {
+
+	private static final Log LOGGER = LogFactory.getLog(SpannerTestExecutionListener.class);
+
+	private SpannerDatabaseAdminTemplate spannerDatabaseAdminTemplate;
+
+	private SpannerSchemaUtils spannerSchemaUtils;
+
+	@Override
+	public void beforeTestClass(TestContext testContext) throws Exception {
+		// This runs before the JUnit @BeforeClass method, so this property needs to be checked here, too.
+		if (!"true".equalsIgnoreCase(System.getProperty("it.spanner"))) {
+			return;
+		}
+
+		spannerDatabaseAdminTemplate = testContext.getApplicationContext().getBean(SpannerDatabaseAdminTemplate.class);
+		spannerSchemaUtils = testContext.getApplicationContext().getBean(SpannerSchemaUtils.class);
+		createDatabaseWithSchema();
+	}
+	@Override
+	public void afterTestClass(TestContext testContext) throws Exception {
+		if (!"true".equalsIgnoreCase(System.getProperty("it.spanner"))) {
+			return;
+		}
+
+		SpannerDatabaseAdminTemplate spannerDatabaseAdminTemplate =
+				testContext.getApplicationContext().getBean(SpannerDatabaseAdminTemplate.class);
+		SpannerSchemaUtils spannerSchemaUtils =
+				testContext.getApplicationContext().getBean(SpannerSchemaUtils.class);
+
+		List<String> dropSchemaStatements =
+				spannerSchemaUtils.getDropTableDdlStringsForInterleavedHierarchy(Trade.class);
+		dropSchemaStatements.add(spannerSchemaUtils.getDropTableDdlString(CommitTimestamps.class));
+
+		spannerDatabaseAdminTemplate.executeDdlStrings(dropSchemaStatements, false);
+	}
+
+
+	protected void createDatabaseWithSchema() {
+		List<String> createStatements = createSchemaStatements();
+
+		if (!this.spannerDatabaseAdminTemplate.databaseExists()) {
+			LOGGER.debug(
+					this.getClass() + " - Integration database created with schema: "
+							+ createStatements);
+			this.spannerDatabaseAdminTemplate.executeDdlStrings(createStatements, true);
+		}
+		else {
+			LOGGER.debug(
+					this.getClass() + " - schema created: " + createStatements);
+			this.spannerDatabaseAdminTemplate.executeDdlStrings(createStatements, false);
+		}
+
+		await().pollDelay(Duration.FIVE_SECONDS)
+				.pollInterval(Duration.TWO_SECONDS)
+				.atMost(Duration.ONE_MINUTE)
+				.untilAsserted(() -> assertThat(this.spannerDatabaseAdminTemplate.databaseExists()).isTrue());
+	}
+
+	protected List<String> createSchemaStatements() {
+		List<String> list = new ArrayList<>(this.spannerSchemaUtils
+				.getCreateTableDdlStringsForInterleavedHierarchy(Trade.class));
+		list.add(this.spannerSchemaUtils
+				.getCreateTableDdlString(CommitTimestamps.class)
+				.replaceAll("TIMESTAMP", "TIMESTAMP OPTIONS (allow_commit_timestamp = true)"));
+		return list;
+	}
+}

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -8,4 +8,5 @@
     <suppress files=".*" checks="LineLength" />
     <suppress checks="Illegal" files=".*RSAKeyGeneratorUtils.java"/>
     <suppress checks="IllegalImport" files=".*KmsTemplate.java"/>
+    <suppress checks="IllegalImport" files=".*SpannerRepositoryIntegrationTests.java"/>
 </suppressions>


### PR DESCRIPTION
Turns out the DB cleanup code was broken too - fixed that as well.

I suggest reviewing one commit at a time.

Context: Was fixing the error flagged by [Test methods should not contain too many assertions](https://sonarcloud.io/organizations/googlecloudplatform/rules?open=java%3AS5961&rule_key=java%3AS5961), but this unit test was heavy on the test but not the _unit_ part. It contained 89 assertions in this one method (max is set at 25).

