### PR TITLE
Modify withParent to accept String only

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreReactiveOperations.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreReactiveOperations.java
@@ -162,5 +162,5 @@ public interface FirestoreReactiveOperations {
 	 * @return template with a given parent.
 	 * @since 2.0.1
 	 */
-	FirestoreReactiveOperations withParent(Object id, Class<?> entityClass);
+	FirestoreReactiveOperations withParent(String id, Class<?> entityClass);
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
@@ -249,7 +249,7 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 	}
 
 	@Override
-	public FirestoreReactiveOperations withParent(Object id, Class<?> entityClass) {
+	public FirestoreReactiveOperations withParent(String id, Class<?> entityClass) {
 		return withParent(buildResourceName(id, entityClass));
 	}
 
@@ -399,7 +399,7 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 		return builder.setUpdate(document).build();
 	}
 
-	private <T> String buildResourceName(Object entityId, Class<T> entityClass) {
+	private <T> String buildResourceName(String entityId, Class<T> entityClass) {
 		FirestorePersistentEntity<?> persistentEntity =
 				this.mappingContext.getPersistentEntity(entityClass);
 
@@ -407,7 +407,7 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
 			throw new IllegalArgumentException(entityClass.toString() + " is not a valid Firestore entity class.");
 		}
 
-		return buildResourceName(persistentEntity, entityId.toString());
+		return buildResourceName(persistentEntity, entityId);
 	}
 
 	private <T> String buildResourceName(T entity) {


### PR DESCRIPTION
This modifies `FirestoreTemplate.withParent(Object id, Class<?> ..)` to `FirestoreTemplate.withParent(String id, Class<?> ..)`.

Turns out that Document IDs can only be Strings (no longs, ints, custom data types, etc.) https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/217#issuecomment-764008911

Fixes #227