### PR TITLE
Fix up some smells in CommitTimestamp

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContext.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContext.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.mapping.context.AbstractMappingContext;
@@ -57,8 +56,7 @@ public class DatastoreMappingContext extends
 	private static final Map<Class, Set<Class>> discriminationFamilies = new ConcurrentHashMap<>();
 
 	@Override
-	public void setApplicationContext(ApplicationContext applicationContext)
-			throws BeansException {
+	public void setApplicationContext(ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
 	}
 


### PR DESCRIPTION
Removes declared RuntimeExceptions, and moves `register` method inside the static class that calls it (SC rule: ["private" methods called only by inner classes should be moved to those classes](https://sonarcloud.io/organizations/googlecloudplatform/rules?open=java%3AS3398&rule_key=java%3AS3398) 