### PR TITLE
Retry mvn install on failure, don't rerun unit tests on failure

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -58,6 +58,18 @@ jobs:
           gcloud components install pubsub-emulator beta && \
             gcloud components update
       - name: Mvn install # Need this when the directory/pom structure changes
+        id: install1
+        continue-on-error: true
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --threads 1.5C \
+            --define maven.test.skip=true \
+            --define maven.javadoc.skip=true \
+            install
+      - name: Retry install on failure
+        id: install2
+        if: steps.install1.outcome == 'failure'
         run: |
           ./mvnw \
             --batch-mode \

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -29,6 +29,19 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Mvn install # Need this when the directory/pom structure changes
+      id: install1
+      continue-on-error: true
+      run: |
+        ./mvnw \
+          --batch-mode \
+          --show-version \
+          --threads 1.5C \
+          --define maven.test.skip=true \
+          --define maven.javadoc.skip=true \
+          install
+    - name: Retry install on failure
+      id: install2
+      if: steps.install1.outcome == 'failure'
       run: |
         ./mvnw \
           --batch-mode \
@@ -40,15 +53,6 @@ jobs:
     - name: Unit Tests
       id: unitTest1
       continue-on-error: true
-      run: |
-        ./mvnw \
-          --batch-mode \
-          --fail-at-end \
-          --threads 1.5C \
-          test
-    - name: Retry on Failure
-      id: unitTest2
-      if: steps.unitTest1.outcome == 'failure'
       run: |
         ./mvnw \
           --batch-mode \


### PR DESCRIPTION
I should have looked more closely at my change the other day on what step was actually failing. In this case we need to retry the `mvn install` step rather than the unit testing step itself. 

I've removed the unit test retry in this PR because there should be no flaky unit tests - it should always pass in 1 go - whereas we see an occasional failure with Maven central (during the mvn install step)