### PR TITLE
Adds periodic cache purge to keep the cache from growing

### DIFF
--- a/.github/workflows/purgeCache.yaml
+++ b/.github/workflows/purgeCache.yaml
@@ -1,0 +1,84 @@
+name: Purge Caches
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '6 4 1,15 * *' # 04:06 UTC every 1st and 15th of the month
+
+jobs:
+  purgeCache:
+    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' # Only run on upstream branch
+    name: Purge Cache
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Purge caches
+        run: |
+          rm -rf ~/.m2 && \
+          rm -rf ~/.sonar/cache
+
+      - name: Mvn install
+        id: install1
+        continue-on-error: true
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --threads 1.5C \
+            --define maven.test.skip=true \
+            --define maven.javadoc.skip=true \
+            install
+
+      - name: Retry install1 on Failure
+        id: install2
+        if: steps.install1.outcome == 'failure'
+        continue-on-error: true
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --threads 1.5C \
+            --define maven.test.skip=true \
+            --define maven.javadoc.skip=true \
+            install
+
+      - name: Retry install2 on Failure
+        id: install3
+        if: steps.install2.outcome == 'failure'
+        continue-on-error: true
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --threads 1.5C \
+            --define maven.test.skip=true \
+            --define maven.javadoc.skip=true \
+            install
+
+      - name: Grab Sonar dependencies
+        id: sonar1
+        continue-on-error: true
+        run: ./mvnw org.sonarsource.scanner.maven:sonar-maven-plugin:help
+
+      - name: Retry Sonar dependencies
+        id: sonar2
+        if: steps.sonar1.outcome == 'failure'
+        continue-on-error: true
+        run: ./mvnw org.sonarsource.scanner.maven:sonar-maven-plugin:help
+


### PR DESCRIPTION
I took a peek at our caches and they appear to be growing over time. A fresh install on my machine showed:

```bash
$ du -sh ~/.m2
1.5G	/home/ttomsu/.m2
```

Whereas [our current cache size is double that at 3GB](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/runs/1921577604?check_suite_focus=true#step:4:31).

It took ~1:47 to load our cache, so cutting it half should reduce our build time, and sometimes by more than just the ratio (you can see the speed dropped from 160MB/s to 60MB/s at around 60%, so I imagine a smaller cache will mostly be loaded with the faster bandwidth, if this test is usual). 

We're not the only ones to hit this issue - it's quite literally issue no. 2 in their repo: https://github.com/actions/cache/issues/2, and while they say old cache entries get deleted, it doesn't help Maven, Gradle, and a bunch of other language repos who need to expire individual files out of the cache rather than the whole cache itself.

So this PR should run on the 1st and 15th of each month to wipe out the current cache and redownload all dependencies. I've also added a few retry steps because, as we know, this doesn't always work on the first try.