### PR TITLE
Use date in dependencies cache and refresh daily

### DIFF
--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -18,16 +18,21 @@ jobs:
       matrix:
         java: [8, 11, 15]
     steps:
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+
     - uses: actions/checkout@v2
+
     - uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
+
     - uses: actions/cache@v2
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+
     - name: Mvn install # Need this when the directory/pom structure changes
       id: install1
       continue-on-error: true
@@ -39,6 +44,7 @@ jobs:
           --define maven.test.skip=true \
           --define maven.javadoc.skip=true \
           install
+
     - name: Retry install on failure
       id: install2
       if: steps.install1.outcome == 'failure'
@@ -50,6 +56,7 @@ jobs:
           --define maven.test.skip=true \
           --define maven.javadoc.skip=true \
           install
+
     - name: Unit Tests
       id: unitTest1
       continue-on-error: true
@@ -59,12 +66,14 @@ jobs:
           --fail-at-end \
           --threads 1.5C \
           test
+
     - name: Aggregate Report
       run: |
         ./mvnw \
           --batch-mode \
           --define aggregate=true \
           surefire-report:report-only
+
     - name: Archive logs
       if: always()
       continue-on-error: true
@@ -81,16 +90,21 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+
       - uses: actions/checkout@v2
+
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+
       - name: releaseCheck
         run: |
           ./mvnw \
@@ -101,6 +115,7 @@ jobs:
             -Dcheckstyle.skip \
             clean \
             package
+
       - name: docsCheck
         run: |
           ./mvnw \
@@ -112,6 +127,7 @@ jobs:
             --projects docs \
             clean \
             package
+
       - name: Archive Artifacts
         if: always()
         continue-on-error: true

--- a/.github/workflows/warmCache.yaml
+++ b/.github/workflows/warmCache.yaml
@@ -22,9 +22,14 @@ jobs:
           java-version: 11
 
       - uses: actions/cache@v2
+        id: loadCache
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+
+      - name: Fail if cache already warm
+        if: steps.loadCache.outputs.cache-hit == 'true'
+        run: /bin/false # Do nothing, unsuccessfully.
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/warmCache.yaml
+++ b/.github/workflows/warmCache.yaml
@@ -1,15 +1,19 @@
-name: Purge Caches
+name: Warm Caches
 on:
   workflow_dispatch:
   schedule:
-    - cron: '6 4 1,15 * *' # 04:06 UTC every 1st and 15th of the month
+    - cron: '1 0 * * *' # 00:01 UTC every day
 
 jobs:
-  purgeCache:
+  warmCache:
     if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' # Only run on upstream branch
-    name: Purge Cache
+    name: Warm Cache
     runs-on: ubuntu-20.04
     steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+
       - uses: actions/checkout@v2
 
       - name: Set up JDK 11
@@ -17,24 +21,15 @@ jobs:
         with:
           java-version: 11
 
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
 
-      - name: Purge caches
-        run: |
-          rm -rf ~/.m2 && \
-          rm -rf ~/.sonar/cache
+      - uses: actions/cache@v2
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar-${{ steps.date.outputs.date }}
 
       - name: Mvn install
         id: install1


### PR DESCRIPTION
Following up from yesterdays conversation about the GHA cache - this changes the "purge cache" job to a "warm cache" job because, as we learned, we cannot _update_ an existing cache - we can only create wholly new ones. 

So this job runs right at the beginning of every day (UTC time, obv, we're not savages after all) and stores the cache based on the YYYY-MM-DD. I've also removed the backup `restore-keys` option as I have no idea what is in this `Linux-maven-` cache. It likely doesn't have much of what we need so lets save the time downloading it.

If this works out as expected I can make similar changes to our other jobs.