### PR TITLE
Simply suggested BOM use in gradle

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -34,7 +34,7 @@ Instead, the version of the BOM you’re using determines the versions of the us
 </dependencyManagement>
 ----
 
-Or, if you're a gradle user:
+Or, if you're a Gradle user:
 
 [source,subs="normal"]
 ----

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -34,12 +34,18 @@ Instead, the version of the BOM you’re using determines the versions of the us
 </dependencyManagement>
 ----
 
+Or, if you're a gradle user:
+
+[source,subs="normal"]
+----
+dependencies {
+    implementation platform("com.google.cloud:spring-cloud-gcp-dependencies:{project-version}")
+}
+----
+
 See the <<README.adoc, sections>> in the README for selecting an available version and Maven repository.
 
 In the following sections, it will be assumed you are using the Spring Cloud GCP BOM and the dependency snippets will not contain versions.
-
-Gradle users can achieve the same kind of BOM experience using Spring's https://github.com/spring-gradle-plugins/dependency-management-plugin[dependency-management-plugin] Gradle plugin.
-For simplicity, the Gradle dependency snippets in the remainder of this document will also omit their versions.
 
 ==== Starter Dependencies
 


### PR DESCRIPTION
The existing instructions seemed to refer to times before gradle supported BOMs. Since there is now a go-to way for BOM use built into gradle, it seems counter-intuitive to refer potential users to an out-dated solution.