### PR TITLE
Set up unified maven cache for GH Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Maven go offline
       id: mvn-offline
       if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: ./mvnw dependency:go-offline
+      run: ./mvnw compile dependency:go-offline
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
       id: mvn-cache
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+        key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
 
     - name: Maven go offline
       id: mvn-offline

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,9 +43,15 @@ jobs:
       uses: actions/checkout@v2
 
     - uses: actions/cache@v2
+      id: mvn-cache
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}-${{ github.job }}
+        key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+
+    - name: Maven go offline
+      id: mvn-offline
+      if: steps.mvn-cache.outputs.cache-hit != 'true'
+      run: mvn dependency:go-offline
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Maven go offline
       id: mvn-offline
       if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: mvn dependency:go-offline
+      run: ./mvnw dependency:go-offline
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -46,7 +46,7 @@ jobs:
         id: mvn-cache
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+          key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline
+        run: ./mvnw compile dependency:go-offline
       - name: Mvn install # Need this when the directory/pom structure changes
         id: install1
         continue-on-error: true

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -43,9 +43,10 @@ jobs:
         with:
           java-version: 11
       - uses: actions/cache@v2
+        id: mvn-cache
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}-${{ github.job }}-${{ matrix.it }}
+          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@master
         with:
@@ -58,6 +59,10 @@ jobs:
         run: |
           gcloud components install pubsub-emulator beta && \
             gcloud components update
+      - name: Maven go offline
+        id: mvn-offline
+        if: steps.mvn-cache.outputs.cache-hit != 'true'
+        run: mvn dependency:go-offline
       - name: Mvn install # Need this when the directory/pom structure changes
         id: install1
         continue-on-error: true

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: mvn dependency:go-offline
+        run: ./mvnw dependency:go-offline
       - name: Mvn install # Need this when the directory/pom structure changes
         id: install1
         continue-on-error: true

--- a/.github/workflows/linkageCheck.yaml
+++ b/.github/workflows/linkageCheck.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: mvn dependency:go-offline
+        run: ./mvnw dependency:go-offline
       - name: install
         # install before running Linkage Checker
         run: |

--- a/.github/workflows/linkageCheck.yaml
+++ b/.github/workflows/linkageCheck.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline
+        run: ./mvnw compile dependency:go-offline
       - name: install
         # install before running Linkage Checker
         run: |

--- a/.github/workflows/linkageCheck.yaml
+++ b/.github/workflows/linkageCheck.yaml
@@ -20,9 +20,14 @@ jobs:
         with:
           java-version: 8
       - uses: actions/cache@v2
+        id: mvn-cache
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}-${{ github.job }}
+          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+      - name: Maven go offline
+        id: mvn-offline
+        if: steps.mvn-cache.outputs.cache-hit != 'true'
+        run: mvn dependency:go-offline
       - name: install
         # install before running Linkage Checker
         run: |

--- a/.github/workflows/linkageCheck.yaml
+++ b/.github/workflows/linkageCheck.yaml
@@ -23,7 +23,7 @@ jobs:
         id: mvn-cache
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+          key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -34,7 +34,7 @@ jobs:
         id: mvn-cache
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+          key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -31,9 +31,14 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar-${{ steps.date.outputs.date }}
       - uses: actions/cache@v2
+        id: mvn-cache
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}-unitTests
+          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+      - name: Maven go offline
+        id: mvn-offline
+        if: steps.mvn-cache.outputs.cache-hit != 'true'
+        run: mvn dependency:go-offline
       - name: Mvn install w/ coverage # Need this when the directory/pom structure changes
         id: install1
         continue-on-error: true

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: mvn dependency:go-offline
+        run: ./mvnw dependency:go-offline
       - name: Mvn install w/ coverage # Need this when the directory/pom structure changes
         id: install1
         continue-on-error: true

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline
+        run: ./mvnw compile dependency:go-offline
       - name: Mvn install w/ coverage # Need this when the directory/pom structure changes
         id: install1
         continue-on-error: true

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -29,9 +29,15 @@ jobs:
         java-version: ${{ matrix.java }}
 
     - uses: actions/cache@v2
+      id: mvn-cache
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}-unitTests # Update sonar.yaml if changing this ID.
+        key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+
+    - name: Maven go offline
+      id: mvn-offline
+      if: steps.mvn-cache.outputs.cache-hit != 'true'
+      run: mvn dependency:go-offline
 
     - name: Mvn install # Need this when the directory/pom structure changes
       id: install1

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Maven go offline
       id: mvn-offline
       if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: mvn dependency:go-offline
+      run: ./mvnw dependency:go-offline
 
     - name: Mvn install # Need this when the directory/pom structure changes
       id: install1

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Maven go offline
       id: mvn-offline
       if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: ./mvnw dependency:go-offline
+      run: ./mvnw compile dependency:go-offline
 
     - name: Mvn install # Need this when the directory/pom structure changes
       id: install1
@@ -107,9 +107,15 @@ jobs:
           java-version: 11
 
       - uses: actions/cache@v2
+        id: mvn-cache
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}-${{ github.job }}
+          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+
+      - name: Maven go offline
+        id: mvn-offline
+        if: steps.mvn-cache.outputs.cache-hit != 'true'
+        run: ./mvnw compile dependency:go-offline
 
       - name: releaseCheck
         run: |

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -32,7 +32,7 @@ jobs:
       id: mvn-cache
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+        key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
 
     - name: Maven go offline
       id: mvn-offline
@@ -110,7 +110,7 @@ jobs:
         id: mvn-cache
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+          key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
 
       - name: Maven go offline
         id: mvn-offline

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -41,7 +41,7 @@ jobs:
     - name: Maven go offline
       id: mvn-offline
       if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: ./mvnw dependency:go-offline
+      run: ./mvnw compile dependency:go-offline
 
     - name: Mvn install # Need this when the version/directory/pom structure changes
       run: |

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -41,7 +41,7 @@ jobs:
     - name: Maven go offline
       id: mvn-offline
       if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: mvn dependency:go-offline
+      run: ./mvnw dependency:go-offline
 
     - name: Mvn install # Need this when the version/directory/pom structure changes
       run: |

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -33,9 +33,15 @@ jobs:
         java-version: 11
 
     - uses: actions/cache@v2
+      id: mvn-cache
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}-${{ github.job }}
+        key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+
+    - name: Maven go offline
+      id: mvn-offline
+      if: steps.mvn-cache.outputs.cache-hit != 'true'
+      run: mvn dependency:go-offline
 
     - name: Mvn install # Need this when the version/directory/pom structure changes
       run: |

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -36,7 +36,7 @@ jobs:
       id: mvn-cache
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ steps.date.outputs.date }}
+        key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
 
     - name: Maven go offline
       id: mvn-offline


### PR DESCRIPTION
Moving away from a cache per job and integration test module.

This eliminates a lot of mostly overlapping maven caches, thereby reducing storage space and daily cache write bandwidth from ~30GB to ~1.5GB.

This also allows us to be within the [5GB cache storage limit](https://github.com/actions/cache#cache-limits).