### PR TITLE
GoogleStorageResource: Returns the self-link of an object or bucket i…

### DIFF
--- a/docs/src/main/asciidoc/storage.adoc
+++ b/docs/src/main/asciidoc/storage.adoc
@@ -90,7 +90,7 @@ However, creating signed URLs requires that the resource was created using servi
 ====
 As of v2.0.2+, the `GoogleStorageResource.getURL()` method returns the `Bucket` or `Blob` 's `selfLink` value, rather than attempting to convert the `URI` a `URL` object that nearly-always threw a `MalformedURLException`.
 This value is notably different from `GoogleStorageResource.getURI()`, which returns the more commonly used `gs://my-bucket/my-object` identifier.
-See https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/341[here] for more details.
+Returning a valid URL is necessary to support some features in the Spring ecosystem, such as `spring.resources.static-locations`.
 ====
 
 The Spring Boot Starter for Google Cloud Storage auto-configures the `Storage` bean required by the `spring-cloud-gcp-storage` module, based on the `CredentialsProvider` provided by the Spring Boot GCP starter.

--- a/docs/src/main/asciidoc/storage.adoc
+++ b/docs/src/main/asciidoc/storage.adoc
@@ -86,6 +86,13 @@ This type represents a GCS file, which has associated https://cloud.google.com/s
 The `createSignedUrl` method can also be used to obtain https://cloud.google.com/storage/docs/access-control/signed-urls[signed URLs] for GCS objects.
 However, creating signed URLs requires that the resource was created using service account credentials.
 
+[CAUTION]
+====
+As of v2.0.2+, the `GoogleStorageResource.getURL()` method returns the `Bucket` or `Blob` 's `selfLink` value, rather than attempting to convert the `URI` a `URL` object that nearly-always threw a `MalformedURLException`.
+This value is notably different from `GoogleStorageResource.getURI()`, which returns the more commonly used `gs://my-bucket/my-object` identifier.
+See https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/341[here] for more details.
+====
+
 The Spring Boot Starter for Google Cloud Storage auto-configures the `Storage` bean required by the `spring-cloud-gcp-storage` module, based on the `CredentialsProvider` provided by the Spring Boot GCP starter.
 
 ==== Setting the Content Type

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/src/main/java/com/example/WebController.java
@@ -24,9 +24,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.WritableResource;
 import org.springframework.util.StreamUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -42,15 +42,15 @@ public class WebController {
 	@Value("gs://${gcs-resource-test-bucket}/my-file.txt")
 	private Resource gcsFile;
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
+	@GetMapping("/")
 	public String readGcsFile() throws IOException {
 		return StreamUtils.copyToString(
 				this.gcsFile.getInputStream(),
 				Charset.defaultCharset()) + "\n";
 	}
 
-	@RequestMapping(value = "/", method = RequestMethod.POST)
-	String writeGcs(@RequestBody String data) throws IOException {
+	@PostMapping("/")
+	public String writeGcs(@RequestBody String data) throws IOException {
 		try (OutputStream os = ((WritableResource) this.gcsFile).getOutputStream()) {
 			os.write(data.getBytes());
 		}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 gcs-resource-test-bucket=[REPLACE_WITH_YOUR_BUCKET]
+
+# You can also serve static resources by reading them from a bucket.
+# spring.web.resources.static-locations=gs://[REPLACE_WITH_YOUR_BUCKET]

--- a/spring-cloud-gcp-storage/src/main/java/com/google/cloud/spring/storage/GoogleStorageLocation.java
+++ b/spring-cloud-gcp-storage/src/main/java/com/google/cloud/spring/storage/GoogleStorageLocation.java
@@ -46,6 +46,7 @@ public class GoogleStorageLocation {
 	 */
 	public GoogleStorageLocation(String gcsLocationUriString) {
 		try {
+			Assert.hasText(gcsLocationUriString, "A Google Storage URI must not be null or empty");
 			Assert.isTrue(
 					gcsLocationUriString.startsWith("gs://"),
 					"A Google Storage URI must start with gs://");

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageLocationTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageLocationTests.java
@@ -19,11 +19,19 @@ package com.google.cloud.spring.storage;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Daniel Zou
  */
 public class GoogleStorageLocationTests {
+
+	@Test
+	public void testBadInputsToConstructor() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new GoogleStorageLocation(null));
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new GoogleStorageLocation(""));
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new GoogleStorageLocation(" "));
+	}
 
 	@Test
 	public void testCorrectLocationForBucket() {

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageResourceTest.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageResourceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.storage;
+
+import java.io.IOException;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GoogleStorageResourceTest {
+
+	@Test
+	public void testConstructorValidation() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new GoogleStorageResource(null, "gs://foo", false))
+				.withMessageContaining("Storage object can not be null");
+
+		Storage mockStorage = mock(Storage.class);
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new GoogleStorageResource(mockStorage, (String) null, false));
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new GoogleStorageResource(mockStorage, "", false));
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new GoogleStorageResource(mockStorage, "foo", false));
+
+		assertThat(new GoogleStorageResource(mockStorage, "gs://foo", true)).isNotNull();
+		assertThat(new GoogleStorageResource(mockStorage, "gs://foo/bar", true)).isNotNull();
+	}
+
+	@Test
+	public void getURL_Bucket() throws IOException {
+		Storage mockStorage = mock(Storage.class);
+		Bucket mockBucket = mock(Bucket.class);
+
+		when(mockStorage.get("my-bucket")).thenReturn(mockBucket);
+		when(mockBucket.getSelfLink()).thenReturn("https://www.googleapis.com/storage/v1/b/my-bucket");
+
+		GoogleStorageResource gsr = new GoogleStorageResource(mockStorage, "gs://my-bucket");
+		assertThat(gsr.getURL()).isNotNull();
+	}
+
+	@Test
+	public void getURL_Object() throws IOException {
+		Storage mockStorage = mock(Storage.class);
+		Blob mockBlob = mock(Blob.class);
+
+		when(mockStorage.get(BlobId.of("my-bucket", "my-object"))).thenReturn(mockBlob);
+		when(mockBlob.getSelfLink()).thenReturn("https://www.googleapis.com/storage/v1/b/my-bucket/o/my-object");
+
+		GoogleStorageResource gsr = new GoogleStorageResource(mockStorage, "gs://my-bucket/my-object");
+		assertThat(gsr.getURL()).isNotNull();
+
+	}
+}

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageTests.java
@@ -19,7 +19,6 @@ package com.google.cloud.spring.storage;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.MalformedURLException;
 import java.util.concurrent.TimeUnit;
 
 import com.google.cloud.WriteChannel;
@@ -376,13 +375,6 @@ public class GoogleStorageTests {
 		Storage.SignUrlOption option = Storage.SignUrlOption.httpMethod(HttpMethod.PUT);
 		resource.createSignedUrl(TimeUnit.DAYS, 1L, option);
 		verify(storage, times(1)).signUrl(any(), eq(1L), eq(TimeUnit.DAYS), eq(option));
-	}
-
-	@Test
-	public void getUrlFails() throws IOException {
-		this.expectedEx.expect(MalformedURLException.class);
-		this.expectedEx.expectMessage("unknown protocol: gs");
-		this.remoteResource.getURL();
 	}
 
 	@Test


### PR DESCRIPTION
…nstead of always throwing a Malformed URL exception.

Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/210

This PR changes primarily changes `GoogleStorageResource.getURL()` from always throwing a `MalformedUrlException` to returning the object's `selfLink`, which is always a valid `https` URL. This URL just gives one back the object metadata, such as

https://www.googleapis.com/storage/v1/b/halconfig/o/versions.yml
```json
{
  "kind": "storage#object",
  "id": "halconfig/versions.yml/1614118188143610",
  "selfLink": "https://www.googleapis.com/storage/v1/b/halconfig/o/versions.yml",
  "mediaLink": "https://www.googleapis.com/download/storage/v1/b/halconfig/o/versions.yml?generation=1614118188143610&alt=media",
  "name": "versions.yml",
  "bucket": "halconfig",
  "generation": "1614118188143610",
  "metageneration": "1",
  "contentType": "application/text",
  "storageClass": "STANDARD",
  "size": "1536",
  "md5Hash": "VsQ39mqqIOaCINWZfiTs3w==",
  "crc32c": "SmfKkg==",
  "etag": "CPqn6+mCge8CEAE=",
  "timeCreated": "2021-02-23T22:09:48.221Z",
  "updated": "2021-02-23T22:09:48.221Z",
  "timeStorageClassUpdated": "2021-02-23T22:09:48.221Z"
}
```

But at least it's a valid URL. When this method always throwns a URL exception, we run into issues with other parts of the Spring ecosystem like the user's bug report. I tested out the user's config and it works as expected (serving index.html) when a bucket is specified. It doesn't look like it works if a bucket + prefix (subdirectory) is specified, but that may be a configuration issue on my end.

Secondarily, this PR cleans up several places where a checked `IOException` is in the method signature, but it appears the underlying library has started throwing a runtime `StorageException` instead, thus IntelliJ and Sonar were throwing up warnings to clean it up.
