### PR TITLE
GH-342: Apply additional emulator properties

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/EmulatorSettings.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/EmulatorSettings.java
@@ -53,7 +53,7 @@ public class EmulatorSettings {
 
 	/**
 	 * The directory to be used to store/retrieve data/config for an emulator run.
-	 * Correspondent CLI property: --data-dir. The default value <USER_CONFIG_DIR>/emulators/datastore is used on null
+	 * Correspondent CLI property: --data-dir. The default value ${USER_CONFIG_DIR}/emulators/datastore is used on null
 	 */
 	private Path dataDir;
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/EmulatorSettings.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/EmulatorSettings.java
@@ -16,8 +16,12 @@
 
 package com.google.cloud.spring.autoconfigure.datastore;
 
+import java.nio.file.Path;
+
 /**
  * Properties for configuring Cloud Datastore Emulator.
+ *
+ * See https://cloud.google.com/sdk/gcloud/reference/beta/emulators/datastore/start for the correspondent properties
  *
  * @author Lucas Soares
  *
@@ -30,14 +34,44 @@ public class EmulatorSettings {
 	private boolean enabled;
 
 	/**
-	 * Is the datastore emulator port. Default: {@code 8081}
+	 * Is the datastore emulator port.
+	 * Correspondent CLI property: --host-port=localhost:{@link EmulatorSettings #port} Default: {@code 8081}
 	 */
 	private int port = 8081;
 
 	/**
-	 * Consistency to use creating the Datastore server instance. Default: {@code 0.9}
+	 * Consistency to use creating the Datastore server instance.
+	 * Correspondent CLI property: --consistency Default: {@code 0.9}
 	 */
 	private double consistency = 0.9D;
+
+	/**
+	 * Configures the emulator not to persist any data to disk for the emulator session.
+	 * Correspondent CLI property: --no-store-on-disk. Default: {@code true}
+	 */
+	private boolean storeOnDisk = true;
+
+	/**
+	 * The directory to be used to store/retrieve data/config for an emulator run.
+	 * Correspondent CLI property: --data-dir. The default value <USER_CONFIG_DIR>/emulators/datastore is used on null
+	 */
+	private Path dataDir;
+
+	public Path getDataDir() {
+		return dataDir;
+	}
+
+	public void setDataDir(Path dataDir) {
+		this.dataDir = dataDir;
+	}
+
+	public boolean isStoreOnDisk() {
+		return storeOnDisk;
+	}
+
+	public void setStoreOnDisk(boolean storeOnDisk) {
+		this.storeOnDisk = storeOnDisk;
+	}
 
 	public boolean isEnabled() {
 		return enabled;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfiguration.java
@@ -55,8 +55,13 @@ public class GcpDatastoreEmulatorAutoConfiguration implements SmartLifecycle {
 			GcpDatastoreProperties datastoreProperties) {
 		EmulatorSettings settings = datastoreProperties.getEmulator();
 
-		this.helper = LocalDatastoreHelper.create(settings.getConsistency(),
-				settings.getPort());
+		this.helper = LocalDatastoreHelper
+				.newBuilder()
+				.setConsistency(settings.getConsistency())
+				.setPort(settings.getPort())
+				.setStoreOnDisk(settings.isStoreOnDisk())
+				.setDataDir(settings.getDataDir())
+				.build();
 
 		return this.helper;
 	}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreEmulatorAutoConfigurationTests.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spring.autoconfigure.datastore;
 
+import java.nio.file.Paths;
+
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import org.junit.Test;
@@ -43,12 +45,16 @@ public class GcpDatastoreEmulatorAutoConfigurationTests {
 				.withPropertyValues(
 						"spring.cloud.gcp.datastore.emulator.port=8182",
 						"spring.cloud.gcp.datastore.emulator.enabled=true",
-						"spring.cloud.gcp.datastore.emulator.consistency=0.8")
+						"spring.cloud.gcp.datastore.emulator.consistency=0.8",
+						"spring.cloud.gcp.datastore.emulator.dataDir=/usr/local/datastore",
+						"spring.cloud.gcp.datastore.emulator.storeOnDisk=false")
 				.run(context -> {
 					LocalDatastoreHelper helper = context.getBean(LocalDatastoreHelper.class);
 					DatastoreOptions datastoreOptions = helper.getOptions();
 					assertThat(datastoreOptions.getHost()).isEqualTo("localhost:8182");
 					assertThat(helper.getConsistency()).isEqualTo(0.8D);
+					assertThat(helper.getGcdPath()).isEqualTo(Paths.get("/usr/local/datastore"));
+					assertThat(helper.isStoreOnDisk()).isFalse();
 				});
 	}
 


### PR DESCRIPTION
#342 Currently, some properties are missing to propagate from the application properties to Datastore emulator.

I propagate `storeOnDisk` and `dataDir` here and adjust the javadoc. The task supposes to add only the first property but consistency order, I add the second one.

Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/342.