### PR TITLE
Add Datastore emulator settings to documentation

### DIFF
--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -75,6 +75,9 @@ The following configuration options are available:
 | `spring.cloud.gcp.datastore.emulator.enabled` | To enable the auto configuration to start a local instance of the Datastore Emulator. | No | `false`
 | `spring.cloud.gcp.datastore.emulator.port` | The local port to use for the Datastore Emulator | No | `8081`
 | `spring.cloud.gcp.datastore.emulator.consistency` | The https://cloud.google.com/sdk/gcloud/reference/beta/emulators/datastore/start?#--consistency[consistency] to use for the Datastore Emulator instance | No | `0.9`
+| `spring.cloud.gcp.datastore.emulator.store-on-disk` | Configures whether or not the emulator should persist any data to disk. | No | `true`
+| `spring.cloud.gcp.datastore.emulator.data-dir` | The directory to be used to store/retrieve data/config for an emulator run. | No | The default value is `<USER_CONFIG_DIR>/emulators/datastore`. See the https://cloud.google.com/sdk/gcloud/reference/beta/emulators/datastore/start[gcloud documentation] for finding your `USER_CONFIG_DIR`.
+
 |===
 
 ==== Repository settings

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/EmulatorSettings.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/EmulatorSettings.java
@@ -46,8 +46,8 @@ public class EmulatorSettings {
 	private double consistency = 0.9D;
 
 	/**
-	 * Configures the emulator not to persist any data to disk for the emulator session.
-	 * Correspondent CLI property: --no-store-on-disk. Default: {@code true}
+	 * Configures whether or not the emulator should persist any data to disk for the emulator session.
+	 * Correspondent CLI property: --store-on-disk. Default: {@code true}
 	 */
 	private boolean storeOnDisk = true;
 


### PR DESCRIPTION
Followup to #342 -- Add the new datastore emulator settings to the documentation.

Also fixes the comment to use the [`--store-on-disk`](https://cloud.google.com/sdk/gcloud/reference/beta/emulators/datastore/start) flag which more accurately corresponds to the setting instead of the negative `--no-store-on-disk`.