### PR TITLE
Adds section in pubsub docs on using the Subscription.Builder to set …

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -234,7 +234,7 @@ NOTE: All `ack()`, `nack()`, and `modifyAckDeadline()` methods on messages, as w
 ===== Dead Letter Topics
 
 Your application may occasionally receive a message it cannot process.
-If you <<creating-a-subscription,create your `Subscription`>> using the `Subscription.Builder` option, you can specify a `DeadLetterPolicy` that will forward all `nack()`-ed and non-`ack()`-ed message after a configurable amount of redelivery attempts.
+If you <<creating-a-subscription,create your `Subscription`>> passing the `Subscription.Builder` argument, you can specify a `DeadLetterPolicy` that will forward all `nack()`-ed and non-`ack()`-ed messages after a configurable amount of redelivery attempts.
 See https://cloud.google.com/pubsub/docs/dead-letter-topics[here] for more information.
 
 // TODO(ttomsu): make this an include to working code.
@@ -410,7 +410,7 @@ public Subscription createSubscription(Subscriber.Builder builder)
 
 The default value for `ackDeadline` is 10 seconds.
 If `pushEndpoint` isn’t specified, the subscription uses message pulling, instead.
-You can also pass a full `Subscription.Builder` for full control over any options or features available in the client library.
+You can also pass a `Subscription.Builder` for full control over any options or features available in the client library.
 
 Here is an example of how to create a Google Cloud Pub/Sub subscription:
 

--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -231,6 +231,32 @@ Using these methods for acknowledging messages in batches is more efficient than
 
 NOTE: All `ack()`, `nack()`, and `modifyAckDeadline()` methods on messages, as well as `PubSubSubscriberTemplate`, are implemented asynchronously, returning a `ListenableFuture<Void>` to enable asynchronous processing.
 
+===== Dead Letter Topics
+
+Your application may occasionally receive a message it cannot process.
+If you <<creating-a-subscription,create your `Subscription`>> using the `Subscription.Builder` option, you can specify a `DeadLetterPolicy` that will forward all `nack()`-ed and non-`ack()`-ed message after a configurable amount of redelivery attempts.
+See https://cloud.google.com/pubsub/docs/dead-letter-topics[here] for more information.
+
+// TODO(ttomsu): make this an include to working code.
+[source,java,indent=0]
+----
+public Subscription newSubscription() {
+	// Must use the fully-qualified topic name.
+	String fullDeadLetterTopic = PubSubTopicUtils
+						.toTopicName(DEAD_LETTER_TOPIC, gcpProjectIdProvider.getProjectId())
+						.toString();
+	return pubSubAdmin.createSubscription(Subscription.newBuilder()
+			.setName(SUBSCRIPTION_NAME)
+			.setTopic(TOPIC_NAME)
+			.setDeadLetterPolicy(DeadLetterPolicy.newBuilder()
+					.setDeadLetterTopic(fullDeadLetterTopic)
+					.setMaxDeliveryAttempts(6)
+					.build()));
+}
+----
+
+Dead letter topics are no different than any other topic, though some https://cloud.google.com/pubsub/docs/dead-letter-topics#granting_forwarding_permissions[additional permissions] are necessary to ensure the Cloud Pub/Sub service can successfully `ack` the original message and re-`publish` it on the dead letter topic.
+
 ==== JSON support
 
 For serialization and deserialization of POJOs using Jackson JSON, configure a `PubSubMessageConverter` bean, and the Spring Boot starter for GCP Pub/Sub will automatically wire it into the `PubSubTemplate`.
@@ -266,7 +292,7 @@ include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/
 
 Please refer to our https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample[Pub/Sub JSON Payload Sample App] as a reference for using this functionality.
 
-=== Reactive Stream Subscription
+=== Reactive Stream Subscriber
 
 It is also possible to acquire a reactive stream backed by a subscription.
 To do so, a Project Reactor dependency (`io.projectreactor:reactor-core`) must be added to the project.
@@ -313,8 +339,6 @@ It allows for the creation, deletion and listing of topics and subscriptions.
 
 NOTE: Generally when referring to topics and subscriptions, you can either use the short canonical name within the current project, or the fully-qualified name referring to a topic or subscription in a different project using the `projects/<project_name>/(topics|subscriptions)/<name>` format.
 
-`PubSubAdmin` depends on `GcpProjectIdProvider` and either a `CredentialsProvider` or a `TopicAdminClient` and a `SubscriptionAdminClient`.
-If given a `CredentialsProvider`, it creates a `TopicAdminClient` and a `SubscriptionAdminClient` with the Google Cloud Java Library for Pub/Sub default settings.
 The Spring Boot starter for GCP Pub/Sub auto-configures a `PubSubAdmin` object using the `GcpProjectIdProvider` and the `CredentialsProvider` auto-configured by the Spring Boot GCP Core starter.
 
 ==== Creating a topic
@@ -371,46 +395,30 @@ include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/
 
 ==== Creating a subscription
 
-`PubSubAdmin` implements a method to create subscriptions to existing topics:
+`PubSubAdmin` implements several methods to create subscriptions to existing topics:
 
 [source,java]
 ----
+public Subscription createSubscription(String subscriptionName, String topicName)
+
+public Subscription createSubscription(String subscriptionName, String topicName, Integer ackDeadline)
+
 public Subscription createSubscription(String subscriptionName, String topicName, Integer ackDeadline, String pushEndpoint)
+
+public Subscription createSubscription(Subscriber.Builder builder)
 ----
+
+The default value for `ackDeadline` is 10 seconds.
+If `pushEndpoint` isn’t specified, the subscription uses message pulling, instead.
+You can also pass a full `Subscription.Builder` for full control over any options or features available in the client library.
 
 Here is an example of how to create a Google Cloud Pub/Sub subscription:
 
 [source,java]
 ----
-public void newSubscription() {
-    pubSubAdmin.createSubscription("subscriptionName", "topicName", 10, “https://my.endpoint/push”);
+public Subscription newSubscription() {
+    return pubSubAdmin.createSubscription("subscriptionName", "topicName", 15);
 }
-----
-
-Alternative methods with default settings are provided for ease of use.
-The default value for `ackDeadline` is 10 seconds.
-If `pushEndpoint` isn’t specified, the subscription uses message pulling, instead.
-
-[source,java]
-----
-public Subscription createSubscription(String subscriptionName, String topicName)
-----
-
-[source,java]
-----
-public Subscription createSubscription(String subscriptionName, String topicName, Integer ackDeadline)
-----
-
-[source,java]
-----
-public Subscription createSubscription(String subscriptionName, String topicName, String pushEndpoint)
-----
-
-You can also pass a full `Subscription.Builder` for full access to any options or features available in the client library.
-
-[source,java]
-----
-public Subscription createSubscription(Subscription.Builder builder)
 ----
 
 ==== Deleting a subscription


### PR DESCRIPTION
…up dead letter topics.

I cleaned up a bit of stuff that I think makes some sections a bit cleaner/clearer to understand.

Personally, as a side note, I don't see that much value in most of the sections under `Pub/Sub management` that wouldn't be better served by pointing to the Javadoc. "PubSubAdmin implements a method to [CRUD operation]" IMO doesn't really need to be explained.