### PR TITLE
Add warning about use of `returnImmediately=true`

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -219,9 +219,9 @@ h|pullNext | Allows for a single message to be pulled and automatically acknowle
 h|pullAndConvert | Works the same as the `pull` method and, additionally, converts the Pub/Sub binary payload to an object of the desired type, using the converter configured in the template.
 |===
 
-WARNING: Setting `returnImmediately` to `true` is not recommended as it may result in long delays in message delivery.
-This is due to the fact that "immediately" really means 1 second, and if no messages can be retrieved in that time from the Pub/Sub backend, no messages will be returned.
-This may happen repeatedly despite having messages queued up on the topic. The recommended alternative is to set `returnImmediately` to `false`, or to use `subscribe` methods described in the previous section.
+WARNING: We do not recommend setting `returnImmediately` to `true`, as it may result in delayed message delivery.
+"Immediately" really means 1 second, and if Pub/Sub cannot retrieve any messages from the backend in that time, it will return 0 messages, despite having messages queue up on the topic.
+Therefore, we recommend setting `returnImmediately` to `false`, or using `subscribe` methods from the previous section.
 
 ===== Acknowledging messages
 

--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -219,6 +219,10 @@ h|pullNext | Allows for a single message to be pulled and automatically acknowle
 h|pullAndConvert | Works the same as the `pull` method and, additionally, converts the Pub/Sub binary payload to an object of the desired type, using the converter configured in the template.
 |===
 
+WARNING: Setting `returnImmediately` to `true` is not recommended as it may result in long delays in message delivery.
+This is due to the fact that "immediately" really means 1 second, and if no messages can be retrieved in that time from the Pub/Sub backend, no messages will be returned.
+This may happen repeatedly despite having messages queued up on the topic. The recommended alternative is to set `returnImmediately` to `false`, or to use `subscribe` methods described in the previous section.
+
 ===== Acknowledging messages
 
 There are two ways to acknowledge messages.

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberOperations.java
@@ -76,7 +76,8 @@ public interface PubSubSubscriberOperations {
 	 * @param maxMessages the maximum number of pulled messages. If this value is null then
 	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
-	 * messages to satisfy {@code maxMessages}
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
 	 * @return the list of received messages
 	 */
 	List<PubsubMessage> pullAndAck(String subscription, Integer maxMessages, Boolean returnImmediately);
@@ -88,7 +89,8 @@ public interface PubSubSubscriberOperations {
 	 * @param maxMessages the maximum number of pulled messages. If this value is null then
 	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
-	 * messages to satisfy {@code maxMessages}
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
 	 * @return the ListenableFuture for the asynchronous execution, returning the list of
 	 * received acknowledgeable messages
 	 * @since 1.2.3
@@ -102,7 +104,8 @@ public interface PubSubSubscriberOperations {
 	 * @param maxMessages the maximum number of pulled messages. If this value is null then
 	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
-	 * messages to satisfy {@code maxMessages}
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
 	 * @return the list of received acknowledgeable messages
 	 */
 	List<AcknowledgeablePubsubMessage> pull(String subscription, Integer maxMessages, Boolean returnImmediately);
@@ -114,7 +117,8 @@ public interface PubSubSubscriberOperations {
 	 * @param maxMessages the maximum number of pulled messages. If this value is null then
 	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
-	 * messages to satisfy {@code maxMessages}
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
 	 * @return the ListenableFuture for the asynchronous execution, returning the list of
 	 * received acknowledgeable messages
 	 * @since 1.2.3
@@ -129,7 +133,8 @@ public interface PubSubSubscriberOperations {
 	 * @param maxMessages the maximum number of pulled messages. If this value is null then
 	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
-	 * messages to satisfy {@code maxMessages}
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
 	 * @param payloadType the type to which the payload of the Pub/Sub messages should be converted
 	 * @param <T> the type of the payload
 	 * @return the list of received acknowledgeable messages
@@ -146,7 +151,8 @@ public interface PubSubSubscriberOperations {
 	 * @param maxMessages the maximum number of pulled messages. If this value is null then
 	 * up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
-	 * messages to satisfy {@code maxMessages}
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
 	 * @param payloadType the type to which the payload of the Pub/Sub messages should be converted
 	 * @param <T> the type of the payload
 	 * @return the ListenableFuture for the asynchronous execution, returning the list of

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/SubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/SubscriberFactory.java
@@ -57,7 +57,8 @@ public interface SubscriberFactory {
 	 * @param maxMessages the maximum number of pulled messages; must be greater than zero.
 	 * If null is passed in, then up to Integer.MAX_VALUE messages will be requested.
 	 * @param returnImmediately causes the pull request to return immediately even
-	 * if subscription doesn't contain enough messages to satisfy {@code maxMessages}
+	 * if subscription doesn't contain enough messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
 	 * @return the pull request that can be executed using a {@link SubscriberStub}
 	 */
 	PullRequest createPullRequest(String subscriptionName, Integer maxMessages,


### PR DESCRIPTION
Updates javadocs and reference documentation with a warning.
However, we decided not to deprecate the field for now.

Addresses: #309.