### PR TITLE
Fix Pub/Sub Integration Snippet in doc

### DIFF
--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -53,9 +53,9 @@ public MessageChannel pubsubInputChannel() {
 @Bean
 public PubSubInboundChannelAdapter messageChannelAdapter(
     @Qualifier("pubsubInputChannel") MessageChannel inputChannel,
-    PubSubSubscriberOperations subscriberOperations) {
+    PubSubTemplate pubsubTemplate) {
     PubSubInboundChannelAdapter adapter =
-        new PubSubInboundChannelAdapter(subscriberOperations, "subscriptionName");
+        new PubSubInboundChannelAdapter(pubsubTemplate, "subscriptionName");
     adapter.setOutputChannel(inputChannel);
     adapter.setAckMode(AckMode.MANUAL);
 


### PR DESCRIPTION
I changed it to inject `PubSubTemplate` instead of `PubSubSubscriberOperations`; turns out there are 2 beans in the environment that implement `PubSubSubscriberOperations` making it non-unique -- `PubSubTemplate` and `PubSubSubscriberTemplate`.