### PR TITLE
Skip integration tests for dependabot

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   integrationTests:
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp'
+    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && github.actor != 'dependabot'
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -11,7 +11,8 @@ on:
 
 jobs:
   sonar:
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' # Only run on upstream branch
+    # Only run on upstream branch
+    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && github.actor != 'dependabot'
     name: Build with Sonar
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -11,8 +11,7 @@ on:
 
 jobs:
   sonar:
-    # Only run on upstream branch
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && github.actor != 'dependabot'
+    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' # Only run on upstream branch
     name: Build with Sonar
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This is because secrets are not available for dependabot.
See: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/