### PR TITLE
Make ITs wait their turn across all branches

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -89,6 +89,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           continue-after-seconds: 1200 # 30 min
+          same-branch-only: false
       - name: Integration Tests
         id: intTest1
         continue-on-error: true


### PR DESCRIPTION
By default, turntstyle will only block concurrent jobs on the same branch.
That's not what we want.