### PR TITLE
Add conditionals on PubSubBinderConfig, including a property to expli…

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -43,7 +43,8 @@
 |spring.cloud.gcp.metrics.enabled | true | Auto-configure Google Cloud Monitoring for Micrometer.
 |spring.cloud.gcp.metrics.project-id |  | Overrides the GCP project ID specified in the Core module.
 |spring.cloud.gcp.project-id |  | GCP project ID where services are running.
-|spring.cloud.gcp.pubsub.credentials.encoded-key |  | 
+|spring.cloud.gcp.pubsub.binder.enabled | true | Auto-configure Google Cloud Pub/Sub Stream Binder components.
+|spring.cloud.gcp.pubsub.credentials.encoded-key |  |
 |spring.cloud.gcp.pubsub.credentials.location |  | 
 |spring.cloud.gcp.pubsub.credentials.scopes |  | 
 |spring.cloud.gcp.pubsub.emulator-host |  | The host and port of the local running emulator. If provided, this will setup the client to connect against a running pub/sub emulator.

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -55,6 +55,12 @@
       "defaultValue": true
     },
     {
+      "name": "spring.cloud.gcp.pubsub.binder.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Cloud Pub/Sub Stream Binder components.",
+      "defaultValue": true
+    },
+    {
       "name": "spring.cloud.gcp.pubsub.reactive.enabled",
       "type": "java.lang.Boolean",
       "description": "Auto-configure Google Cloud Pub/Sub Reactive components.",

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/config/PubSubBinderConfiguration.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/config/PubSubBinderConfiguration.java
@@ -26,7 +26,9 @@ import com.google.cloud.spring.stream.binder.pubsub.PubSubMessageChannelBinder;
 import com.google.cloud.spring.stream.binder.pubsub.properties.PubSubExtendedBindingProperties;
 import com.google.cloud.spring.stream.binder.pubsub.provisioning.PubSubChannelProvisioner;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.cloud.stream.binder.Binder;
@@ -46,6 +48,8 @@ import org.springframework.lang.Nullable;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnMissingBean(Binder.class)
+@ConditionalOnBean({PubSubAdmin.class, PubSubTemplate.class})
+@ConditionalOnProperty(value = "spring.cloud.gcp.pubsub.binder.enabled", matchIfMissing = true)
 @EnableConfigurationProperties(PubSubExtendedBindingProperties.class)
 public class PubSubBinderConfiguration {
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/config/PubSubBinderConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/config/PubSubBinderConfigurationTests.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -35,6 +36,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for PubSubBinderConfiguration and its interaction with other autoconfiguration classes.
  */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class PubSubBinderConfigurationTests {
 
 	@Test

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/config/PubSubBinderConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/config/PubSubBinderConfigurationTests.java
@@ -20,6 +20,7 @@ import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
 import com.google.cloud.spring.autoconfigure.pubsub.GcpPubSubAutoConfiguration;
+import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.pubsub.PubSubAdmin;
 import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 import com.google.cloud.spring.stream.binder.pubsub.provisioning.PubSubChannelProvisioner;
@@ -128,6 +129,12 @@ public class PubSubBinderConfigurationTests {
 		@Bean
 		public CredentialsProvider googleCredentials() {
 			return () -> mock(Credentials.class);
+		}
+
+
+		@Bean
+		public GcpProjectIdProvider gcpProjectIdProvider() {
+			return () -> "test-project";
 		}
 	}
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/config/PubSubBinderConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/config/PubSubBinderConfigurationTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.stream.binder.pubsub.config;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
+import com.google.cloud.spring.autoconfigure.pubsub.GcpPubSubAutoConfiguration;
+import com.google.cloud.spring.pubsub.PubSubAdmin;
+import com.google.cloud.spring.pubsub.core.PubSubTemplate;
+import com.google.cloud.spring.stream.binder.pubsub.provisioning.PubSubChannelProvisioner;
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for PubSubBinderConfiguration and its interaction with other autoconfiguration classes.
+ */
+public class PubSubBinderConfigurationTests {
+
+	@Test
+	public void testEverythingEnabled_implicit() {
+		ApplicationContextRunner baseContext = new ApplicationContextRunner()
+				// no property values specified
+				.withConfiguration(AutoConfigurations.of(
+						GcpContextAutoConfiguration.class,
+						GcpPubSubAutoConfiguration.class,
+						PubSubBinderConfiguration.class))
+				.withUserConfiguration(TestConfiguration.class);
+		baseContext.run(ctx -> assertThat(ctx).hasSingleBean(PubSubChannelProvisioner.class));
+	}
+
+	@Test
+	public void testEverythingEnabled_explicit() {
+		ApplicationContextRunner baseContext = new ApplicationContextRunner()
+				.withPropertyValues(
+						// including 'core' for completeness, but it's not super relevant to the test.
+						"spring.cloud.gcp.core.enabled=true",
+						"spring.cloud.gcp.pubsub.enabled=true",
+						"spring.cloud.gcp.pubsub.binder.enabled=true")
+				.withConfiguration(AutoConfigurations.of(
+						GcpContextAutoConfiguration.class,
+						GcpPubSubAutoConfiguration.class,
+						PubSubBinderConfiguration.class))
+				.withUserConfiguration(TestConfiguration.class);
+		baseContext.run(ctx -> assertThat(ctx).hasSingleBean(PubSubChannelProvisioner.class));
+	}
+
+	@Test
+	public void testBinderDisabled() {
+		ApplicationContextRunner baseContext = new ApplicationContextRunner()
+				.withPropertyValues(
+						"spring.cloud.gcp.pubsub.enabled=true",
+						"spring.cloud.gcp.pubsub.binder.enabled=false")
+				.withConfiguration(AutoConfigurations.of(
+						GcpContextAutoConfiguration.class,
+						GcpPubSubAutoConfiguration.class,
+						PubSubBinderConfiguration.class))
+				.withUserConfiguration(TestConfiguration.class);
+		baseContext.run(ctx -> assertThat(ctx).doesNotHaveBean(PubSubChannelProvisioner.class));
+	}
+
+	@Test
+	public void testPubSubDisabled_noReplacements() {
+		ApplicationContextRunner baseContext = new ApplicationContextRunner()
+				.withPropertyValues(
+						"spring.cloud.gcp.pubsub.enabled=false",
+						"spring.cloud.gcp.pubsub.binder.enabled=true")
+				.withConfiguration(AutoConfigurations.of(
+						GcpContextAutoConfiguration.class,
+						GcpPubSubAutoConfiguration.class,
+						PubSubBinderConfiguration.class))
+				.withUserConfiguration(TestConfiguration.class);
+		baseContext.run(ctx -> assertThat(ctx).doesNotHaveBean(PubSubChannelProvisioner.class));
+	}
+	@Test
+	public void testPubSubDisabled_withReplacements() {
+		ApplicationContextRunner baseContext = new ApplicationContextRunner()
+				.withPropertyValues(
+						"spring.cloud.gcp.pubsub.enabled=false",
+						"spring.cloud.gcp.pubsub.binder.enabled=true")
+				.withBean(PubSubAdmin.class, () -> mock(PubSubAdmin.class))
+				.withBean(PubSubTemplate.class, () -> mock(PubSubTemplate.class))
+				.withConfiguration(AutoConfigurations.of(
+						GcpContextAutoConfiguration.class,
+						GcpPubSubAutoConfiguration.class,
+						PubSubBinderConfiguration.class))
+				.withUserConfiguration(TestConfiguration.class);
+		baseContext.run(ctx -> assertThat(ctx).hasSingleBean(PubSubChannelProvisioner.class));
+	}
+
+	@Test
+	public void testBothDisabled() {
+		ApplicationContextRunner baseContext = new ApplicationContextRunner()
+				.withPropertyValues(
+						"spring.cloud.gcp.pubsub.enabled=false",
+						"spring.cloud.gcp.pubsub.binder.enabled=false")
+				.withConfiguration(AutoConfigurations.of(
+						GcpContextAutoConfiguration.class,
+						GcpPubSubAutoConfiguration.class,
+						PubSubBinderConfiguration.class))
+				.withUserConfiguration(TestConfiguration.class);
+		baseContext.run(ctx -> assertThat(ctx).doesNotHaveBean(PubSubChannelProvisioner.class));
+	}
+
+	private static class TestConfiguration {
+		@Bean
+		public CredentialsProvider googleCredentials() {
+			return () -> mock(Credentials.class);
+		}
+	}
+}


### PR DESCRIPTION
…citly disable it.

Originally filed issue: https://github.com/spring-cloud/spring-cloud-gcp/issues/2653

Thing to discuss is the `testPubSubDisabled_noReplacements` test, which as written will not fail on startup even if that particular configuration doesn't make a whole lot of sense.