### PR TITLE
Enable Pub/Sub message ordering for publishing

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -77,6 +77,8 @@ The delay threshold to use for batching.
 After this amount of time has elapsed (counting from the first element added), the elements will be wrapped up in a batch and sent. | No | 1 ms (batching off)
 | `spring.cloud.gcp.pubsub.publisher.batching.enabled`|
 Enables batching. | No | false
+| `spring.cloud.gcp.pubsub.publisher.enable-message-ordering`|
+Enables message ordering. | No | false
 |===
 
 ==== GRPC Connection Settings
@@ -175,6 +177,16 @@ include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/
 ----
 
 By default, the `SimplePubSubMessageConverter` is used to convert payloads of type `byte[]`, `ByteString`, `ByteBuffer`, and `String` to Pub/Sub messages.
+
+===== Ordering messages
+
+If you are relying on message converters and would like to provide an ordering key, use the `GcpPubSubHeaders.ORDERING_KEY` header.
+You will also need to make sure to enable message ordering on the publisher via the `spring.cloud.gcp.pubsub.publisher.enable-message-ordering` property.
+
+[source,java,indent=0]
+----
+include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubTemplateDocumentationIntegrationTests.java[tag=publish_ordering]
+----
 
 ==== Subscribing to a subscription
 

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -296,8 +296,11 @@ include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/
 
 These channel adapters contain header mappers that allow you to map, or filter out, headers from Spring to Google Cloud Pub/Sub messages, and vice-versa.
 By default, the inbound channel adapter maps every header on the Google Cloud Pub/Sub messages to the Spring messages produced by the adapter.
-The outbound channel adapter maps every header from Spring messages into Google Cloud Pub/Sub ones, except the ones added by Spring, like headers with key `"id"`, `"timestamp"` and `"gcp_pubsub_acknowledgement"`.
+The outbound channel adapter maps every header from Spring messages into Google Cloud Pub/Sub ones, except the ones added by Spring and some special headers, like headers with key `"id"`, `"timestamp"`, `"gcp_pubsub_acknowledgement"`, and `"gcp_pubsub_ordering_key"`.
 In the process, the outbound mapper also converts the value of the headers into string.
+
+Note that you can provide the `GcpPubSubHeaders.ORDERING_KEY` (`"gcp_pubsub_ordering_key"`) header, which will be automatically mapped to `PubsubMessage.orderingKey` property, and excluded from the headers in the published message.
+Remember to set `spring.cloud.gcp.pubsub.publisher.enable-message-ordering` to `true`, if you are publishing messages with this header.
 
 Each adapter declares a `setHeaderMapper()` method to let you further customize which headers you want to map from Spring to Google Cloud Pub/Sub, and vice-versa.
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -309,6 +309,7 @@ public class GcpPubSubAutoConfiguration {
 		factory.setChannelProvider(publisherTransportChannelProvider);
 		retrySettings.ifAvailable(factory::setRetrySettings);
 		batchingSettings.ifAvailable(factory::setBatchingSettings);
+		factory.setEnableMessageOrdering(gcpPubSubProperties.getPublisher().getEnableMessageOrdering());
 		return factory;
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubProperties.java
@@ -126,6 +126,11 @@ public class GcpPubSubProperties implements CredentialsSupplier {
 		 */
 		private final Batching batching = new Batching();
 
+		/**
+		 * Enable message ordering setting.
+		 */
+		private Boolean enableMessageOrdering;
+
 		public Batching getBatching() {
 			return this.batching;
 		}
@@ -140,6 +145,14 @@ public class GcpPubSubProperties implements CredentialsSupplier {
 
 		public void setExecutorThreads(int executorThreads) {
 			this.executorThreads = executorThreads;
+		}
+
+		public Boolean getEnableMessageOrdering() {
+			return enableMessageOrdering;
+		}
+
+		public void setEnableMessageOrdering(Boolean enableMessageOrdering) {
+			this.enableMessageOrdering = enableMessageOrdering;
 		}
 	}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactory.java
@@ -61,6 +61,8 @@ public class DefaultPublisherFactory implements PublisherFactory {
 
 	private BatchingSettings batchingSettings;
 
+	private Boolean enableMessageOrdering;
+
 	/**
 	 * Create {@link DefaultPublisherFactory} instance based on the provided {@link GcpProjectIdProvider}.
 	 * <p>The {@link GcpProjectIdProvider} must not be null, neither provide an empty {@code projectId}.
@@ -123,6 +125,14 @@ public class DefaultPublisherFactory implements PublisherFactory {
 		this.batchingSettings = batchingSettings;
 	}
 
+	/**
+	 * Set whether message ordering should be enabled on the publisher.
+	 * @param enableMessageOrdering whether to enable message ordering
+	 */
+	public void setEnableMessageOrdering(Boolean enableMessageOrdering) {
+		this.enableMessageOrdering = enableMessageOrdering;
+	}
+
 	@Override
 	public Publisher createPublisher(String topic) {
 		return this.publishers.computeIfAbsent(topic, key -> {
@@ -130,29 +140,7 @@ public class DefaultPublisherFactory implements PublisherFactory {
 				Publisher.Builder publisherBuilder =
 						Publisher.newBuilder(PubSubTopicUtils.toTopicName(topic, this.projectId));
 
-				if (this.executorProvider != null) {
-					publisherBuilder.setExecutorProvider(this.executorProvider);
-				}
-
-				if (this.channelProvider != null) {
-					publisherBuilder.setChannelProvider(this.channelProvider);
-				}
-
-				if (this.credentialsProvider != null) {
-					publisherBuilder.setCredentialsProvider(this.credentialsProvider);
-				}
-
-				if (this.headerProvider != null) {
-					publisherBuilder.setHeaderProvider(this.headerProvider);
-				}
-
-				if (this.retrySettings != null) {
-					publisherBuilder.setRetrySettings(this.retrySettings);
-				}
-
-				if (this.batchingSettings != null) {
-					publisherBuilder.setBatchingSettings(this.batchingSettings);
-				}
+				applyPublisherSettings(publisherBuilder);
 
 				return publisherBuilder.build();
 			}
@@ -161,6 +149,36 @@ public class DefaultPublisherFactory implements PublisherFactory {
 						"occurred.", ioe);
 			}
 		});
+	}
+
+	void applyPublisherSettings(Publisher.Builder publisherBuilder) {
+		if (this.executorProvider != null) {
+			publisherBuilder.setExecutorProvider(this.executorProvider);
+		}
+
+		if (this.channelProvider != null) {
+			publisherBuilder.setChannelProvider(this.channelProvider);
+		}
+
+		if (this.credentialsProvider != null) {
+			publisherBuilder.setCredentialsProvider(this.credentialsProvider);
+		}
+
+		if (this.headerProvider != null) {
+			publisherBuilder.setHeaderProvider(this.headerProvider);
+		}
+
+		if (this.retrySettings != null) {
+			publisherBuilder.setRetrySettings(this.retrySettings);
+		}
+
+		if (this.batchingSettings != null) {
+			publisherBuilder.setBatchingSettings(this.batchingSettings);
+		}
+
+		if (this.enableMessageOrdering != null) {
+			publisherBuilder.setEnableMessageOrdering(this.enableMessageOrdering);
+		}
 	}
 
 	Map<String, Publisher> getCache() {

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/GcpPubSubHeaders.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/GcpPubSubHeaders.java
@@ -45,6 +45,11 @@ public abstract class GcpPubSubHeaders {
 	public static final String ORIGINAL_MESSAGE = PREFIX + "original_message";
 
 	/**
+	 * The Pub/Sub message ordering key.
+	 */
+	public static final String ORDERING_KEY = PREFIX + "ordering_key";
+
+	/**
 	 * A simple utility method for pulling the {@link #ORIGINAL_MESSAGE} header out of a {@link Message}.
 	 *
 	 * @param message The Spring Message that was converted by a

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/converter/JacksonPubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/converter/JacksonPubSubMessageConverter.java
@@ -48,14 +48,8 @@ public class JacksonPubSubMessageConverter implements PubSubMessageConverter {
 	@Override
 	public PubsubMessage toPubSubMessage(Object payload, Map<String, String> headers) {
 		try {
-			PubsubMessage.Builder pubsubMessageBuilder = PubsubMessage.newBuilder()
-					.setData(ByteString.copyFrom(this.objectMapper.writeValueAsBytes(payload)));
-
-			if (headers != null) {
-				pubsubMessageBuilder.putAllAttributes(headers);
-			}
-
-			return pubsubMessageBuilder.build();
+			return byteStringToPubSubMessage(ByteString.copyFrom(
+					this.objectMapper.writeValueAsBytes(payload)), headers);
 		}
 		catch (JsonProcessingException ex) {
 			throw new PubSubMessageConversionException("JSON serialization of an object of type " +

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/converter/PubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/converter/PubSubMessageConverter.java
@@ -18,6 +18,8 @@ package com.google.cloud.spring.pubsub.support.converter;
 
 import java.util.Map;
 
+import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
+import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 
 /**
@@ -44,4 +46,20 @@ public interface PubSubMessageConverter {
 	 * @return the object converted from the message's payload
 	 */
 	<T> T fromPubSubMessage(PubsubMessage message, Class<T> payloadType);
+
+	default PubsubMessage byteStringToPubSubMessage(ByteString payload, Map<String, String> headers) {
+		PubsubMessage.Builder pubsubMessageBuilder = PubsubMessage.newBuilder()
+				.setData(payload);
+
+		if (headers != null) {
+			pubsubMessageBuilder.putAllAttributes(headers);
+
+			if (headers.containsKey(GcpPubSubHeaders.ORDERING_KEY)) {
+				pubsubMessageBuilder.removeAttributes(GcpPubSubHeaders.ORDERING_KEY);
+				pubsubMessageBuilder.setOrderingKey(headers.get(GcpPubSubHeaders.ORDERING_KEY));
+			}
+		}
+
+		return pubsubMessageBuilder.build();
+	}
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/converter/SimplePubSubMessageConverter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/converter/SimplePubSubMessageConverter.java
@@ -63,14 +63,7 @@ public class SimplePubSubMessageConverter implements PubSubMessageConverter {
 					payload.getClass().getName() + " to byte[] for sending to Pub/Sub.");
 		}
 
-		PubsubMessage.Builder pubsubMessageBuilder = PubsubMessage.newBuilder()
-				.setData(convertedPayload);
-
-		if (headers != null) {
-			pubsubMessageBuilder.putAllAttributes(headers);
-		}
-
-		return pubsubMessageBuilder.build();
+		return byteStringToPubSubMessage(convertedPayload, headers);
 
 	}
 

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spring.pubsub.integration.outbound;
 
+import java.util.Collections;
+
 import com.google.cloud.spring.core.util.MapBuilder;
 import com.google.cloud.spring.pubsub.core.PubSubOperations;
 import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
@@ -227,4 +229,18 @@ public class PubSubMessageHandlerTests {
 
 		this.adapter.setHeaderMapper(null);
 	}
+
+	@Test
+	public void testPublishWithOrderingKey() {
+		this.message = new GenericMessage<byte[]>("testPayload".getBytes(),
+				new MapBuilder<String, Object>()
+						.put(GcpPubSubHeaders.ORDERING_KEY, "key1")
+						.build());
+
+		this.adapter.handleMessage(this.message);
+		verify(this.pubSubTemplate, times(1))
+				.publish(eq("testTopic"), eq("testPayload".getBytes()),
+						eq(Collections.singletonMap(GcpPubSubHeaders.ORDERING_KEY, "key1")));
+	}
+
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -238,8 +238,8 @@ public class PubSubMessageHandlerTests {
 
 		this.adapter.handleMessage(this.message);
 		verify(this.pubSubTemplate)
-				.publish(eq("testTopic"), eq("testPayload".getBytes()),
-						eq(Collections.singletonMap(GcpPubSubHeaders.ORDERING_KEY, "key1")));
+				.publish("testTopic", "testPayload".getBytes(),
+						Collections.singletonMap(GcpPubSubHeaders.ORDERING_KEY, "key1"));
 	}
 
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -42,7 +42,6 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -88,7 +87,7 @@ public class PubSubMessageHandlerTests {
 	@Test
 	public void testPublish() {
 		this.adapter.handleMessage(this.message);
-		verify(this.pubSubTemplate, times(1))
+		verify(this.pubSubTemplate)
 				.publish(eq("testTopic"), eq("testPayload".getBytes()), anyMap());
 	}
 
@@ -101,7 +100,7 @@ public class PubSubMessageHandlerTests {
 						.put(GcpPubSubHeaders.TOPIC, "dynamicTopic")
 						.build());
 		this.adapter.handleMessage(dynamicMessage);
-		verify(this.pubSubTemplate, times(1))
+		verify(this.pubSubTemplate)
 			.publish(eq("dynamicTopic"), eq("testPayload".getBytes()), anyMap());
 	}
 
@@ -116,7 +115,7 @@ public class PubSubMessageHandlerTests {
 						.put("sendToTopic", "expressionTopic")
 						.build());
 		this.adapter.handleMessage(expressionMessage);
-		verify(this.pubSubTemplate, times(1))
+		verify(this.pubSubTemplate)
 				.publish(eq("expressionTopic"), eq("testPayload".getBytes()), anyMap());
 	}
 
@@ -127,7 +126,7 @@ public class PubSubMessageHandlerTests {
 		this.adapter.setPublishTimeoutExpression(timeout);
 
 		this.adapter.handleMessage(this.message);
-		verify(timeout, times(1)).getValue(isNull(), eq(this.message), eq(Long.class));
+		verify(timeout).getValue(isNull(), eq(this.message), eq(Long.class));
 	}
 
 	@Test
@@ -150,7 +149,7 @@ public class PubSubMessageHandlerTests {
 
 		assertThat(this.adapter.getPublishCallback()).isSameAs(callbackSpy);
 
-		verify(callbackSpy, times(1)).onSuccess("benfica");
+		verify(callbackSpy).onSuccess("benfica");
 	}
 
 	@Test
@@ -238,7 +237,7 @@ public class PubSubMessageHandlerTests {
 						.build());
 
 		this.adapter.handleMessage(this.message);
-		verify(this.pubSubTemplate, times(1))
+		verify(this.pubSubTemplate)
 				.publish(eq("testTopic"), eq("testPayload".getBytes()),
 						eq(Collections.singletonMap(GcpPubSubHeaders.ORDERING_KEY, "key1")));
 	}

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/converter/JacksonPubSubMessageConverterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/converter/JacksonPubSubMessageConverterTests.java
@@ -16,10 +16,12 @@
 
 package com.google.cloud.spring.pubsub.support.converter;
 
+import java.util.Collections;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
 import com.google.pubsub.v1.PubsubMessage;
 import org.json.JSONException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -74,7 +76,27 @@ public class JacksonPubSubMessageConverterTests {
 	@Test
 	public void testToPubSubMessageWithNullPayload() throws JSONException {
 		PubsubMessage pubsubMessage = this.converter.toPubSubMessage(null, null);
-		Assert.assertNotNull(pubsubMessage);
+		assertThat(pubsubMessage).isNotNull();
+		assertThat(pubsubMessage.getAttributesCount()).isZero();
+	}
+
+	@Test
+	public void testToPubSubMessageWithOrderingKeyHeader() throws JSONException {
+		PubsubMessage pubsubMessage = this.converter.toPubSubMessage(null,
+				Collections.singletonMap(GcpPubSubHeaders.ORDERING_KEY, "key1"));
+		assertThat(pubsubMessage).isNotNull();
+		assertThat(pubsubMessage.getOrderingKey()).isEqualTo("key1");
+		assertThat(pubsubMessage.getAttributesCount()).isZero();
+	}
+
+	@Test
+	public void testToPubSubMessageWitHeader() throws JSONException {
+		PubsubMessage pubsubMessage = this.converter.toPubSubMessage(null,
+				Collections.singletonMap("custom-header", "val1"));
+		assertThat(pubsubMessage).isNotNull();
+		assertThat(pubsubMessage.getOrderingKey()).isEmpty();
+		assertThat(pubsubMessage.getAttributesCount()).isOne();
+		assertThat(pubsubMessage.getAttributesMap()).containsEntry("custom-header", "val1");
 	}
 
 	/**

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/converter/SimplePubSubMessageConverterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/converter/SimplePubSubMessageConverterTests.java
@@ -18,12 +18,15 @@ package com.google.cloud.spring.pubsub.support.converter;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.google.cloud.spring.core.util.MapBuilder;
+import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
+import org.json.JSONException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -144,4 +147,15 @@ public class SimplePubSubMessageConverterTests {
 		assertThat(new String(convertedPubSubMessage.getData().toByteArray())).isEqualTo(TEST_STRING);
 		assertThat(convertedPubSubMessage.getAttributesMap()).isEqualTo(TEST_HEADERS);
 	}
+
+	@Test
+	public void testOrderingKeyHeader() throws JSONException {
+		SimplePubSubMessageConverter converter = new SimplePubSubMessageConverter();
+		PubsubMessage pubsubMessage = converter.toPubSubMessage("test payload",
+				Collections.singletonMap(GcpPubSubHeaders.ORDERING_KEY, "key1"));
+		assertThat(pubsubMessage).isNotNull();
+		assertThat(pubsubMessage.getOrderingKey()).isEqualTo("key1");
+		assertThat(pubsubMessage.getAttributesCount()).isZero();
+	}
+
 }


### PR DESCRIPTION
Introduces `GcpPubSubHeaders.ORDERING_KEY` header that will be automatically applied to the `PubsubMessage` up conversion.
Also, introduces `spring.cloud.gcp.pubsub.publisher.enable-message-ordering` property to enable message ordering on the `Publisher`.

First step in addressing: #85.