### PR TITLE
Document findBy(Pageable) for Firestore

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/entities/UserRepository.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/entities/UserRepository.java
@@ -32,6 +32,8 @@ import org.springframework.data.domain.Sort;
  */
 //tag::repository[]
 public interface UserRepository extends FirestoreReactiveRepository<User> {
+	Flux<User> findBy(Pageable pageable);
+
 	Flux<User> findByAge(Integer age);
 
 	Flux<User> findByAgeNot(Integer age);

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -157,6 +157,7 @@ public class FirestoreRepositoryIntegrationTests {
 		this.userRepository.saveAll(users).blockLast();
 
 		assertThat(this.userRepository.count().block()).isEqualTo(2);
+		assertThat(this.userRepository.findBy(PageRequest.of(0, 10)).collectList().block()).containsExactly(u1, u2);
 		assertThat(this.userRepository.findByAge(22).collectList().block()).containsExactly(u1);
 		assertThat(this.userRepository.findByAgeNot(22).collectList().block()).containsExactly(u2);
 		assertThat(this.userRepository.findByHomeAddressCountry("USA").collectList().block()).containsExactly(u1);


### PR DESCRIPTION
This is a substitute for `findAll(Pageable)`.

Related to #409.