### PR TITLE
Linkage Checker: adding exclusion file for autoconfigure package

### DIFF
--- a/.github/workflows/linkageCheck.yaml
+++ b/.github/workflows/linkageCheck.yaml
@@ -46,6 +46,7 @@ jobs:
         run: |
           ./mvnw \
             --activate-profiles linkage-check \
+            --projects spring-cloud-gcp-dependencies \
             --batch-mode \
             --show-version \
             --threads 1.5C \

--- a/spring-cloud-gcp-dependencies/linkage-checker-exclusion-rules.xml
+++ b/spring-cloud-gcp-dependencies/linkage-checker-exclusion-rules.xml
@@ -1,0 +1,21 @@
+<LinkageCheckerFilter>
+	<LinkageError>
+		<Source>
+			<Package name="com.google.cloud.spring.autoconfigure"/>
+		</Source>
+		<Reason>
+			Spring's autoconfigure classes work only when certain classes are available.
+		</Reason>
+	</LinkageError>
+	<LinkageError>
+		<Target>
+			<Class name="org.springframework.integration.file.remote.handler.FileTransferringMessageHandler"/>
+		</Target>
+		<Source>
+			<Class name="com.google.cloud.spring.storage.integration.outbound.GcsMessageHandler"/>
+		</Source>
+		<Reason>
+			The source class is used only when the target class is available.
+		</Reason>
+	</LinkageError>
+</LinkageCheckerFilter>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -379,6 +379,7 @@
 											implementation="com.google.cloud.tools.dependencies.enforcer.LinkageCheckerRule">
 											<dependencySection>DEPENDENCY_MANAGEMENT</dependencySection>
 											<reportOnlyReachable>true</reportOnlyReachable>
+											<exclusionFile>spring-cloud-gcp-dependencies/linkage-checker-exclusion-rules.xml</exclusionFile>
 										</LinkageCheckerRule>
 									</rules>
 								</configuration>


### PR DESCRIPTION
Towards https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/389

@meltsufin  As discussed, here is an example filtering XML file. The output of running Linkage Checker (https://gist.github.com/suztomo/7f3a02b246cb0e18e280a69c461fb466) does not show autoconfigure or GcsMessageHandler any more.

After this is merged, would you try adding more rules and share feedback?