### PR TITLE
Add implementation to GoogleStorageResource.java getFile() method

### DIFF
--- a/spring-cloud-gcp-storage/src/main/java/com/google/cloud/spring/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/com/google/cloud/spring/storage/GoogleStorageResource.java
@@ -33,6 +33,7 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -250,9 +251,10 @@ public class GoogleStorageResource implements WritableResource {
 
 	@Override
 	@NonNull
-	public File getFile() {
-		throw new UnsupportedOperationException(
-				getDescription() + " cannot be resolved to absolute file path");
+	public File getFile() throws IOException {
+		File file = new File(location.getBlobName());
+		FileUtils.writeByteArrayToFile(file,this.getBlob().getContent());
+		return file;
 	}
 
 	@Override

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageResourceTest.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageResourceTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spring.storage;
 
+import java.io.File;
 import java.io.IOException;
 
 import com.google.cloud.storage.Blob;
@@ -72,5 +73,19 @@ public class GoogleStorageResourceTest {
 		GoogleStorageResource gsr = new GoogleStorageResource(mockStorage, "gs://my-bucket/my-object");
 		assertThat(gsr.getURL()).isNotNull();
 
+	}
+
+	@Test
+	public void getGoogleObject() throws IOException {
+		Storage mockStorage = mock(Storage.class);
+		Blob mockBlob = mock(Blob.class);
+		String content= "some Content";
+
+		when(mockStorage.get(BlobId.of("my-bucket", "my-object"))).thenReturn(mockBlob);
+		when(mockBlob.getContent()).thenReturn(content.getBytes());
+
+		GoogleStorageResource googleStorageResource = new GoogleStorageResource(mockStorage, "gs://my-bucket/my-object");
+		File file = googleStorageResource.getFile();
+		assertThat(file).isNotNull();
 	}
 }


### PR DESCRIPTION
We would like to add an implementation to getFile() method in GoogleStorageResource.java in order to use it with FlatFileItemWriter and close https://github.com/spring-projects/spring-batch/issues/3854

TODO: I'm not confident about creating new File(path) inside the getFile() method and I'm open to suggestions about how to improve it.