### PR TITLE
Add class condition on ManagedChannel

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
@@ -21,6 +21,7 @@ import javax.annotation.PreDestroy;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
@@ -40,7 +41,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Mike Eltsufin
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass(ManagedChannel.class)
+@ConditionalOnClass({ManagedChannel.class, PubSubTemplate.class})
 @ConditionalOnProperty(prefix = "spring.cloud.gcp.pubsub", name = "emulator-host")
 @AutoConfigureBefore(GcpPubSubAutoConfiguration.class)
 @EnableConfigurationProperties(GcpPubSubProperties.class)

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
@@ -25,6 +25,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -39,6 +40,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Mike Eltsufin
  */
 @Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(ManagedChannel.class)
 @ConditionalOnProperty(prefix = "spring.cloud.gcp.pubsub", name = "emulator-host")
 @AutoConfigureBefore(GcpPubSubAutoConfiguration.class)
 @EnableConfigurationProperties(GcpPubSubProperties.class)

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubEmulatorAutoConfiguration.java
@@ -42,7 +42,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ManagedChannel.class, PubSubTemplate.class})
-@ConditionalOnProperty(prefix = "spring.cloud.gcp.pubsub", name = "emulator-host")
+@ConditionalOnProperty(prefix = "spring.cloud.gcp.pubsub", name = "enabled", matchIfMissing = true)
 @AutoConfigureBefore(GcpPubSubAutoConfiguration.class)
 @EnableConfigurationProperties(GcpPubSubProperties.class)
 public class GcpPubSubEmulatorAutoConfiguration {
@@ -50,6 +50,7 @@ public class GcpPubSubEmulatorAutoConfiguration {
 
 	@Bean(name = {"subscriberTransportChannelProvider", "publisherTransportChannelProvider"})
 	@ConditionalOnMissingBean(name = {"subscriberTransportChannelProvider", "publisherTransportChannelProvider"})
+	@ConditionalOnProperty(prefix = "spring.cloud.gcp.pubsub", name = "emulator-host")
 	public TransportChannelProvider transportChannelProvider(GcpPubSubProperties gcpPubSubProperties) {
 		this.channel = ManagedChannelBuilder
 				.forTarget("dns:///" + gcpPubSubProperties.getEmulatorHost())


### PR DESCRIPTION
This fixes the edge case where the project has the `spring.cloud.gcp.pubsub.emulator-host` set but not actually imports the `spring-cloud-gcp-starter-pubsub` starter.

Before this change, this would cause a `NoClassDefFoundError` when the auto config encountered the `GcpPubSubEmulatorAutoConfiguration`.
