### PR TITLE
Add jdbc-socket-factory-core version

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -232,6 +232,12 @@
 			<!-- spring-cloud-gcp-starter-sql -->
 			<dependency>
 				<groupId>com.google.cloud.sql</groupId>
+				<artifactId>jdbc-socket-factory-core</artifactId>
+				<version>${cloud-sql-socket-factory.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.google.cloud.sql</groupId>
 				<artifactId>mysql-socket-factory</artifactId>
 				<version>${cloud-sql-socket-factory.version}</version>
 			</dependency>


### PR DESCRIPTION
This is used by some services we use, and it would be convenient to be able to not have to keep track of the version manually.
