### PR TITLE
Revert "Bump spring-boot-starter-parent from 2.4.5 to 2.5.0"

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.0</version>
+		<version>2.4.5</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/spring-cloud-gcp#468

Integration tests are failing and these are not just flakes.
For example `SecretManagerSampleIntegrationTests` failures can be reproduced locally.
Getting
` No converter found capable of converting from type [com.google.protobuf.ByteString$LiteralByteString] to type [java.lang.String]` which seems to indicate the converter registration in bootstrap autoconfig no longer works in Spring Boot 2.5.
