### PR TITLE
Pub/Sub publish callbacks with original Message awareness

### DIFF
--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -262,8 +262,10 @@ The provided `PubSubTemplate` contains all the necessary configuration to publis
 A publish timeout can be configured for synchronous publishing.
 If none is provided, the adapter waits indefinitely for a response.
 
-It is possible to set user-defined callbacks for the `publish()` call in `PubSubMessageHandler` through the `setPublishFutureCallback()` method.
-These are useful to process the message ID, in case of success, or the error if any was thrown.
+It is possible to set user-defined callbacks for the `publish()` call in `PubSubMessageHandler` through the `setSuccessCallback()` and `setFailureCallback()` methods (either one or both may be set).
+These give access to the Pub/Sub publish message ID in case of success, or the root cause exception in case of error.
+Both callbacks include the original message as the second argument.
+The old `setPublishFutureCallback()` methods that only gave access to message ID or root cause exception is deprecated and will be removed in a future release.
 
 [source,java,indent=0]
 ----

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -265,7 +265,7 @@ If none is provided, the adapter waits indefinitely for a response.
 It is possible to set user-defined callbacks for the `publish()` call in `PubSubMessageHandler` through the `setSuccessCallback()` and `setFailureCallback()` methods (either one or both may be set).
 These give access to the Pub/Sub publish message ID in case of success, or the root cause exception in case of error.
 Both callbacks include the original message as the second argument.
-The old `setPublishFutureCallback()` methods that only gave access to message ID or root cause exception is deprecated and will be removed in a future release.
+The old `setPublishFutureCallback()` method that only gave access to message ID or root cause exception is deprecated and will be removed in a future release.
 
 [source,java,indent=0]
 ----

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -265,11 +265,19 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 	}
 
+	/**
+	 * Implement this callback to post-process a successfully published message.
+	 */
+	@FunctionalInterface
 	public interface SuccessCallback {
 
 		void onSuccess(String ackId, Message<?> message);
 	}
 
+	/**
+	 * Implement this callback to post-process a message that failed to publish to Cloud Pub/Sub.
+	 */
+	@FunctionalInterface
 	public interface FailureCallback {
 
 		void onFailure(Throwable cause, Message<?> message);

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -16,9 +16,16 @@
 
 package com.google.cloud.spring.pubsub.integration.outbound;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import com.google.cloud.spring.pubsub.core.publisher.PubSubPublisherOperations;
 import com.google.cloud.spring.pubsub.integration.PubSubHeaderMapper;
 import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
+
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
@@ -32,12 +39,6 @@ import org.springframework.messaging.MessageHandlingException;
 import org.springframework.util.Assert;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Outbound channel adapter to publish messages to Google Cloud Pub/Sub.
@@ -239,12 +240,12 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 	}
 
-	public static interface SuccessCallback {
+	public interface SuccessCallback {
 
 		void onSuccess(String ackId, Message<?> message);
 	}
 
-	public static interface FailureCallback {
+	public interface FailureCallback {
 
 		void onFailure(Throwable cause, Message<?> message);
 	}

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -134,7 +134,7 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 	/**
 	 * Set the callback to be activated when the publish call resolves.
 	 * @param publishCallback callback for the publish future
-	 * @deprecated Use {@code setSuccessCallback()} and {@code setFailureCallback()} instead.
+	 * @deprecated Use {@link #setSuccessCallback} and {@link #setFailureCallback} instead.
 	 */
 	@Deprecated
 	public void setPublishCallback(ListenableFutureCallback<String> publishCallback) {
@@ -144,19 +144,19 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 	/**
 	 * Set callback (can be a lambda) for processing the published message ID and the original {@code Message} after the
 	 * message was successfully published.
-	 * @param cb callback accepting a {@code String} message ID and the original {@code Message}.
+	 * @param successCallback callback accepting a {@code String} message ID and the original {@code Message}.
 	 */
-	public void setSuccessCallback(SuccessCallback cb) {
-		this.successCallback = cb;
+	public void setSuccessCallback(SuccessCallback successCallback) {
+		this.successCallback = successCallback;
 	}
 
 	/**
 	 * Set callback (can be a lambda) for processing the root cause exception and the original {@code Message} in case
 	 * of failure.
-	 * @param cb callback accepting a {@code Throwable} and a {@code Message}.
+	 * @param failureCallback callback accepting a {@code Throwable} and a {@code Message}.
 	 */
-	public void setFailureCallback(FailureCallback cb) {
-		this.failureCallback = cb;
+	public void setFailureCallback(FailureCallback failureCallback) {
+		this.failureCallback = failureCallback;
 	}
 
 	public Expression getTopicExpression() {

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandler.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandler.java
@@ -141,10 +141,20 @@ public class PubSubMessageHandler extends AbstractMessageHandler {
 		this.publishCallback = publishCallback;
 	}
 
+	/**
+	 * Set callback (can be a lambda) for processing the published message ID and the original {@code Message} after the
+	 * message was successfully published.
+	 * @param cb callback accepting a {@code String} message ID and the original {@code Message}.
+	 */
 	public void setSuccessCallback(SuccessCallback cb) {
 		this.successCallback = cb;
 	}
 
+	/**
+	 * Set callback (can be a lambda) for processing the root cause exception and the original {@code Message} in case
+	 * of failure.
+	 * @param cb callback accepting a {@code Throwable} and a {@code Message}.
+	 */
 	public void setFailureCallback(FailureCallback cb) {
 		this.failureCallback = cb;
 	}

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -16,6 +16,10 @@
 
 package com.google.cloud.spring.pubsub.integration.outbound;
 
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
 import com.google.cloud.spring.core.util.MapBuilder;
 import com.google.cloud.spring.pubsub.core.PubSubOperations;
 import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
@@ -26,6 +30,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.expression.ValueExpression;
@@ -33,10 +38,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.util.concurrent.SettableListenableFuture;
-
-import java.util.Collections;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -256,6 +256,8 @@ public class PubSubMessageHandlerTests {
 		AtomicReference<String> successfulId = new AtomicReference<>();
 		AtomicReference<String> failedId = new AtomicReference<>();
 		CountDownLatch latch = new CountDownLatch(1);
+
+
 		this.adapter.setEnhancedCallback(new PubSubMessageHandler.PublishCallback() {
 
 			@Override

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -16,11 +16,6 @@
 
 package com.google.cloud.spring.pubsub.integration.outbound;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
-
 import com.google.cloud.spring.core.util.MapBuilder;
 import com.google.cloud.spring.pubsub.core.PubSubOperations;
 import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
@@ -31,7 +26,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.expression.ValueExpression;
@@ -39,6 +33,10 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.util.concurrent.SettableListenableFuture;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -258,19 +256,14 @@ public class PubSubMessageHandlerTests {
 		CountDownLatch latch = new CountDownLatch(1);
 
 
-		this.adapter.setEnhancedCallback(new PubSubMessageHandler.PublishCallback() {
-
-			@Override
-			public void onSuccess(String ackId, Object payload, Map<String, String> headers) {
-				successfulId.set(headers.get("message_id"));
+		this.adapter.setSuccessCallback((ackId, message) -> {
+				successfulId.set(message.getHeaders().get("message_id", String.class));
 				latch.countDown();
-			}
+		});
 
-			@Override
-			public void onFailure(Throwable cause, Object payload, Map<String, String> headers) {
-				failedId.set(headers.get("message_id"));
+		this.adapter.setFailureCallback((cause, message) -> {
+				failedId.set(message.getHeaders().get("message_id", String.class));
 				latch.countDown();
-			}
 		});
 
 		this.adapter.handleMessage(this.message);

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/src/main/java/com/example/SenderApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-sender/src/main/java/com/example/SenderApplication.java
@@ -27,7 +27,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.MessageHandler;
-import org.springframework.util.concurrent.ListenableFutureCallback;
 
 /**
  * Spring Integration Channel Adapters for Google Cloud Pub/Sub code sample.
@@ -48,17 +47,13 @@ public class SenderApplication {
 	public MessageHandler messageSender(PubSubTemplate pubsubTemplate) {
 		PubSubMessageHandler adapter =
 				new PubSubMessageHandler(pubsubTemplate, "exampleTopic");
-		adapter.setPublishCallback(new ListenableFutureCallback<String>() {
-			@Override
-			public void onFailure(Throwable ex) {
-				LOGGER.info("There was an error sending the message.");
-			}
+		adapter.setFailureCallback(
+				(exception, message) -> LOGGER.info("There was an error sending the message: " + message.getPayload()));
 
-			@Override
-			public void onSuccess(String result) {
-				LOGGER.info("Message was sent successfully.");
-			}
-		});
+		adapter.setSuccessCallback(
+				(messageId, message) -> LOGGER.info(
+						"Message was sent successfully;\n\tpublish ID = " + messageId
+								+ "\n\tmessage=" + message.getPayload()));
 
 		return adapter;
 	}


### PR DESCRIPTION
Two callbacks provided: `setSuccessCallback()` and `setFailureCallback()`. 
Second parameter to both is the original `Message` for consistency, and to enable forwarding to downstream channels.

Fixes #467.