### PR TITLE
Add support for IAM database authentication

### DIFF
--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -71,6 +71,7 @@ Used to authenticate and authorize new connections to a Google Cloud SQL instanc
 | `spring.cloud.gcp.sql.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key in JSON format.
 Used to authenticate and authorize new connections to a Google Cloud SQL instance. | No
 | Default credentials provided by the Spring GCP Boot starter
+| `spring.cloud.gcp.sql.enableIamAuth` | Specifies whether to enable IAM database authentication (PostgreSQL only). | No | `False`
 | `spring.datasource.username` | Database username | No | MySQL: `root`; PostgreSQL: `postgres`
 | `spring.datasource.password` | Database password | No | `null`
 | `spring.datasource.driver-class-name` | JDBC driver to use. | No | MySQL: `com.mysql.cj.jdbc.Driver`; PostgreSQL: `org.postgresql.Driver`
@@ -89,6 +90,17 @@ You can select the type of connection pool (e.g., Tomcat, HikariCP, etc.) by htt
 
 Using the created `DataSource` in conjunction with Spring JDBC provides you with a fully configured and operational `JdbcTemplate` object that you can use to interact with your SQL database.
 You can connect to your database with as little as a database and instance names.
+
+==== Cloud SQL IAM database authentication
+
+Currently, Cloud SQL only supports https://cloud.google.com/sql/docs/postgres/authentication:[IAM database authentication for PostgreSQL].
+It allows you to connect to the database using an IAM account, rather than a predefined database username and password.
+You will need to do the following to enable it:
+
+. In your database instance settings, turn on the `cloudsql.iam_authentication` flag.
+. Add the IAM user or service account to the list of database users.
+. In the application settings, set `spring.cloud.gcp.sql.enableIamAuth` to `true`.
+Note that this will also set the `sslmode` to `disabled`, as it's required for IAM authentication to work.
 
 ==== Troubleshooting tips
 

--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -100,7 +100,8 @@ You will need to do the following to enable it:
 . In your database instance settings, turn on the `cloudsql.iam_authentication` flag.
 . Add the IAM user or service account to the list of database users.
 . In the application settings, set `spring.cloud.gcp.sql.enableIamAuth` to `true`.
-Note that this will also set the `sslmode` to `disabled`, as it's required for IAM authentication to work.
+(Note that this will also set the database protocol `sslmode` to `disabled`, as it's required for IAM authentication to work.
+However, it doesn't compromise the security of the communication because the connection is always encrypted.)
 
 ==== Troubleshooting tips
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/DefaultCloudSqlJdbcInfoProvider.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/DefaultCloudSqlJdbcInfoProvider.java
@@ -53,9 +53,15 @@ public class DefaultCloudSqlJdbcInfoProvider implements CloudSqlJdbcInfoProvider
 		String jdbcUrl = String.format(this.databaseType.getJdbcUrlTemplate(),
 				this.properties.getDatabaseName(),
 				this.properties.getInstanceConnectionName());
+
 		if (StringUtils.hasText(properties.getIpTypes())) {
 			jdbcUrl += "&ipTypes=" + properties.getIpTypes();
 		}
+
+		if (properties.isEnableIamAuth()) {
+			jdbcUrl += "&enableIamAuth=true&sslmode=disable";
+		}
+
 		return jdbcUrl;
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/GcpCloudSqlProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/GcpCloudSqlProperties.java
@@ -40,6 +40,9 @@ public class GcpCloudSqlProperties {
 	/** Overrides the GCP OAuth2 credentials specified in the Core module. */
 	private Credentials credentials = new Credentials();
 
+	/** Specifies whether to enable IAM database authentication (PostgreSQL only). */
+	private boolean enableIamAuth;
+
 	public String getDatabaseName() {
 		return this.databaseName;
 	}
@@ -70,5 +73,13 @@ public class GcpCloudSqlProperties {
 
 	public void setCredentials(Credentials credentials) {
 		this.credentials = credentials;
+	}
+
+	public boolean isEnableIamAuth() {
+		return enableIamAuth;
+	}
+
+	public void setEnableIamAuth(boolean enableIamAuth) {
+		this.enableIamAuth = enableIamAuth;
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/sql/CloudSqlEnvironmentPostProcessorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/sql/CloudSqlEnvironmentPostProcessorTests.java
@@ -251,6 +251,19 @@ public class CloudSqlEnvironmentPostProcessorTests {
 	}
 
 	@Test
+	public void testIamAuth() {
+		this.contextRunner.withPropertyValues(
+				"spring.cloud.gcp.sql.instance-connection-name=world:asia:japan",
+				"spring.cloud.gcp.sql.enableIamAuth=true")
+				.run(context -> {
+					DataSourceProperties dataSourceProperties =
+							context.getBean(DataSourceProperties.class);
+					assertThat(dataSourceProperties.getUrl()).contains(
+							"&enableIamAuth=true&sslmode=disable");
+				});
+	}
+
+	@Test
 	public void testPlaceholdersNotResolved() {
 		this.contextRunner.withPropertyValues(
 				"spring.cloud.gcp.sql.instance-connection-name=world:asia:japan",


### PR DESCRIPTION
Introduces `spring.cloud.gcp.sql.enableIamAuth=true` for enabling IAM authentication,
which currently only works on PostgreSQL.

Fixes: #474.