### PR TITLE
Add customizer for SpannerOptions object

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -92,6 +92,8 @@ The schema for the tables will be "ON DELETE NO ACTION" if `false`. | No | `true
 | `spring.cloud.gcp.spanner.emulator-host` |  The host and port of the Spanner emulator; can be overridden to specify connecting to an already-running https://cloud.google.com/spanner/docs/emulator#installing_and_running_the_emulator[Spanner emulator] instance. | No | `localhost:9010`
 |===
 
+NOTE: For further customization of the client library `SpannerOptions`, provide a bean implementing `SpannerOptionsCustomizer`, with a single method that accepts a `SpannerOptions.Builder` and modifies it as necessary.
+
 ==== Repository settings
 
 Spring Data Repositories can be configured via the `@EnableSpannerRepositories` annotation on your main `@Configuration` class.

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
@@ -52,6 +52,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import org.springframework.data.rest.webmvc.spi.BackendIdConverter;
 
 /**
@@ -123,9 +124,11 @@ public class GcpSpannerAutoConfiguration {
 		}
 
 		@Bean
+		@Scope("prototype")
 		@ConditionalOnMissingBean
-		public SpannerOptions spannerOptions(SessionPoolOptions sessionPoolOptions,
-											Optional<SpannerOptionsCustomizer> customizer) {
+		public SpannerOptions.Builder spannerOptionsBuilder(
+				SessionPoolOptions sessionPoolOptions,
+				Optional<SpannerOptionsCustomizer> customizer) {
 			Builder builder = SpannerOptions.newBuilder()
 					.setProjectId(this.projectId)
 					.setHeaderProvider(new UserAgentHeaderProvider(this.getClass()))
@@ -137,8 +140,15 @@ public class GcpSpannerAutoConfiguration {
 				builder.setPrefetchChunks(this.prefetchChunks);
 			}
 			builder.setSessionPoolOption(sessionPoolOptions);
+
 			customizer.ifPresent(c -> c.apply(builder));
 
+			return builder;
+		}
+
+		@Bean
+		@ConditionalOnMissingBean
+		public SpannerOptions spannerOptions(SpannerOptions.Builder builder) {
 			return builder.build();
 		}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfiguration.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spring.autoconfigure.spanner;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.google.api.gax.core.CredentialsProvider;
@@ -123,7 +124,8 @@ public class GcpSpannerAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public SpannerOptions spannerOptions(SessionPoolOptions sessionPoolOptions) {
+		public SpannerOptions spannerOptions(SessionPoolOptions sessionPoolOptions,
+											Optional<SpannerOptionsCustomizer> customizer) {
 			Builder builder = SpannerOptions.newBuilder()
 					.setProjectId(this.projectId)
 					.setHeaderProvider(new UserAgentHeaderProvider(this.getClass()))
@@ -135,6 +137,8 @@ public class GcpSpannerAutoConfiguration {
 				builder.setPrefetchChunks(this.prefetchChunks);
 			}
 			builder.setSessionPoolOption(sessionPoolOptions);
+			customizer.ifPresent(c -> c.apply(builder));
+
 			return builder.build();
 		}
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/SpannerOptionsCustomizer.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/SpannerOptionsCustomizer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.spanner;
+
+import com.google.cloud.spanner.SpannerOptions;
+
+@FunctionalInterface
+public interface SpannerOptionsCustomizer {
+	void apply(SpannerOptions.Builder builder);
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfigurationTests.java
@@ -125,6 +125,8 @@ public class GcpSpannerAutoConfigurationTests {
 			assertThat(
 					spannerOptions.getSpannerStubSettings().executeSqlSettings().getRetrySettings().getMaxRetryDelay()
 			).isEqualTo(duration);
+			// unchanged options stay at their default values
+			assertThat(spannerOptions.getNumChannels()).isEqualTo(SpannerOptions.getDefaultInstance().getNumChannels());
 		});
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfigurationTests.java
@@ -19,6 +19,7 @@ package com.google.cloud.spring.autoconfigure.spanner;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.Credentials;
+import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
 import com.google.cloud.spring.data.spanner.core.SpannerOperations;
@@ -126,7 +127,11 @@ public class GcpSpannerAutoConfigurationTests {
 					spannerOptions.getSpannerStubSettings().executeSqlSettings().getRetrySettings().getMaxRetryDelay()
 			).isEqualTo(duration);
 			// unchanged options stay at their default values
-			assertThat(spannerOptions.getNumChannels()).isEqualTo(SpannerOptions.getDefaultInstance().getNumChannels());
+			SpannerOptions defaultSpannerOptions = SpannerOptions.newBuilder()
+					.setProjectId("unused")
+					.setCredentials(NoCredentials.getInstance())
+					.build();
+			assertThat(spannerOptions.getNumChannels()).isEqualTo(defaultSpannerOptions.getNumChannels());
 		});
 	}
 


### PR DESCRIPTION
I looked at providing individual option overrides, but there are too many options that are not very relevant to Spring fundamentals. So we might as well introduce a customizer that works for any need. I put it in autoconfiguration project because it's not really useful for any other scenario -- without Spring Boot, users would be creating their own `SpannerOptions` in the first place.

Fixes #480.