### PR TITLE
Propagate bean factory to adapter

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinder.java
@@ -88,6 +88,7 @@ public class PubSubMessageChannelBinder
 		ErrorInfrastructure errorInfrastructure = registerErrorInfrastructure(destination, group, properties);
 		adapter.setErrorChannel(errorInfrastructure.getErrorChannel());
 		adapter.setAckMode(properties.getExtension().getAckMode());
+		adapter.setBeanFactory(getBeanFactory());
 
 		return adapter;
 	}


### PR DESCRIPTION
Fixed missing `beanFactory` in #509