### PR TITLE
Revert to published cfenv version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
 		<errorprone.version>2.7.1</errorprone.version>
 		<integration-test.pattern>**/*IntegrationTest*</integration-test.pattern>
-		<java-cfenv.version>2.4.0</java-cfenv.version>
+		<java-cfenv.version>2.3.0</java-cfenv.version>
 		<javadoc.failOnError>false</javadoc.failOnError>
 		<javadoc.failOnWarnings>false</javadoc.failOnWarnings>
 		<maven-checkstyle-plugin.failOnViolation>true</maven-checkstyle-plugin.failOnViolation>


### PR DESCRIPTION
`java-cfenv:2.4.0` is not released yet; it most likely made its way to spring release repo [as an experiment](https://github.com/pivotal-cf/java-cfenv/issues/155#issuecomment-877498452), and we got lucky and picked it up.