### PR TITLE
Remove workaround nulling out Pub/Sub error channel on shutdown.

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -29,7 +29,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.mapping.HeaderMapper;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 
 /**

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -148,17 +148,4 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
 			}
 		}
 	}
-
-	/**
-	 * Workaround for GH-2615; prevents successful completion when exception received with closed context.
-	 * @return error channel configured in parent class
-	 */
-	@Override
-	public MessageChannel getErrorChannel() {
-		if (!this.isRunning()) {
-			return null;
-		}
-		return super.getErrorChannel();
-	}
-
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -143,7 +143,7 @@ public class PubSubInboundChannelAdapterTests {
 		this.adapter.setAckMode(AckMode.AUTO);
 		this.adapter.setOutputChannel(this.mockMessageChannel);
 
-		PublishSubscribeChannel errorChannel = new PublishSubscribeChannel();
+		PublishSubscribeChannel errorChannel = new PublishSubscribeChannel(true);
 		// Simulating what FinalRethrowingErrorMessageHandler would do.
 		MessageHandler errorHandler = message -> {
 			throw new RuntimeException("error channel fails, too");


### PR DESCRIPTION
Fix [GH-505](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/505) remove workaround for GH-2615, and using new requireSubscribers option introduced in Spring Integration.