### PR TITLE
Upgrade samples project kotlin to 1.5.21

### DIFF
--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -39,13 +39,6 @@ jobs:
       if: steps.mvn-cache.outputs.cache-hit != 'true'
       run: ./mvnw compile dependency:go-offline
 
-    - name: Set Maven Options for Java 16
-      # needed for Kotlin Sample on JDK 16
-      if: matrix.java == 16
-      run: |
-        echo "MAVEN_OPTS=--illegal-access=permit" >> $GITHUB_ENV
-        echo "Remove this step if https://youtrack.jetbrains.com/issue/KT-44624 is fixed."
-
     - name: Mvn install # Need this when the directory/pom structure changes
       id: install1
       continue-on-error: true

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/pom.xml
@@ -14,7 +14,7 @@
 	<name>Spring Cloud GCP Code Sample - Kotlin App Sample</name>
 
 	<properties>
-		<kotlin.version>1.4.32</kotlin.version>
+		<kotlin.version>1.5.21</kotlin.version>
 	</properties>
 
 	<!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->


### PR DESCRIPTION
Fix [GH-538](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/538), upgrade spring-cloud-gcp-kotlin-samples kotlin version to 1.5.21 and remove workaround step from unit test workflow.