### PR TITLE
Update additional-spring-configuration-metadata to contain missing ma…

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -123,7 +123,7 @@
     {
       "name": "management.health.pubsub.enabled",
       "type": "java.lang.Boolean",
-      "description": "The health indicator will verify whether Cloud Pub/Sub is up and accessible by your application.",
+      "description": "Whether to enable the Pub/Sub health indicator when used with Spring Boot Actuator.",
       "defaultValue": true
     }
   ]

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -119,6 +119,12 @@
       "type": "java.lang.Boolean",
       "description": "Auto-configure Google Cloud Core components.",
       "defaultValue": true
+    },
+    {
+      "name": "management.health.pubsub",
+      "type": "java.lang.Boolean",
+      "description": "The health indicator will verify whether Cloud Pub/Sub is up and accessible by your application.",
+      "defaultValue": true
     }
   ]
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -121,11 +121,10 @@
       "defaultValue": true
     },
     {
-      "name": "management.health.pubsub",
+      "name": "management.health.pubsub.enabled",
       "type": "java.lang.Boolean",
       "description": "The health indicator will verify whether Cloud Pub/Sub is up and accessible by your application.",
       "defaultValue": true
     }
   ]
 }
-


### PR DESCRIPTION
This change adds the missing management endpoint found in the [documentation](https://googlecloudplatform.github.io/spring-cloud-gcp/2.0.3/reference/html/index.html#cloud-pubsub-health-indicator) to the additional-spring-configuration-metadata.json. This will allow IDEs to provide proper tooltips and recognize the property. 

Fixes: #542