### PR TITLE
Support Stream as return type to datastore queries

### DIFF
--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -739,6 +739,7 @@ In addition to retrieving entities by their IDs, you can also submit queries.
 ----
 
 These methods, respectively, allow querying for:
+
 * entities mapped by a given entity class using all the same mapping and converting features
 * arbitrary types produced by a given mapping function
 * only the Cloud Datastore keys of the entities found by the query
@@ -949,6 +950,8 @@ public interface TradeRepository extends DatastoreRepository<Trade, String[]> {
   Slice<TestEntity> findBySymbol(String symbol, Pageable pageable);
 
   List<TestEntity> findBySymbol(String symbol, Sort sort);
+
+  Stream<TestEntity> findBySymbol(String symbol);
 }
 ----
 
@@ -1038,6 +1041,9 @@ public interface TraderRepository extends DatastoreRepository<Trader, String> {
 
   @Query("SELECT * FROM traders WHERE name = @trader_name")
   List<Trader> tradersByName(@Param("trader_name") String traderName);
+
+  @Query("SELECT * FROM traders WHERE name = @trader_name")
+  Stream<Trader> tradersStreamByName(@Param("trader_name") String traderName);
 
   @Query("SELECT * FROM  test_entities_ci WHERE name = @trader_name")
   TestEntity getOneTestEntity(@Param("trader_name") String traderName);

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQuery.java
@@ -149,7 +149,7 @@ public class GqlDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 		if (isPageQuery() || isSliceQuery()) {
 			result = buildPageOrSlice(parameters, parsedQueryWithTagsAndValues, found);
 		}
-		else if (this.queryMethod.isCollectionQuery()) {
+		else if (this.queryMethod.isCollectionQuery() || this.queryMethod.isStreamQuery()) {
 			result = convertCollectionResult(returnedItemType, found);
 		}
 		else {
@@ -199,6 +199,9 @@ public class GqlDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 	}
 
 	private Object convertCollectionResult(Class returnedItemType, Iterable rawResult) {
+		if (this.queryMethod.isStreamQuery()) {
+			return StreamSupport.stream(rawResult.spliterator(), false);
+		}
 		Object result = this.datastoreOperations.getDatastoreEntityConverter()
 				.getConversions().convertOnRead(
 						rawResult, this.queryMethod.getCollectionReturnType(), returnedItemType);

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQuery.java
@@ -444,7 +444,13 @@ public class PartTreeDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 
 			structuredQueryBuilder.setKind(PartTreeDatastoreQuery.this.datastorePersistentEntity.kindName());
 
-			singularResult = (!isCountingQuery && collectionType == null && !isStreamQuery) && !PartTreeDatastoreQuery.this.tree.isDelete();
+			if (isCountingQuery || collectionType != null || isStreamQuery
+					|| PartTreeDatastoreQuery.this.tree.isDelete()) {
+				singularResult = false;
+			}
+			else {
+				singularResult = true;
+			}
 		}
 
 		boolean isReturnedTypeIsNumber() {

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQuery.java
@@ -186,13 +186,18 @@ public class PartTreeDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 	}
 
 	private Object runQuery(Object[] parameters, Class returnedElementType, Class<?> collectionType, boolean requiresCount) {
-		ExecutionOptions options = new ExecutionOptions(returnedElementType, collectionType, requiresCount);
+		ExecutionOptions options = new ExecutionOptions(returnedElementType, collectionType, requiresCount,
+				getQueryMethod().isStreamQuery());
 
 		DatastoreResultsIterable rawResults = getDatastoreOperations()
 				.queryKeysOrEntities(
 						applyQueryBody(parameters, options.getQueryBuilder(),
 								requiresCount, options.isSingularResult(), null),
 						this.entityType);
+
+		if (getQueryMethod().isStreamQuery()) {
+			return StreamSupport.stream(rawResults.spliterator(), false);
+		}
 
 		Object result = StreamSupport.stream(rawResults.spliterator(), false)
 				.map(options.isReturnedTypeIsNumber() ? Function.identity() : this::processRawObjectForProjection)
@@ -422,7 +427,7 @@ public class PartTreeDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 
 		private boolean singularResult;
 
-		ExecutionOptions(Class returnedElementType, Class<?> collectionType, boolean requiresCount) {
+		ExecutionOptions(Class returnedElementType, Class<?> collectionType, boolean requiresCount, boolean isStreamQuery) {
 
 			returnedTypeIsNumber = Number.class.isAssignableFrom(returnedElementType)
 					|| returnedElementType == int.class || returnedElementType == long.class;
@@ -439,7 +444,7 @@ public class PartTreeDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 
 			structuredQueryBuilder.setKind(PartTreeDatastoreQuery.this.datastorePersistentEntity.kindName());
 
-			singularResult = (!isCountingQuery && collectionType == null) && !PartTreeDatastoreQuery.this.tree.isDelete();
+			singularResult = (!isCountingQuery && collectionType == null && !isStreamQuery) && !PartTreeDatastoreQuery.this.tree.isDelete();
 		}
 
 		boolean isReturnedTypeIsNumber() {

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
@@ -1040,14 +1040,14 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 	}
 
 	@Test
-	public void returnStreamPartTreeTest(){
+	public void returnStreamPartTreeTest() {
 		this.testEntityRepository.saveAll(this.allTestEntities);
 		Stream<TestEntity> resultStream = this.testEntityRepository.findStreamByColor("red");
 		assertThat(resultStream).hasSize(3).contains(testEntityA, testEntityC, testEntityD);
 	}
 
 	@Test
-	public void returnStreamGqlTest(){
+	public void returnStreamGqlTest() {
 		this.testEntityRepository.saveAll(this.allTestEntities);
 		Stream<TestEntity> resultStream = this.testEntityRepository.findByColorStream("red");
 		assertThat(resultStream).hasSize(3).contains(testEntityA, testEntityC, testEntityD);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
@@ -1042,14 +1042,14 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 	@Test
 	public void returnStreamPartTreeTest() {
 		this.testEntityRepository.saveAll(this.allTestEntities);
-		Stream<TestEntity> resultStream = this.testEntityRepository.findStreamByColor("red");
+		Stream<TestEntity> resultStream = this.testEntityRepository.findPartTreeStreamByColor("red");
 		assertThat(resultStream).hasSize(3).contains(testEntityA, testEntityC, testEntityD);
 	}
 
 	@Test
 	public void returnStreamGqlTest() {
 		this.testEntityRepository.saveAll(this.allTestEntities);
-		Stream<TestEntity> resultStream = this.testEntityRepository.findByColorStream("red");
+		Stream<TestEntity> resultStream = this.testEntityRepository.findGqlStreamByColor("red");
 		assertThat(resultStream).hasSize(3).contains(testEntityA, testEntityC, testEntityD);
 	}
 }

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import com.google.cloud.datastore.Blob;
 import com.google.cloud.datastore.DatastoreException;
@@ -1036,6 +1037,20 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 						this.datastoreTemplate.findById(1L, CompanyWithBooleanPrimitive.class);
 		assertThat(companyWithBooleanPrimitive.name).isEqualTo(company.name);
 		assertThat(companyWithBooleanPrimitive.active).isFalse();
+	}
+
+	@Test
+	public void returnStreamPartTreeTest(){
+		this.testEntityRepository.saveAll(this.allTestEntities);
+		Stream<TestEntity> resultStream = this.testEntityRepository.findStreamByColor("red");
+		assertThat(resultStream).hasSize(3).contains(testEntityA, testEntityC, testEntityD);
+	}
+
+	@Test
+	public void returnStreamGqlTest(){
+		this.testEntityRepository.saveAll(this.allTestEntities);
+		Stream<TestEntity> resultStream = this.testEntityRepository.findByColorStream("red");
+		assertThat(resultStream).hasSize(3).contains(testEntityA, testEntityC, testEntityD);
 	}
 }
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntityRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntityRepository.java
@@ -20,6 +20,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
@@ -133,6 +134,11 @@ public interface TestEntityRepository extends DatastoreRepository<TestEntity, Lo
 	Slice<TestEntity> findByColor(String color, Pageable pageable);
 
 	Optional<TestEntity> findFirstByColor(String color);
+
+	Stream<TestEntity> findStreamByColor(String color);
+
+	@Query("select * from  test_entities_ci where color = @color")
+	Stream<TestEntity> findByColorStream(@Param("color") String color);
 
 	@Nullable
 	TestEntity getByColor(String color);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntityRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntityRepository.java
@@ -135,10 +135,10 @@ public interface TestEntityRepository extends DatastoreRepository<TestEntity, Lo
 
 	Optional<TestEntity> findFirstByColor(String color);
 
-	Stream<TestEntity> findStreamByColor(String color);
+	Stream<TestEntity> findPartTreeStreamByColor(String color);
 
 	@Query("select * from  test_entities_ci where color = @color")
-	Stream<TestEntity> findByColorStream(@Param("color") String color);
+	Stream<TestEntity> findGqlStreamByColor(@Param("color") String color);
 
 	@Nullable
 	TestEntity getByColor(String color);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQueryTests.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import com.google.cloud.datastore.Cursor;
 import com.google.cloud.datastore.DoubleValue;
@@ -445,6 +446,38 @@ public class GqlDatastoreQueryTests {
 
 		verify(this.datastoreTemplate, times(1))
 				.queryKeysOrEntities(any(), eq(Trade.class));
+	}
+
+	@Test
+	public void streamResultTest() {
+		Mockito.<Class>when(this.queryMethod.getReturnedObjectType())
+				.thenReturn(Trade.class);
+		Parameters parameters = mock(Parameters.class);
+
+		when(this.queryMethod.getParameters())
+				.thenReturn(parameters);
+		when(parameters.getNumberOfParameters())
+				.thenReturn(0);
+		when(this.queryMethod.isStreamQuery()).thenReturn(true);
+
+		Trade tradeA = new Trade();
+		tradeA.id = "a";
+		Trade tradeB = new Trade();
+		tradeB.id = "b";
+		doAnswer(invocation -> {
+			GqlQuery statement = invocation.getArgument(0);
+			assertThat(statement.getQueryString()).isEqualTo("unusedGqlString");
+
+			Cursor cursor = Cursor.copyFrom("abc".getBytes());
+			DatastoreResultsIterable datastoreResultsIterable = new DatastoreResultsIterable(Arrays.asList(tradeA, tradeB), cursor);
+			return datastoreResultsIterable;
+		}).when(this.datastoreTemplate).queryKeysOrEntities(any(), eq(Trade.class));
+
+		GqlDatastoreQuery gqlDatastoreQuery = createQuery("unusedGqlString", false, false);
+
+		Object result = gqlDatastoreQuery.execute(new Parameters[0]);
+		assertThat(result).isInstanceOf(Stream.class);
+		assertThat((Stream) result).hasSize(2).containsExactly(tradeA, tradeB);
 	}
 
 	private Parameters buildParameters(Object[] params, String[] paramNames) {

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQueryTests.java
@@ -469,7 +469,8 @@ public class GqlDatastoreQueryTests {
 			assertThat(statement.getQueryString()).isEqualTo("unusedGqlString");
 
 			Cursor cursor = Cursor.copyFrom("abc".getBytes());
-			DatastoreResultsIterable datastoreResultsIterable = new DatastoreResultsIterable(Arrays.asList(tradeA, tradeB), cursor);
+			DatastoreResultsIterable datastoreResultsIterable = new DatastoreResultsIterable(
+					Arrays.asList(tradeA, tradeB), cursor);
 			return datastoreResultsIterable;
 		}).when(this.datastoreTemplate).queryKeysOrEntities(any(), eq(Trade.class));
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQueryTests.java
@@ -450,14 +450,10 @@ public class GqlDatastoreQueryTests {
 
 	@Test
 	public void streamResultTest() {
-		Mockito.<Class>when(this.queryMethod.getReturnedObjectType())
-				.thenReturn(Trade.class);
+		Mockito.<Class>when(this.queryMethod.getReturnedObjectType()).thenReturn(Trade.class);
 		Parameters parameters = mock(Parameters.class);
-
-		when(this.queryMethod.getParameters())
-				.thenReturn(parameters);
-		when(parameters.getNumberOfParameters())
-				.thenReturn(0);
+		when(this.queryMethod.getParameters()).thenReturn(parameters);
+		when(parameters.getNumberOfParameters()).thenReturn(0);
 		when(this.queryMethod.isStreamQuery()).thenReturn(true);
 
 		Trade tradeA = new Trade();

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
@@ -900,7 +900,9 @@ public class PartTreeDatastoreQueryTests {
 		return null;
 	}
 
-	public Stream<Trade> findStreamByAction(String action) { return  null;}
+	public Stream<Trade> findStreamByAction(String action) {
+		return null;
+	}
 
 	@Nullable
 	public Trade findByActionNullable(String action) {

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import com.google.cloud.datastore.Cursor;
 import com.google.cloud.datastore.EntityQuery;
@@ -846,6 +847,21 @@ public class PartTreeDatastoreQueryTests {
 		assertThat((Optional) this.partTreeDatastoreQuery.execute(params)).isNotPresent();
 	}
 
+	@Test
+	public void streamResultTest() throws NoSuchMethodException {
+		Trade tradeA = new Trade();
+		tradeA.id = "a";
+		Trade tradeB = new Trade();
+		tradeB.id = "b";
+		queryWithMockResult("findStreamByAction", Arrays.asList(tradeA, tradeB),
+				getClass().getMethod("findStreamByAction", String.class));
+		when(this.queryMethod.isStreamQuery()).thenReturn(true);
+		Object[] params = new Object[] { "BUY", };
+		Object result = this.partTreeDatastoreQuery.execute(params);
+		assertThat(result).isInstanceOf(Stream.class);
+		assertThat((Stream) result).hasSize(2).contains(tradeA, tradeB);
+	}
+
 	private void queryWithMockResult(String queryName, List results, Method m,
 			ProjectionInformation projectionInformation) {
 		queryWithMockResult(queryName, results, m, false, projectionInformation);
@@ -883,6 +899,8 @@ public class PartTreeDatastoreQueryTests {
 	public Trade findByAction(String action) {
 		return null;
 	}
+
+	public Stream<Trade> findStreamByAction(String action) { return  null;}
 
 	@Nullable
 	public Trade findByActionNullable(String action) {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/DatastoreRepositoryExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/DatastoreRepositoryExample.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
@@ -98,6 +99,10 @@ public class DatastoreRepositoryExample {
 		this.singerRepository
 				.findAllById(Arrays.asList("singer1", "singer2", "singer3"))
 				.forEach(x -> System.out.println("retrieved singer: " + x));
+
+		System.out.println("Query results can also be returned as Stream: ");
+		Stream<Singer> streamResult = singerRepository.findSingersByLastName("Doe");
+		streamResult.forEach(System.out::println);
 
 		//Query by example: find all singers with the last name "Doe"
 		Iterable<Singer> singers = this.singerRepository.findAll(

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/SingerRepository.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/SingerRepository.java
@@ -17,6 +17,7 @@
 package com.example;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import com.google.cloud.spring.data.datastore.repository.DatastoreRepository;
 import com.google.cloud.spring.data.datastore.repository.query.Query;
@@ -39,4 +40,6 @@ public interface SingerRepository extends DatastoreRepository<Singer, String> {
 	List<Singer> findSingersByFirstBand(@Param("band") Band band);
 
 	List<Singer> findByFirstBand(Band band);
+
+	Stream<Singer> findSingersByLastName(String name);
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/test/java/com/example/DatastoreSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/test/java/com/example/DatastoreSampleApplicationIntegrationTests.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -239,5 +240,12 @@ public class DatastoreSampleApplicationIntegrationTests {
 		return singerMaps.stream().map(som -> new Singer(null,
 				(String) som.get("firstName"), (String) som.get("lastName"), null))
 				.collect(Collectors.toList());
+	}
+
+	@Test
+	public void testQueryReturnStream() {
+		Stream<Singer> streamResult = singerRepository.findSingersByLastName("Doe");
+		assertThat(streamResult).isInstanceOf(Stream.class);
+		streamResult.map(Singer::getLastName).forEach(x -> assertThat(x).isEqualTo("Doe"));
 	}
 }


### PR DESCRIPTION
This is fix for #452. 
Fixed code in `GqlDatastoreQuery` and `PartTreeDatastoreQuery` to support for Stream as a return type and added corresponding unit tests and integration tests.