### PR TITLE
Fix Datastore pageable return type compatibility

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/DatastorePageable.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/DatastorePageable.java
@@ -24,7 +24,7 @@ import org.springframework.data.domain.Pageable;
 /**
  * A pageable implementation for Cloud Datastore that uses the cursor for efficient reads.
  *
- * The static methods can take either paged or unpaged {@code Pageable}, while instance methods only deal with a paged
+ * The static methods can take either paged or unpaged {@link Pageable}, while instance methods only deal with a paged
  * self object.
  *
  * @author Dmitry Solomakha
@@ -46,24 +46,24 @@ public class DatastorePageable extends PageRequest {
 	}
 
 	/**
-	 * Creates a {@code DatastorePageable} wrapper for a paged request, but passes unpaged requests back unchanged.
+	 * Creates a {@link DatastorePageable} wrapper for a paged request, but passes unpaged requests back unchanged.
 	 *
-	 * @param pageable The source {@code Pageable} that can be paged or unpaged
+	 * @param pageable The source {@link Pageable} that can be paged or unpaged
 	 * @param cursor Current cursor; null if not applicable
 	 * @param totalCount Total result count
-	 * @return an instance of {@code DatastorePageable} or the original unpaged {@code Pageable}.
+	 * @return an instance of {@link DatastorePageable} or the original unpaged {@link Pageable}.
 	 */
 	public static Pageable from(Pageable pageable, Cursor cursor, Long totalCount) {
 		return from(pageable, cursor == null ? null : cursor.toUrlSafe(), totalCount);
 	}
 
 	/**
-	 * Creates a {@code DatastorePageable} wrapper for a paged request, but passes unpaged requests back unchanged.
+	 * Creates a {@link DatastorePageable} wrapper for a paged request, but passes unpaged requests back unchanged.
 	 *
-	 * @param pageable The source {@code Pageable} that can be paged or unpaged
+	 * @param pageable The source {@link Pageable} that can be paged or unpaged
 	 * @param urlSafeCursor Current cursor as ; null if not applicable
 	 * @param totalCount Current cursor; null if not applicable
-	 * @return an instance of {@code DatastorePageable} or the original unpaged {@code Pageable}.
+	 * @return an instance of {@link DatastorePageable} or the original unpaged {@link Pageable}.
 	 */
 	public static Pageable from(Pageable pageable, String urlSafeCursor, Long totalCount) {
 		if (pageable.isUnpaged()) {

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepository.java
@@ -210,4 +210,9 @@ public class SimpleDatastoreRepository<T, I> implements DatastoreRepository<T, I
 	private static Long getOrComputeTotalCount(Pageable pageable, LongSupplier countCall) {
 		return pageable instanceof DatastorePageable ? ((DatastorePageable) pageable).getTotalCount() : countCall.getAsLong();
 	}
+
+	// TODO: Restore @Override when not supporting Spring Boot 2.4 anymore
+	public void deleteAllById(Iterable<? extends I> iterable) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepositoryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -349,5 +350,11 @@ public class SimpleDatastoreRepositoryTests {
 						new Sort.Order(Sort.Direction.ASC, "property2")
 				)).build();
 		verify(this.datastoreTemplate).findAll(Object.class, opts);
+	}
+
+	@Test
+	public void deleteAllByIdUnimplemented() {
+		assertThatThrownBy(() -> this.simpleDatastoreRepository.deleteAllById(new ArrayList<>()))
+				.isInstanceOf(UnsupportedOperationException.class);
 	}
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepository.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepository.java
@@ -120,4 +120,10 @@ public class SimpleFirestoreReactiveRepository<T> implements FirestoreReactiveRe
 	public Mono<Void> deleteAll() {
 		return this.firestoreTemplate.deleteAll(this.type);
 	}
+
+	// TODO: Restore @Override when not supporting Spring Boot 2.4 anymore
+	//@Override
+	public Mono<Void> deleteAllById(Iterable<? extends String> ids) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.data.firestore;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+public class SimpleFirestoreReactiveRepositoryTests {
+
+	@Test
+	public void deleteAllByIdUnimplemented() {
+		FirestoreTemplate mockTemplate = mock(FirestoreTemplate.class);
+		SimpleFirestoreReactiveRepository<String> repository =
+				new SimpleFirestoreReactiveRepository<>(mockTemplate, String.class);
+		assertThatThrownBy(() -> repository.deleteAllById(new ArrayList<>()))
+				.isInstanceOf(UnsupportedOperationException.class);
+	}
+}

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
@@ -164,6 +164,12 @@ public class SimpleSpannerRepository<T, I> implements SpannerRepository<T, I> {
 				pageable, this.spannerTemplate.count(this.entityType));
 	}
 
+	// TODO: Restore @Override when not supporting Spring Boot 2.4 anymore
+	//@Override
+	public void deleteAllById(Iterable<? extends I> is) {
+		throw new UnsupportedOperationException();
+	}
+
 	private Key toKey(Object id) {
 		return this.spannerTemplate.getSpannerEntityProcessor().convertToKey(id);
 	}

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/SimpleSpannerRepositoryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/SimpleSpannerRepositoryTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.data.spanner;
+
+import java.util.ArrayList;
+
+import com.google.cloud.spring.data.spanner.core.SpannerTemplate;
+import com.google.cloud.spring.data.spanner.repository.support.SimpleSpannerRepository;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+public class SimpleSpannerRepositoryTests {
+
+	@Test
+	public void deleteAllByIdUnimplemented() {
+		SpannerTemplate mockTemplate = mock(SpannerTemplate.class);
+		SimpleSpannerRepository<Book, String> repository = new SimpleSpannerRepository<>(mockTemplate, Book.class);
+
+		assertThatThrownBy(() -> repository.deleteAllById(new ArrayList<>()))
+				.isInstanceOf(UnsupportedOperationException.class);
+	}
+
+	static class Book {
+		String id;
+	}
+}


### PR DESCRIPTION
This PR allows Datastore to work with both Spring Data/Spring Boot 2.4 and 2.5. It also adds placeholder methods for the new `CrudRepository` method `deleteAllById()` to fix compilation issues with 2.5.

I've inlined `super.next()` creating a new `PageRequest` because there were inheritance issues with Spring Data 2.4.9 (at runtime, the overridden superclass method was not called, causing the infinite loop. But this only happens if the signature is `public PageRequest next() {`. If the signature is `public Pageable next() {`, java finds the overridden method, and all is well. Classic "this should never happen" type of Java situation, which I would normally troubleshoot to bitter end, but inlining the `PageRequest` creation also improves readability).

Fixes #564.