### PR TITLE
Fix Timestamp as datastore supported types

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContext.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContext.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.google.cloud.spring.data.datastore.core.convert.DatastoreNativeTypes;
+
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.mapping.context.AbstractMappingContext;
@@ -54,6 +56,10 @@ public class DatastoreMappingContext extends
 	// Maps a given class to the set of other classes with which it shares the same Datastore
 	// Kind and that are subclasses of the given class.
 	private static final Map<Class, Set<Class>> discriminationFamilies = new ConcurrentHashMap<>();
+
+	public DatastoreMappingContext() {
+		this.setSimpleTypeHolder(DatastoreNativeTypes.HOLDER);
+	}
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) {

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
@@ -72,7 +72,7 @@ public class DatastoreMappingContextTests {
 	}
 
 	@Test
-	public void testGetInvalidEntityTimeStamp() {
+	public void testGetInvalidEntityTimestamp() {
 		DatastorePersistentEntityImpl mockEntity = mock(
 				DatastorePersistentEntityImpl.class);
 		DatastoreMappingContext context = createDatastoreMappingContextWith(mockEntity);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
@@ -23,7 +23,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -72,11 +71,11 @@ public class DatastoreMappingContextTests {
 	}
 
 	@Test
-	public void testGetInvalidEntityTimestamp() {
-		DatastorePersistentEntityImpl mockEntity = mock(
-				DatastorePersistentEntityImpl.class);
-		DatastoreMappingContext context = createDatastoreMappingContextWith(mockEntity);
-		assertThat(context.hasPersistentEntityFor(Timestamp.class)).isFalse();
+	public void testGetSimpleTypeTimestamp() {
+		DatastoreMappingContext context = new DatastoreMappingContext();
+		assertThatThrownBy(() -> context.getDatastorePersistentEntity(Timestamp.class))
+				.isInstanceOf(DatastoreDataException.class)
+				.hasMessage("Unable to find a DatastorePersistentEntity for: class com.google.cloud.Timestamp");
 	}
 
 	private DatastoreMappingContext createDatastoreMappingContextWith(

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
@@ -71,7 +71,8 @@ public class DatastoreMappingContextTests {
 	}
 
 	@Test
-	public void testGetSimpleTypeTimestamp() {
+	public void testTimestampNotAnEntity() {
+		// Datastore native types like Timestamp should be considered simple type and no an entity
 		DatastoreMappingContext context = new DatastoreMappingContext();
 		assertThatThrownBy(() -> context.getDatastorePersistentEntity(Timestamp.class))
 				.isInstanceOf(DatastoreDataException.class)

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
@@ -16,12 +16,14 @@
 
 package com.google.cloud.spring.data.datastore.core.mapping;
 
+import com.google.cloud.Timestamp;
 import org.junit.Test;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -67,6 +69,14 @@ public class DatastoreMappingContextTests {
 		assertThatThrownBy(() -> context.getDatastorePersistentEntity(Integer.class))
 				.isInstanceOf(DatastoreDataException.class)
 				.hasMessage("Unable to find a DatastorePersistentEntity for: class java.lang.Integer");
+	}
+
+	@Test
+	public void testGetInvalidEntityTimeStamp() {
+		DatastorePersistentEntityImpl mockEntity = mock(
+				DatastorePersistentEntityImpl.class);
+		DatastoreMappingContext context = createDatastoreMappingContextWith(mockEntity);
+		assertThat(context.hasPersistentEntityFor(Timestamp.class)).isFalse();
 	}
 
 	private DatastoreMappingContext createDatastoreMappingContextWith(

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
@@ -1055,22 +1055,26 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 	}
 
 	@Test
-	public void queryTimeStampGqlTest() {
+	public void queryByTimestampTest() {
 		Timestamp date1 = Timestamp.parseTimestamp("2020-08-04T00:00:00Z");
 		Timestamp date2 = Timestamp.parseTimestamp("2021-08-04T00:00:00Z");
-		this.allTestEntities.get(0).setDatetime(date1);
-		this.allTestEntities.get(1).setDatetime(date2);
-		this.allTestEntities.get(2).setDatetime(date1);
+		TestEntity testEntity1 = new TestEntity(1L, "red", 1L, date1);
+		TestEntity testEntity2 = new TestEntity(2L, "blue", 2L, date2);
+		TestEntity testEntity3 = new TestEntity(3L, "red", 1L, date1);
+		TestEntity testEntity4 = new TestEntity(4L, "red", 1L, null);
 
-		this.testEntityRepository.saveAll(this.allTestEntities);
+		this.testEntityRepository.saveAll(Arrays.asList(testEntity1,
+				testEntity2,
+				testEntity3,
+				testEntity4));
 		Timestamp startDate = Timestamp.parseTimestamp("2020-07-04T00:00:00Z");
 		Timestamp endDate = Timestamp.parseTimestamp("2020-08-06T00:00:00Z");
 
 		List<TestEntity> results = this.testEntityRepository.getAllBetweenDates(startDate, endDate);
-		assertThat(results).containsExactly(this.allTestEntities.get(0), this.allTestEntities.get(2));
+		assertThat(results).containsExactly(testEntity1, testEntity3);
 
 		List<TestEntity> results2 = this.testEntityRepository.findByDatetimeGreaterThan(endDate);
-		assertThat(results2).containsExactly(this.allTestEntities.get(1));
+		assertThat(results2).containsExactly(testEntity2);
 	}
 }
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import com.google.cloud.Timestamp;
 import com.google.cloud.datastore.Blob;
 import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.DatastoreReaderWriter;
@@ -1051,6 +1052,23 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		this.testEntityRepository.saveAll(this.allTestEntities);
 		Stream<TestEntity> resultStream = this.testEntityRepository.findGqlStreamByColor("red");
 		assertThat(resultStream).hasSize(3).contains(testEntityA, testEntityC, testEntityD);
+	}
+
+	@Test
+	public void queryTimeStampGqlTest() {
+		Timestamp date1 = Timestamp.parseTimestamp("2020-08-04T00:00:00Z");
+		Timestamp date2 = Timestamp.parseTimestamp("2021-08-04T00:00:00Z");
+		this.allTestEntities.get(0).setDatetime(date1);
+		this.allTestEntities.get(1).setDatetime(date2);
+		this.allTestEntities.get(2).setDatetime(date1);
+
+		this.testEntityRepository.saveAll(this.allTestEntities);
+		Timestamp startDate = Timestamp.parseTimestamp("2020-07-04T00:00:00Z");
+		Timestamp endDate = Timestamp.parseTimestamp("2020-08-06T00:00:00Z");
+
+		List<TestEntity> results = this.testEntityRepository.getAllBetweenDates(startDate, endDate);
+		assertThat(results).isNotEmpty();
+		assertThat(results).containsExactly(this.allTestEntities.get(0), this.allTestEntities.get(2));
 	}
 }
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
@@ -1067,8 +1067,10 @@ public class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests
 		Timestamp endDate = Timestamp.parseTimestamp("2020-08-06T00:00:00Z");
 
 		List<TestEntity> results = this.testEntityRepository.getAllBetweenDates(startDate, endDate);
-		assertThat(results).isNotEmpty();
 		assertThat(results).containsExactly(this.allTestEntities.get(0), this.allTestEntities.get(2));
+
+		List<TestEntity> results2 = this.testEntityRepository.findByDatetimeGreaterThan(endDate);
+		assertThat(results2).containsExactly(this.allTestEntities.get(1));
 	}
 }
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntity.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntity.java
@@ -67,6 +67,13 @@ public class TestEntity {
 		this.embeddedEntity = embeddedEntity;
 	}
 
+	public TestEntity(Long id, String color, Long size, Timestamp datetime) {
+		this.id = id;
+		this.color = color;
+		this.size = size;
+		this.datetime = datetime;
+	}
+
 	public Shape getShape() {
 		return this.shape;
 	}

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntity.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntity.java
@@ -18,6 +18,7 @@ package com.google.cloud.spring.data.datastore.it;
 
 import java.util.Objects;
 
+import com.google.cloud.Timestamp;
 import com.google.cloud.datastore.Blob;
 import com.google.cloud.spring.data.datastore.core.mapping.Entity;
 
@@ -41,6 +42,8 @@ public class TestEntity {
 	private Shape shape;
 
 	private Blob blobField;
+
+	private Timestamp datetime;
 
 	EmbeddedEntity embeddedEntity;
 
@@ -104,6 +107,14 @@ public class TestEntity {
 		this.size = size;
 	}
 
+	public Timestamp getDatetime() {
+		return datetime;
+	}
+
+	public void setDatetime(Timestamp datetime) {
+		this.datetime = datetime;
+	}
+
 	/**
 	 * An enum that tests conversion and storage.
 	 */
@@ -141,6 +152,7 @@ public class TestEntity {
 				", shape=" + shape +
 				", blobField=" + blobField +
 				", embeddedEntity=" + embeddedEntity +
+				", datetime=" + datetime +
 				'}';
 	}
 }

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntityRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntityRepository.java
@@ -141,8 +141,10 @@ public interface TestEntityRepository extends DatastoreRepository<TestEntity, Lo
 	@Query("select * from  test_entities_ci where color = @color")
 	Stream<TestEntity> findGqlStreamByColor(@Param("color") String color);
 
-	@Query("select * from  test_entities_ci where datetime >= @startDate AND datetime <= @endDate")
-	List<TestEntity> getAllBetweenDates(@Param("startDate") Timestamp startDate, @Param("endDate") Timestamp endDate);
+	@Query("select * from  test_entities_ci where datetime >= @startTime AND datetime <= @endTime")
+	List<TestEntity> getAllBetweenDates(@Param("startTime") Timestamp startTime, @Param("endTime") Timestamp endTime);
+
+	List<TestEntity> findByDatetimeGreaterThan(Timestamp oldestTime);
 
 	@Nullable
 	TestEntity getByColor(String color);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntityRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntityRepository.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
+import com.google.cloud.Timestamp;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.spring.data.datastore.it.TestEntity.Shape;
 import com.google.cloud.spring.data.datastore.repository.DatastoreRepository;
@@ -139,6 +140,9 @@ public interface TestEntityRepository extends DatastoreRepository<TestEntity, Lo
 
 	@Query("select * from  test_entities_ci where color = @color")
 	Stream<TestEntity> findGqlStreamByColor(@Param("color") String color);
+
+	@Query("select * from  test_entities_ci where datetime >= @startDate AND datetime <= @endDate")
+	List<TestEntity> getAllBetweenDates(@Param("startDate") Timestamp startDate, @Param("endDate") Timestamp endDate);
 
 	@Nullable
 	TestEntity getByColor(String color);


### PR DESCRIPTION
Fixes #552.
Added Datastore native types on top of Spring natives as simple types in `DatastoreMappingContext` constructor.
Also added tests in `DatastoreMappingContextTests.java` and `DatastoreIntegrationTests.java` .

