### PR TITLE
Add PubSubTemplate ProjectTopicName/ProjectSubscriptionName parameters

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubTemplate.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spring.pubsub.core;
 
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ProjectTopicName;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -129,6 +131,23 @@ public class PubSubTemplate implements PubSubOperations {
 	}
 
 	@Override
+	public <T> ListenableFuture<String> publish(ProjectTopicName projectTopicName, T payload,
+			Map<String, String> headers) {
+		return publish(projectTopicName.toString(), payload, headers);
+	}
+
+	@Override
+	public <T> ListenableFuture<String> publish(ProjectTopicName projectTopicName, T payload) {
+		return publish(projectTopicName.toString(), payload);
+	}
+
+	@Override
+	public ListenableFuture<String> publish(ProjectTopicName projectTopicName,
+			PubsubMessage pubsubMessage) {
+		return publish(projectTopicName.toString(), pubsubMessage);
+	}
+
+	@Override
 	public Subscriber subscribe(String subscription, Consumer<BasicAcknowledgeablePubsubMessage> messageConsumer) {
 		return this.pubSubSubscriberTemplate.subscribe(subscription, messageConsumer);
 	}
@@ -184,6 +203,70 @@ public class PubSubTemplate implements PubSubOperations {
 	@Override
 	public ListenableFuture<PubsubMessage> pullNextAsync(String subscription) {
 		return this.pubSubSubscriberTemplate.pullNextAsync(subscription);
+	}
+
+	@Override
+	public Subscriber subscribe(ProjectSubscriptionName projectSubscriptionName,
+			Consumer<BasicAcknowledgeablePubsubMessage> messageConsumer) {
+		return subscribe(projectSubscriptionName.toString(), messageConsumer);
+	}
+
+	@Override
+	public <T> Subscriber subscribeAndConvert(ProjectSubscriptionName projectSubscriptionName,
+			Consumer<ConvertedBasicAcknowledgeablePubsubMessage<T>> convertedBasicAcknowledgeablePubsubMessageConsumer,
+			Class<T> payloadType) {
+		return subscribeAndConvert(projectSubscriptionName.toString(), convertedBasicAcknowledgeablePubsubMessageConsumer, payloadType);
+	}
+
+	@Override
+	public List<PubsubMessage> pullAndAck(ProjectSubscriptionName projectSubscriptionName,
+			Integer maxMessages, Boolean returnImmediately) {
+		return pullAndAck(projectSubscriptionName.toString(), maxMessages, returnImmediately);
+	}
+
+	@Override
+	public ListenableFuture<List<PubsubMessage>> pullAndAckAsync(
+			ProjectSubscriptionName projectSubscriptionName, Integer maxMessages,
+			Boolean returnImmediately) {
+		return pullAndAckAsync(projectSubscriptionName.toString(), maxMessages, returnImmediately);
+	}
+
+	@Override
+	public List<AcknowledgeablePubsubMessage> pull(ProjectSubscriptionName projectSubscriptionName,
+			Integer maxMessages, Boolean returnImmediately) {
+		return pull(projectSubscriptionName.toString(), maxMessages, returnImmediately);
+	}
+
+	@Override
+	public ListenableFuture<List<AcknowledgeablePubsubMessage>> pullAsync(
+			ProjectSubscriptionName projectSubscriptionName, Integer maxMessages,
+			Boolean returnImmediately) {
+		return pullAsync(projectSubscriptionName.toString(), maxMessages, returnImmediately);
+	}
+
+	@Override
+	public <T> List<ConvertedAcknowledgeablePubsubMessage<T>> pullAndConvert(
+			ProjectSubscriptionName projectSubscriptionName, Integer maxMessages,
+			Boolean returnImmediately, Class<T> payloadType) {
+		return pullAndConvert(projectSubscriptionName.toString(), maxMessages, returnImmediately, payloadType);
+	}
+
+	@Override
+	public <T> ListenableFuture<List<ConvertedAcknowledgeablePubsubMessage<T>>> pullAndConvertAsync(
+			ProjectSubscriptionName projectSubscriptionName, Integer maxMessages,
+			Boolean returnImmediately, Class<T> payloadType) {
+		return pullAndConvertAsync(projectSubscriptionName, maxMessages, returnImmediately, payloadType);
+	}
+
+	@Override
+	public PubsubMessage pullNext(ProjectSubscriptionName projectSubscriptionName) {
+		return pullNext(projectSubscriptionName.toString());
+	}
+
+	@Override
+	public ListenableFuture<PubsubMessage> pullNextAsync(
+			ProjectSubscriptionName projectSubscriptionName) {
+		return pullNextAsync(projectSubscriptionName.toString());
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/publisher/PubSubPublisherOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/publisher/PubSubPublisherOperations.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spring.pubsub.core.publisher;
 
+import com.google.pubsub.v1.ProjectTopicName;
 import java.util.Map;
 
 import com.google.pubsub.v1.PubsubMessage;
@@ -65,4 +66,30 @@ public interface PubSubPublisherOperations {
 	 */
 	ListenableFuture<String> publish(String topic, PubsubMessage pubsubMessage);
 
+	/**
+	 * Send a message to Pub/Sub.
+	 * @param projectTopicName the project topic to publish to
+	 * @param payload an object that will be serialized and sent
+	 * @param headers the headers to publish
+	 * @param <T> the type of the payload to publish
+	 * @return the listenable future of the call
+	 */
+	<T> ListenableFuture<String> publish(ProjectTopicName projectTopicName, T payload, Map<String, String> headers);
+
+	/**
+	 * Send a message to Pub/Sub.
+	 * @param projectTopicName the project topic to publish to
+	 * @param payload an object that will be serialized and sent
+	 * @param <T> the type of the payload to publish
+	 * @return the listenable future of the call
+	 */
+	<T> ListenableFuture<String> publish(ProjectTopicName projectTopicName, T payload);
+
+	/**
+	 * Send a message to Pub/Sub.
+	 * @param projectTopicName the project topic to publish to
+	 * @param pubsubMessage a Google Cloud Pub/Sub API message
+	 * @return the listenable future of the call
+	 */
+	ListenableFuture<String> publish(ProjectTopicName projectTopicName, PubsubMessage pubsubMessage);
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/publisher/PubSubPublisherTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/publisher/PubSubPublisherTemplate.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spring.pubsub.core.publisher;
 
+import com.google.pubsub.v1.ProjectTopicName;
 import java.util.Map;
 
 import com.google.api.core.ApiFuture;
@@ -124,6 +125,23 @@ public class PubSubPublisherTemplate implements PubSubPublisherOperations {
 		}, directExecutor());
 
 		return settableFuture;
+	}
+
+	@Override
+	public <T> ListenableFuture<String> publish(ProjectTopicName projectTopicName, T payload,
+			Map<String, String> headers) {
+		return publish(projectTopicName.toString(), payload, headers);
+	}
+
+	@Override
+	public <T> ListenableFuture<String> publish(ProjectTopicName projectTopicName, T payload) {
+		return publish(projectTopicName.toString(), payload);
+	}
+
+	@Override
+	public ListenableFuture<String> publish(ProjectTopicName projectTopicName,
+			PubsubMessage pubsubMessage) {
+		return publish(projectTopicName.toString(), pubsubMessage);
 	}
 
 	public PublisherFactory getPublisherFactory() {

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberOperations.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spring.pubsub.core.subscriber;
 
+import com.google.pubsub.v1.ProjectSubscriptionName;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
@@ -179,6 +180,133 @@ public interface PubSubSubscriberOperations {
 	 * @since 1.2.3
 	 */
 	ListenableFuture<PubsubMessage> pullNextAsync(String subscription);
+
+	/**
+	 * Add a callback method to an existing subscription.
+	 * <p>The created {@link Subscriber} is returned so it can be stopped.
+	 * @param projectSubscriptionName the project subscription to subscribe to
+	 * @param messageConsumer the callback method triggered when new messages arrive
+	 * @return subscriber listening to new messages
+	 * @since 1.1
+	 */
+	Subscriber subscribe(ProjectSubscriptionName projectSubscriptionName, Consumer<BasicAcknowledgeablePubsubMessage> messageConsumer);
+
+	/**
+	 * Add a callback method to an existing subscription that receives Pub/Sub messages converted to the requested
+	 * payload type.
+	 * <p>The created {@link Subscriber} is returned so it can be stopped.
+	 * @param projectSubscriptionName the project subscription to subscribe to
+	 * @param messageConsumer the callback method triggered when new messages arrive
+	 * @param payloadType the type to which the payload of the Pub/Sub message should be converted
+	 * @param <T> the type of the payload
+	 * @return subscriber listening to new messages
+	 * @since 1.1
+	 */
+	<T> Subscriber subscribeAndConvert(ProjectSubscriptionName projectSubscriptionName,
+			Consumer<ConvertedBasicAcknowledgeablePubsubMessage<T>> messageConsumer, Class<T> payloadType);
+
+	/**
+	 * Pull and auto-acknowledge a number of messages from a Google Cloud Pub/Sub subscription.
+	 * @param projectSubscriptionName the project subscription to subscribe to
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
+	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
+	 * @return the list of received messages
+	 */
+	List<PubsubMessage> pullAndAck(ProjectSubscriptionName projectSubscriptionName, Integer maxMessages, Boolean returnImmediately);
+
+	/**
+	 * Asynchronously pull and auto-acknowledge a number of messages from a Google Cloud Pub/Sub subscription.
+	 * @param projectSubscriptionName the project subscription to subscribe to
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
+	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
+	 * @return the ListenableFuture for the asynchronous execution, returning the list of
+	 * received acknowledgeable messages
+	 * @since 1.2.3
+	 */
+	ListenableFuture<List<PubsubMessage>> pullAndAckAsync(ProjectSubscriptionName projectSubscriptionName, Integer maxMessages, Boolean returnImmediately);
+
+	/**
+	 * Pull a number of messages from a Google Cloud Pub/Sub subscription.
+	 * @param projectSubscriptionName the project subscription to subscribe to
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
+	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
+	 * @return the list of received acknowledgeable messages
+	 */
+	List<AcknowledgeablePubsubMessage> pull(ProjectSubscriptionName projectSubscriptionName, Integer maxMessages, Boolean returnImmediately);
+
+	/**
+	 * Asynchronously pull a number of messages from a Google Cloud Pub/Sub subscription.
+	 * @param projectSubscriptionName the project subscription to subscribe to
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
+	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
+	 * @return the ListenableFuture for the asynchronous execution, returning the list of
+	 * received acknowledgeable messages
+	 * @since 1.2.3
+	 */
+	ListenableFuture<List<AcknowledgeablePubsubMessage>> pullAsync(ProjectSubscriptionName projectSubscriptionName, Integer maxMessages, Boolean returnImmediately);
+
+	/**
+	 * Pull a number of messages from a Google Cloud Pub/Sub subscription and convert them to Spring messages with
+	 * the desired payload type.
+	 * @param projectSubscriptionName the project subscription to subscribe to
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
+	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
+	 * @param payloadType the type to which the payload of the Pub/Sub messages should be converted
+	 * @param <T> the type of the payload
+	 * @return the list of received acknowledgeable messages
+	 * @since 1.1
+	 */
+	<T> List<ConvertedAcknowledgeablePubsubMessage<T>> pullAndConvert(ProjectSubscriptionName projectSubscriptionName, Integer maxMessages,
+			Boolean returnImmediately, Class<T> payloadType);
+
+	/**
+	 * Asynchronously pull a number of messages from a Google Cloud Pub/Sub subscription and convert them to Spring messages with
+	 * the desired payload type.
+	 * @param projectSubscriptionName the project subscription to subscribe to
+	 * @param maxMessages the maximum number of pulled messages. If this value is null then
+	 * up to Integer.MAX_VALUE messages will be requested.
+	 * @param returnImmediately returns immediately even if subscription doesn't contain enough
+	 * messages to satisfy {@code maxMessages}.
+	 * Setting this parameter to {@code true} is not recommended as it may result in long delays in message delivery.
+	 * @param payloadType the type to which the payload of the Pub/Sub messages should be converted
+	 * @param <T> the type of the payload
+	 * @return the ListenableFuture for the asynchronous execution, returning the list of
+	 *  received acknowledgeable messages
+	 * @since 1.2.3
+	 */
+	<T> ListenableFuture<List<ConvertedAcknowledgeablePubsubMessage<T>>> pullAndConvertAsync(ProjectSubscriptionName projectSubscriptionName,
+			Integer maxMessages, Boolean returnImmediately, Class<T> payloadType);
+
+	/**
+	 * Pull and auto-acknowledge a message from a Google Cloud Pub/Sub subscription.
+	 * @param projectSubscriptionName the project subscription to subscribe to
+	 * @return a received message, or {@code null} if none exists in the subscription
+	 */
+	PubsubMessage pullNext(ProjectSubscriptionName projectSubscriptionName);
+
+	/**
+	 * Asynchronously pull and auto-acknowledge a message from a Google Cloud Pub/Sub subscription.
+	 * @param projectSubscriptionName the project subscription to subscribe to
+	 * @return the ListenableFuture for the asynchronous execution, returning a received message,
+	 * or {@code null} if none exists in the subscription
+	 * @since 1.2.3
+	 */
+	ListenableFuture<PubsubMessage> pullNextAsync(ProjectSubscriptionName projectSubscriptionName);
 
 	/**
 	 * Acknowledge a batch of messages. The messages must have the same project id.

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberTemplate.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberTemplate.java
@@ -348,6 +348,70 @@ public class PubSubSubscriberTemplate
 		return settableFuture;
 	}
 
+	@Override
+	public Subscriber subscribe(ProjectSubscriptionName projectSubscriptionName,
+			Consumer<BasicAcknowledgeablePubsubMessage> messageConsumer) {
+		return subscribe(projectSubscriptionName.toString(), messageConsumer);
+	}
+
+	@Override
+	public <T> Subscriber subscribeAndConvert(ProjectSubscriptionName projectSubscriptionName,
+			Consumer<ConvertedBasicAcknowledgeablePubsubMessage<T>> convertedBasicAcknowledgeablePubsubMessageConsumer,
+			Class<T> payloadType) {
+		return subscribeAndConvert(projectSubscriptionName.toString(), convertedBasicAcknowledgeablePubsubMessageConsumer, payloadType);
+	}
+
+	@Override
+	public List<PubsubMessage> pullAndAck(ProjectSubscriptionName projectSubscriptionName,
+			Integer maxMessages, Boolean returnImmediately) {
+		return pullAndAck(projectSubscriptionName.toString(), maxMessages, returnImmediately);
+	}
+
+	@Override
+	public ListenableFuture<List<PubsubMessage>> pullAndAckAsync(
+			ProjectSubscriptionName projectSubscriptionName, Integer maxMessages,
+			Boolean returnImmediately) {
+		return pullAndAckAsync(projectSubscriptionName, maxMessages, returnImmediately);
+	}
+
+	@Override
+	public List<AcknowledgeablePubsubMessage> pull(ProjectSubscriptionName projectSubscriptionName,
+			Integer maxMessages, Boolean returnImmediately) {
+		return pull(projectSubscriptionName, maxMessages, returnImmediately);
+	}
+
+	@Override
+	public ListenableFuture<List<AcknowledgeablePubsubMessage>> pullAsync(
+			ProjectSubscriptionName projectSubscriptionName, Integer maxMessages,
+			Boolean returnImmediately) {
+		return pullAsync(projectSubscriptionName, maxMessages, returnImmediately);
+	}
+
+	@Override
+	public <T> List<ConvertedAcknowledgeablePubsubMessage<T>> pullAndConvert(
+			ProjectSubscriptionName projectSubscriptionName, Integer maxMessages,
+			Boolean returnImmediately, Class<T> payloadType) {
+		return pullAndConvert(projectSubscriptionName, maxMessages, returnImmediately, payloadType);
+	}
+
+	@Override
+	public <T> ListenableFuture<List<ConvertedAcknowledgeablePubsubMessage<T>>> pullAndConvertAsync(
+			ProjectSubscriptionName projectSubscriptionName, Integer maxMessages,
+			Boolean returnImmediately, Class<T> payloadType) {
+		return pullAndConvertAsync(projectSubscriptionName, maxMessages, returnImmediately, payloadType);
+	}
+
+	@Override
+	public PubsubMessage pullNext(ProjectSubscriptionName projectSubscriptionName) {
+		return pullNext(projectSubscriptionName.toString());
+	}
+
+	@Override
+	public ListenableFuture<PubsubMessage> pullNextAsync(
+			ProjectSubscriptionName projectSubscriptionName) {
+		return pullNextAsync(projectSubscriptionName);
+	}
+
 	public SubscriberFactory getSubscriberFactory() {
 		return this.subscriberFactory;
 	}


### PR DESCRIPTION
# Motivation and Context
The PubSubTemplate interface contract does not make it clear that it's possible to specify a fully qualified topic or subscription name, including the project. The documentation of this feature is present, but it's easily overlooked.

# What has changed
These convenience methods make it clear that a ProjectSubscriptionName or a ProjectTopicName can be supplied with a project, to make it easier for developers to understand this functionality/capability.

# How to test?
Zero regression - existing test all pass.

# Links
Original issue/feature request: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/581