### PR TITLE
Add diagnostic message to find source of trace test flakiness

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
@@ -148,7 +148,8 @@ public class TraceSampleApplicationIntegrationTests {
 
 			log.debug("Getting trace...");
 			Trace trace = this.traceServiceStub.getTrace(getTraceRequest);
-			log.info("Found trace! " + trace.getTraceId() + " with " + trace.getSpansCount() + " spans ("
+			log.info("Found trace! " + trace.getTraceId()
+					+ " with " + trace.getSpansCount() + " spans ("
 					+ trace.getSpansList().stream().map(TraceSpan::getName).collect(Collectors.toList())
 					+ ").");
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
@@ -148,9 +148,17 @@ public class TraceSampleApplicationIntegrationTests {
 
 			log.debug("Getting trace...");
 			Trace trace = this.traceServiceStub.getTrace(getTraceRequest);
-			log.debug("Found trace! " + trace.getTraceId() + " with " + trace.getSpansCount() + " spans.");
+			log.info("Found trace! " + trace.getTraceId() + " with " + trace.getSpansCount() + " spans ("
+					+ trace.getSpansList().stream().map(TraceSpan::getName).collect(Collectors.toList())
+					+ ").");
 
 			assertThat(trace.getTraceId()).isEqualTo(uuidString);
+			/* The 25 expected spans are:
+			 *   get /, visit-meet-endpoint, get, get /meet, get, get /meet, get, get /meet,
+			 *   send-message-spring-integration, send, handle, handle, publish, send-message-pub-sub-template, publish,
+			 *   next-message, on-message, next-message, on-message, send, send, handle, handle, handle, handle
+			 */
+
 			assertThat(trace.getSpansCount()).isEqualTo(25);
 			log.debug("Trace spans match.");
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
@@ -157,6 +157,12 @@ public class TraceSampleApplicationIntegrationTests {
 			 *   get /, visit-meet-endpoint, get, get /meet, get, get /meet, get, get /meet,
 			 *   send-message-spring-integration, send, handle, handle, publish, send-message-pub-sub-template, publish,
 			 *   next-message, on-message, next-message, on-message, send, send, handle, handle, handle, handle
+			 *
+			 * Example of a bad run (notice that the last line only has one "send". Two are expected!).
+			 * 	Found trace! 148bcda619bd448ea6a718ca0f662bd2 with 24 spans (
+			 *  [get /, visit-meet-endpoint, get, get /meet, get, get /meet, get, get /meet,
+			 * 	send-message-spring-integration, send, handle, handle, publish, send-message-pub-sub-template, publish,
+			 * 	next-message, on-message, handle, handle, next-message, on-message, send, handle, handle]).
 			 */
 
 			assertThat(trace.getSpansCount()).isEqualTo(25);
@@ -206,6 +212,9 @@ public class TraceSampleApplicationIntegrationTests {
 							.getDataAsMap().get("message"))
 					.collect(Collectors.toList());
 
+			log.info("\n========================= [START OF LOG CONTENTS] =========================\n"
+					+ logContents.toString()
+					+ "\n========================= [END OF LOG CONTENTS]   =========================\n");
 			assertThat(logContents).contains("starting busy work");
 			log.debug("Found 'starting' line");
 			assertThat(logContents).contains("finished busy work");


### PR DESCRIPTION
Trace tests run just fine locally, but flake regularly when running on GitHubActions.

Let's find out why.