### PR TITLE
Implement deleteAllById() in SimpleFirestoreReactiveRepository 

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepository.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepository.java
@@ -124,10 +124,6 @@ public class SimpleFirestoreReactiveRepository<T> implements FirestoreReactiveRe
 	// TODO: Restore @Override when not supporting Spring Boot 2.4 anymore
 	// @Override
 	public Mono<Void> deleteAllById(Iterable<? extends String> ids) {
-		return deleteAllById(Flux.fromIterable(ids));
-	}
-
-	public Mono<Void> deleteAllById(Publisher<String> idPublisher) {
-		return this.firestoreTemplate.deleteById(idPublisher, this.type);
+		return this.firestoreTemplate.deleteById(Flux.fromIterable(ids), this.type);
 	}
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepository.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepository.java
@@ -122,12 +122,12 @@ public class SimpleFirestoreReactiveRepository<T> implements FirestoreReactiveRe
 	}
 
 	// TODO: Restore @Override when not supporting Spring Boot 2.4 anymore
-	//@Override
+	// @Override
 	public Mono<Void> deleteAllById(Iterable<? extends String> ids) {
 		return deleteAllById(Flux.fromIterable(ids));
 	}
 
 	public Mono<Void> deleteAllById(Publisher<String> idPublisher) {
-		return this.firestoreTemplate.deleteById( idPublisher, this.type);
+		return this.firestoreTemplate.deleteById(idPublisher, this.type);
 	}
 }

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepository.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepository.java
@@ -124,6 +124,10 @@ public class SimpleFirestoreReactiveRepository<T> implements FirestoreReactiveRe
 	// TODO: Restore @Override when not supporting Spring Boot 2.4 anymore
 	//@Override
 	public Mono<Void> deleteAllById(Iterable<? extends String> ids) {
-		throw new UnsupportedOperationException();
+		return deleteAllById(Flux.fromIterable(ids));
+	}
+
+	public Mono<Void> deleteAllById(Publisher<String> idPublisher) {
+		return this.firestoreTemplate.deleteById( idPublisher, this.type);
 	}
 }

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
@@ -215,6 +215,23 @@ public class FirestoreTemplateTests {
 		verify(this.firestoreStub, times(1)).commit(eq(builder.build()), any());
 	}
 
+	@Test
+	public void deleteByIdTest() {
+		mockCommitMethod();
+		Flux<String> idPublisher = Flux.just("e1", "e2");
+		StepVerifier.create(
+				this.firestoreTemplate
+						.deleteById(idPublisher, TestEntity.class))
+				.verifyComplete();
+
+		CommitRequest.Builder builder = CommitRequest.newBuilder()
+				.setDatabase("projects/my-project/databases/(default)");
+
+		builder.addWrites(Write.newBuilder().setDelete(parent + "/testEntities/e1").build());
+		builder.addWrites(Write.newBuilder().setDelete(parent + "/testEntities/e2").build());
+
+		verify(this.firestoreStub, times(1)).commit(eq(builder.build()), any());
+	}
 
 	private void mockCommitMethod() {
 		doAnswer(invocation -> {

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
@@ -230,7 +230,7 @@ public class FirestoreTemplateTests {
 		builder.addWrites(Write.newBuilder().setDelete(parent + "/testEntities/e1").build());
 		builder.addWrites(Write.newBuilder().setDelete(parent + "/testEntities/e2").build());
 
-		verify(this.firestoreStub, times(1)).commit(eq(builder.build()), any());
+		verify(this.firestoreStub).commit(eq(builder.build()), any());
 	}
 
 	private void mockCommitMethod() {

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
@@ -17,13 +17,15 @@
 package com.google.cloud.spring.data.firestore;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -34,8 +36,12 @@ public class SimpleFirestoreReactiveRepositoryTests {
 		FirestoreTemplate mockTemplate = mock(FirestoreTemplate.class);
 		SimpleFirestoreReactiveRepository<String> repository = new SimpleFirestoreReactiveRepository<>(mockTemplate,
 				String.class);
-		Publisher<String> ids = Flux.fromIterable(Arrays.asList("1", "2"));
-		repository.deleteAllById(ids);
-		verify(mockTemplate).deleteById(same(ids), eq(String.class));
+		Iterable<String> idList = Arrays.asList("1", "2");
+		repository.deleteAllById(idList);
+
+		ArgumentCaptor<Publisher> argumentCaptor = ArgumentCaptor.forClass(Publisher.class);
+		verify(mockTemplate).deleteById(argumentCaptor.capture(), eq(String.class));
+		List<String> arguments = (List<String>) ((Flux) argumentCaptor.getValue()).collectList().block();
+		assertThat(arguments).containsExactlyInAnyOrder("1", "2");
 	}
 }

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
@@ -37,6 +37,7 @@ public class SimpleFirestoreReactiveRepositoryTests {
 		SimpleFirestoreReactiveRepository<String> repository = new SimpleFirestoreReactiveRepository<>(mockTemplate,
 				String.class);
 		Iterable<String> idList = Arrays.asList("1", "2");
+		// only testing that the request is passed through to FirestoreTemplate as expected
 		repository.deleteAllById(idList);
 
 		ArgumentCaptor<Publisher> argumentCaptor = ArgumentCaptor.forClass(Publisher.class);

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
@@ -32,8 +32,8 @@ public class SimpleFirestoreReactiveRepositoryTests {
 	@Test
 	public void deleteAllById() {
 		FirestoreTemplate mockTemplate = mock(FirestoreTemplate.class);
-		SimpleFirestoreReactiveRepository<String> repository =
-				new SimpleFirestoreReactiveRepository<>(mockTemplate, String.class);
+		SimpleFirestoreReactiveRepository<String> repository = new SimpleFirestoreReactiveRepository<>(mockTemplate,
+				String.class);
 		Publisher<String> ids = Flux.fromIterable(Arrays.asList("1", "2"));
 		repository.deleteAllById(ids);
 		verify(mockTemplate).deleteById(same(ids), eq(String.class));

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
@@ -16,21 +16,26 @@
 
 package com.google.cloud.spring.data.firestore;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.junit.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class SimpleFirestoreReactiveRepositoryTests {
 
 	@Test
-	public void deleteAllByIdUnimplemented() {
+	public void deleteAllById() {
 		FirestoreTemplate mockTemplate = mock(FirestoreTemplate.class);
 		SimpleFirestoreReactiveRepository<String> repository =
 				new SimpleFirestoreReactiveRepository<>(mockTemplate, String.class);
-		assertThatThrownBy(() -> repository.deleteAllById(new ArrayList<>()))
-				.isInstanceOf(UnsupportedOperationException.class);
+		Publisher<String> ids = Flux.fromIterable(Arrays.asList("1", "2"));
+		repository.deleteAllById(ids);
+		verify(mockTemplate).deleteById(same(ids), eq(String.class));
 	}
 }

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTests.java
@@ -273,6 +273,14 @@ public class FirestoreIntegrationTests {
 		assertThat(this.firestoreTemplate.deleteAll(User.class).block()).isEqualTo(2);
 		assertThat(this.firestoreTemplate.findAll(User.class).collectList().block()).isEmpty();
 
+		alice.setUpdateTime(null);
+		this.firestoreTemplate.save(alice).block();
+		bob.setUpdateTime(null);
+		this.firestoreTemplate.save(bob).block();
+
+		this.firestoreTemplate.deleteById(Flux.just("Bob", "Saitama", "Alice"),User.class).block();
+		assertThat(this.firestoreTemplate.count(User.class).block()).isZero();
+
 		//tag::subcollection[]
 		FirestoreReactiveOperations bobTemplate = this.firestoreTemplate.withParent(new User("Bob", 60));
 

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTests.java
@@ -273,14 +273,6 @@ public class FirestoreIntegrationTests {
 		assertThat(this.firestoreTemplate.deleteAll(User.class).block()).isEqualTo(2);
 		assertThat(this.firestoreTemplate.findAll(User.class).collectList().block()).isEmpty();
 
-		alice.setUpdateTime(null);
-		this.firestoreTemplate.save(alice).block();
-		bob.setUpdateTime(null);
-		this.firestoreTemplate.save(bob).block();
-
-		this.firestoreTemplate.deleteById(Flux.just("Bob", "Saitama", "Alice"), User.class).block();
-		assertThat(this.firestoreTemplate.count(User.class).block()).isZero();
-
 		//tag::subcollection[]
 		FirestoreReactiveOperations bobTemplate = this.firestoreTemplate.withParent(new User("Bob", 60));
 
@@ -292,6 +284,19 @@ public class FirestoreIntegrationTests {
 		//end::subcollection[]
 	}
 
+	@Test
+	public void deleteAllByIdTest() {
+		User alice = new User("Alice", 29);
+		User bob = new User("Bob", 60);
+
+		this.firestoreTemplate.save(alice).block();
+		this.firestoreTemplate.save(bob).block();
+
+		StepVerifier.create(
+				this.firestoreTemplate.deleteById(Flux.just("Bob", "Saitama", "Alice"), User.class)
+						.then(this.firestoreTemplate.count(User.class)))
+				.expectNext(0L).verifyComplete();
+	}
 
 	@Test
 	public void saveTest() {

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTests.java
@@ -278,7 +278,7 @@ public class FirestoreIntegrationTests {
 		bob.setUpdateTime(null);
 		this.firestoreTemplate.save(bob).block();
 
-		this.firestoreTemplate.deleteById(Flux.just("Bob", "Saitama", "Alice"),User.class).block();
+		this.firestoreTemplate.deleteById(Flux.just("Bob", "Saitama", "Alice"), User.class).block();
 		assertThat(this.firestoreTemplate.count(User.class).block()).isZero();
 
 		//tag::subcollection[]

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import com.google.cloud.spring.data.firestore.SimpleFirestoreReactiveRepository;
 import com.google.cloud.spring.data.firestore.entities.User;
 import com.google.cloud.spring.data.firestore.entities.User.Address;
 import com.google.cloud.spring.data.firestore.entities.UserRepository;
@@ -29,6 +30,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.test.util.AopTestUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -114,6 +116,11 @@ public class FirestoreRepositoryIntegrationTests {
 		User aliceLoaded = this.userRepository.findById("Alice").block();
 		assertThat(aliceLoaded.getAddresses()).isEqualTo(addresses);
 		assertThat(aliceLoaded.getHomeAddress()).isEqualTo(homeAddress);
+
+		// cast to SimpleFirestoreReactiveRepository for method be reachable with Spring Boot 2.4
+		SimpleFirestoreReactiveRepository repository = AopTestUtils.getTargetObject(this.userRepository);
+		repository.deleteAllById(Arrays.asList("Alice", "Bob")).block();
+		assertThat(this.userRepository.count().block()).isEqualTo(0);
 	}
 	//end::repository_built_in[]
 

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.test.util.AopTestUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -41,6 +40,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.AopTestUtils;
 import org.springframework.transaction.reactive.TransactionalOperator;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -119,8 +119,8 @@ public class FirestoreRepositoryIntegrationTests {
 
 		// cast to SimpleFirestoreReactiveRepository for method be reachable with Spring Boot 2.4
 		SimpleFirestoreReactiveRepository repository = AopTestUtils.getTargetObject(this.userRepository);
-		repository.deleteAllById(Arrays.asList("Alice", "Bob")).block();
-		assertThat(this.userRepository.count().block()).isEqualTo(0);
+		StepVerifier.create(repository.deleteAllById(Arrays.asList("Alice", "Bob")).then(this.userRepository.count()))
+				.expectNext(0L).verifyComplete();
 	}
 	//end::repository_built_in[]
 


### PR DESCRIPTION
Implement `deleteAllById()` in `SimpleFirestoreReactiveRepository` and add relevant tests.
Resolves #566.
This is in the checklist of #472.