### PR TITLE
Add implementation to choose global properties when subscription-specific properties are not specified

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -203,6 +203,28 @@ public class GcpPubSubAutoConfigurationTests {
 		});
 	}
 
+	@Test
+	public void executorThreads_noConfigurationSet_pickDefault() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
+				.withUserConfiguration(TestConfig.class);
+
+		contextRunner.run(ctx -> {
+			GcpPubSubProperties gcpPubSubProperties = ctx
+					.getBean(GcpPubSubProperties.class);
+			GcpProjectIdProvider projectIdProvider = ctx.getBean(GcpProjectIdProvider.class);
+			assertThat(
+					gcpPubSubProperties.computeSubscriberExecutorThreads("subscription-name",
+							projectIdProvider.getProjectId()))
+									.isEqualTo(4);
+			assertThat(gcpPubSubProperties.getSubscription())
+					.containsKey("projects/fake project/subscriptions/subscription-name");
+			assertThat(
+					gcpPubSubProperties.computeSubscriberExecutorThreads("other", projectIdProvider.getProjectId()))
+							.isEqualTo(4);
+		});
+	}
+
 	static class TestConfig {
 
 		@Bean

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -219,9 +219,6 @@ public class GcpPubSubAutoConfigurationTests {
 									.isEqualTo(4);
 			assertThat(gcpPubSubProperties.getSubscription())
 					.containsKey("projects/fake project/subscriptions/subscription-name");
-			assertThat(
-					gcpPubSubProperties.computeSubscriberExecutorThreads("other", projectIdProvider.getProjectId()))
-							.isEqualTo(4);
 		});
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -74,8 +74,7 @@ public class PubSubAutoConfigurationIntegrationTests {
 			pubSubTemplate.pull(subscriptionName, 4, false);
 
 			GcpPubSubProperties gcpPubSubProperties = context.getBean(GcpPubSubProperties.class);
-			assertThat(gcpPubSubProperties.getSubscriber(subscriptionName, projectIdProvider.getProjectId())
-					.getExecutorThreads()).isEqualTo(3);
+			assertThat(gcpPubSubProperties.computeSubscriberExecutorThreads(subscriptionName, projectIdProvider.getProjectId())).isEqualTo(3);
 
 			pubSubAdmin.deleteSubscription(subscriptionName);
 			pubSubAdmin.deleteTopic(topicName);
@@ -110,8 +109,7 @@ public class PubSubAutoConfigurationIntegrationTests {
 			});
 
 			GcpPubSubProperties gcpPubSubProperties = context.getBean(GcpPubSubProperties.class);
-			assertThat(gcpPubSubProperties.getSubscriber(subscriptionName, projectIdProvider.getProjectId())
-					.getExecutorThreads()).isEqualTo(1);
+			assertThat(gcpPubSubProperties.computeSubscriberExecutorThreads(subscriptionName, projectIdProvider.getProjectId())).isEqualTo(1);
 
 			pubSubAdmin.deleteSubscription(subscriptionName);
 			pubSubAdmin.deleteTopic(topicName);

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -37,9 +37,9 @@ public class PubSubConfiguration {
 	private final Map<String, Subscriber> subscription = new HashMap<>();
 
 	/**
-	 * Contains default subscriber settings.
+	 * Contains global and default subscriber settings.
 	 */
-	private final Subscriber subscriber = new Subscriber();
+	private final Subscriber globalSubscriber = new Subscriber();
 
 	/**
 	 * Contains default publisher settings.
@@ -47,7 +47,7 @@ public class PubSubConfiguration {
 	private final Publisher publisher = new Publisher();
 
 	public Subscriber getSubscriber() {
-		return this.subscriber;
+		return this.globalSubscriber;
 	}
 
 	public Publisher getPublisher() {
@@ -78,7 +78,7 @@ public class PubSubConfiguration {
 		}
 
 		Subscriber subscriberProperties = this.subscription.computeIfAbsent(fullyQualifiedSubscriptionKey,
-				k -> this.subscriber);
+				k -> this.globalSubscriber);
 		subscriberProperties.global = true;
 		return subscriberProperties;
 	}
@@ -96,7 +96,7 @@ public class PubSubConfiguration {
 		if (numThreads != null) {
 			return numThreads;
 		}
-		Integer globalExecutorThreads = subscriber.getExecutorThreads();
+		Integer globalExecutorThreads = this.globalSubscriber.getExecutorThreads();
 		return globalExecutorThreads != null ? globalExecutorThreads : DEFAULT_EXECUTOR_THREADS;
 	}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -32,6 +32,8 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
  */
 public class PubSubConfiguration {
 
+	private static final int DEFAULT_EXECUTOR_THREADS = 4;
+
 	private final Map<String, Subscriber> subscription = new HashMap<>();
 
 	/**
@@ -79,6 +81,23 @@ public class PubSubConfiguration {
 				k -> this.subscriber);
 		subscriberProperties.global = true;
 		return subscriberProperties;
+	}
+
+	/**
+	 * Computes the number of executor threads. The subscription-specific property takes
+	 * precedence if both global and subscription-specific properties are set. If none are set
+	 * then the default (4) is returned.
+	 * @param subscriptionName subscription name
+	 * @param projectId project id
+	 * @return number of executor threads
+	 */
+	public int computeSubscriberExecutorThreads(String subscriptionName, String projectId) {
+		Integer numThreads = getSubscriber(subscriptionName, projectId).getExecutorThreads();
+		if (numThreads != null) {
+			return numThreads;
+		}
+		Integer globalExecutorThreads = subscriber.getExecutorThreads();
+		return globalExecutorThreads != null ? globalExecutorThreads : DEFAULT_EXECUTOR_THREADS;
 	}
 
 	/**
@@ -157,7 +176,7 @@ public class PubSubConfiguration {
 		/**
 		 * Number of threads used by every subscriber.
 		 */
-		private int executorThreads = 4;
+		private Integer executorThreads;
 
 		/**
 		 * Number of threads used for batch acknowledgement.
@@ -225,7 +244,7 @@ public class PubSubConfiguration {
 			this.parallelPullCount = parallelPullCount;
 		}
 
-		public int getExecutorThreads() {
+		public Integer getExecutorThreads() {
 			return this.executorThreads;
 		}
 

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
@@ -30,7 +30,7 @@ public class PubSubConfigurationTests {
 		PubSubConfiguration.FlowControl flowControl = subscriber.getFlowControl();
 		PubSubConfiguration.Retry retrySettings = subscriber.getRetry();
 
-		assertThat(subscriber.getExecutorThreads()).isEqualTo(4);
+		assertThat(subscriber.getExecutorThreads()).isNull();
 		assertThat(subscriber.getMaxAcknowledgementThreads()).isEqualTo(4);
 		assertThat(subscriber.getParallelPullCount()).isNull();
 		assertThat(subscriber.getMaxAckExtensionPeriod()).isZero();
@@ -117,10 +117,10 @@ public class PubSubConfigurationTests {
 
 		assertThat(pubSubConfiguration.getSubscription()).isEmpty();
 		assertThat(pubSubConfiguration.getSubscriber("subscription-name", "projectId").getExecutorThreads())
-				.isEqualTo(4);
+				.isNull();
 		assertThat(pubSubConfiguration.getSubscription()).hasSize(1);
 		assertThat(pubSubConfiguration.getSubscription().get("projects/projectId/subscriptions/subscription-name")
-				.getExecutorThreads()).isEqualTo(4);
+				.getExecutorThreads()).isNull();
 	}
 
 	@Test
@@ -178,9 +178,26 @@ public class PubSubConfigurationTests {
 		assertThat(pubSubConfiguration.getSubscription()).isEmpty();
 		assertThat(pubSubConfiguration
 				.getSubscriber("projects/otherProjectId/subscriptions/subscription-name", "projectId")
-				.getExecutorThreads()).isEqualTo(4);
+				.getExecutorThreads()).isNull();
 		assertThat(pubSubConfiguration.getSubscription().get("projects/otherProjectId/subscriptions/subscription-name")
-				.getExecutorThreads()).isEqualTo(4);
+				.getExecutorThreads()).isNull();
+	}
+
+	@Test
+	public void testComputeExecutorThreads_returnCustom() {
+		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
+		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
+		subscriber.setExecutorThreads(8);
+
+		pubSubConfiguration.getSubscription().put("projects/otherProjectId/subscriptions/subscription-name",
+				subscriber);
+
+		assertThat(pubSubConfiguration.getSubscription()).hasSize(1);
+		assertThat(pubSubConfiguration
+				.getSubscriber("projects/otherProjectId/subscriptions/subscription-name", "projectId")
+				.getExecutorThreads()).isEqualTo(8);
+		assertThat(pubSubConfiguration.getSubscription().get("projects/otherProjectId/subscriptions/subscription-name")
+				.getExecutorThreads()).isEqualTo(8);
 	}
 
 	@Test

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
@@ -172,19 +172,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testSubscriberMapProperties_fullNameWithDifferentProjectId_returnDefault() {
-		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
-
-		assertThat(pubSubConfiguration.getSubscription()).isEmpty();
-		assertThat(pubSubConfiguration
-				.getSubscriber("projects/otherProjectId/subscriptions/subscription-name", "projectId")
-				.getExecutorThreads()).isNull();
-		assertThat(pubSubConfiguration.getSubscription().get("projects/otherProjectId/subscriptions/subscription-name")
-				.getExecutorThreads()).isNull();
-	}
-
-	@Test
-	public void testComputeExecutorThreads_returnCustom() {
+	public void testComputeExecutorThreads_fullNameWithDifferentProjectId_returnCustom() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
 		subscriber.setExecutorThreads(8);
@@ -194,10 +182,18 @@ public class PubSubConfigurationTests {
 
 		assertThat(pubSubConfiguration.getSubscription()).hasSize(1);
 		assertThat(pubSubConfiguration
-				.getSubscriber("projects/otherProjectId/subscriptions/subscription-name", "projectId")
-				.getExecutorThreads()).isEqualTo(8);
-		assertThat(pubSubConfiguration.getSubscription().get("projects/otherProjectId/subscriptions/subscription-name")
-				.getExecutorThreads()).isEqualTo(8);
+				.computeSubscriberExecutorThreads("projects/otherProjectId/subscriptions/subscription-name",
+						"projectId")).isEqualTo(8);
+	}
+
+	@Test
+	public void testComputeExecutorThreads_fullNameWithDifferentProjectId_returnDefault() {
+		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
+
+		assertThat(pubSubConfiguration.getSubscription()).isEmpty();
+		assertThat(pubSubConfiguration
+				.computeSubscriberExecutorThreads("projects/otherProjectId/subscriptions/subscription-name",
+						"projectId")).isEqualTo(4);
 	}
 
 	@Test

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -87,9 +87,7 @@ public class DefaultSubscriberFactoryTests {
 	@Test
 	public void testNewSubscriber_constructorWithPubSubConfiguration() {
 		GcpProjectIdProvider projectIdProvider = () -> "angeldust";
-		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
-		when(mockPubSubConfiguration.getSubscriber("midnight cowboy", projectIdProvider.getProjectId()))
-				.thenReturn(new PubSubConfiguration.Subscriber());
+		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
 		factory.setCredentialsProvider(this.credentialsProvider);
 
 		Subscriber subscriber = factory.createSubscriber("midnight cowboy", (message, consumer) -> {
@@ -157,10 +155,13 @@ public class DefaultSubscriberFactoryTests {
 	public void testGetExecutorProvider_allSubscribersWithDefaultConfig_oneCreated() {
 		GcpProjectIdProvider projectIdProvider = () -> "project";
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
-		when(mockPubSubConfiguration.getSubscriber("defaultSubscription1", projectIdProvider.getProjectId())).thenReturn(mockDefaultSubscriber1);
-		when(mockDefaultSubscriber1.getExecutorThreads()).thenReturn(4);
+		when(mockPubSubConfiguration.getSubscriber("defaultSubscription1", projectIdProvider.getProjectId()))
+				.thenReturn(mockDefaultSubscriber1);
+		when(mockPubSubConfiguration.computeSubscriberExecutorThreads("defaultSubscription1", projectIdProvider.getProjectId()))
+				.thenReturn(4);
 		when(mockDefaultSubscriber1.isGlobal()).thenReturn(true);
-		when(mockPubSubConfiguration.getSubscriber("defaultSubscription2", projectIdProvider.getProjectId())).thenReturn(mockDefaultSubscriber2);
+		when(mockPubSubConfiguration.getSubscriber("defaultSubscription2", projectIdProvider.getProjectId()))
+				.thenReturn(mockDefaultSubscriber2);
 		when(mockDefaultSubscriber2.isGlobal()).thenReturn(true);
 
 		ExecutorProvider executorProviderForSub1 = factory.getExecutorProvider("defaultSubscription1");
@@ -177,10 +178,14 @@ public class DefaultSubscriberFactoryTests {
 	public void testGetExecutorProvider_allSubscribersWithCustomConfigs_manyCreated() {
 		GcpProjectIdProvider projectIdProvider = () -> "project";
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
-		when(mockPubSubConfiguration.getSubscriber("customSubscription1", projectIdProvider.getProjectId())).thenReturn(mockCustomSubscriber1);
-		when(mockCustomSubscriber1.getExecutorThreads()).thenReturn(4);
-		when(mockPubSubConfiguration.getSubscriber("customSubscription2", projectIdProvider.getProjectId())).thenReturn(mockCustomSubscriber2);
-		when(mockCustomSubscriber2.getExecutorThreads()).thenReturn(4);
+		when(mockPubSubConfiguration.getSubscriber("customSubscription1", projectIdProvider.getProjectId()))
+				.thenReturn(mockCustomSubscriber1);
+		when(mockPubSubConfiguration.computeSubscriberExecutorThreads("customSubscription1", projectIdProvider.getProjectId()))
+				.thenReturn(4);
+		when(mockPubSubConfiguration.getSubscriber("customSubscription2", projectIdProvider.getProjectId()))
+				.thenReturn(mockCustomSubscriber2);
+		when(mockPubSubConfiguration.computeSubscriberExecutorThreads("customSubscription2", projectIdProvider.getProjectId()))
+				.thenReturn(4);
 
 		ExecutorProvider executorProviderForSub1 = factory.getExecutorProvider("customSubscription1");
 		ExecutorProvider executorProviderForSub2 = factory.getExecutorProvider("customSubscription2");
@@ -198,14 +203,19 @@ public class DefaultSubscriberFactoryTests {
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
 
 		// One subscriber with subscription-specific subscriber properties
-		when(mockPubSubConfiguration.getSubscriber("customSubscription1", projectIdProvider.getProjectId())).thenReturn(mockCustomSubscriber1);
-		when(mockCustomSubscriber1.getExecutorThreads()).thenReturn(4);
+		when(mockPubSubConfiguration.getSubscriber("customSubscription1", projectIdProvider.getProjectId()))
+				.thenReturn(mockCustomSubscriber1);
+		when(mockPubSubConfiguration.computeSubscriberExecutorThreads("customSubscription1", projectIdProvider.getProjectId()))
+				.thenReturn(4);
 
 		// Two subscribers with default/global subscriber properties
-		when(mockPubSubConfiguration.getSubscriber("defaultSubscription1", projectIdProvider.getProjectId())).thenReturn(mockDefaultSubscriber1);
+		when(mockPubSubConfiguration.getSubscriber("defaultSubscription1", projectIdProvider.getProjectId()))
+				.thenReturn(mockDefaultSubscriber1);
+		when(mockPubSubConfiguration.computeSubscriberExecutorThreads("defaultSubscription1", projectIdProvider.getProjectId()))
+				.thenReturn(4);
 		when(mockDefaultSubscriber1.isGlobal()).thenReturn(true);
-		when(mockDefaultSubscriber1.getExecutorThreads()).thenReturn(4);
-		when(mockPubSubConfiguration.getSubscriber("defaultSubscription2", projectIdProvider.getProjectId())).thenReturn(mockDefaultSubscriber2);
+		when(mockPubSubConfiguration.getSubscriber("defaultSubscription2", projectIdProvider.getProjectId()))
+				.thenReturn(mockDefaultSubscriber2);
 		when(mockDefaultSubscriber2.isGlobal()).thenReturn(true);
 
 		ExecutorProvider executorProviderForCustom1 = factory.getExecutorProvider("customSubscription1");
@@ -230,11 +240,13 @@ public class DefaultSubscriberFactoryTests {
 
 	@Test
 	public void testCreateThreadPoolTaskScheduler() {
+		GcpProjectIdProvider projectIdProvider = () -> "project";
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
-		when(mockCustomSubscriber1.getExecutorThreads()).thenReturn(6);
+		when(mockPubSubConfiguration.computeSubscriberExecutorThreads("subscription-name", projectIdProvider.getProjectId()))
+				.thenReturn(6);
 
 		ThreadPoolTaskScheduler threadPoolTaskScheduler = factory
-				.createThreadPoolTaskScheduler(mockCustomSubscriber1, "subscription-name");
+				.createThreadPoolTaskScheduler("subscription-name");
 
 		assertThat(
 				threadPoolTaskScheduler.getThreadNamePrefix())


### PR DESCRIPTION
Fixes #605
