### PR TITLE
Disable SI trace instrumentation with Pub/Sub tracing

### DIFF
--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -164,7 +164,7 @@ It's set to `false` by default, but when set to `true`, trace spans will be crea
 # Enable Pub/Sub tracing using this property
 spring.cloud.gcp.trace.pubsub.enabled=true
 
-# You should disable Spring Integration instrumentation by Sleuth as it's unnecessary
+# You should disable Spring Integration instrumentation by Sleuth as it's unnecessary when Pub/Sub tracing is enabled
 spring.sleuth.integration.enabled=false
 ----
 

--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -164,7 +164,7 @@ It's set to `false` by default, but when set to `true`, trace spans will be crea
 # Enable Pub/Sub tracing using this property
 spring.cloud.gcp.trace.pubsub.enabled=true
 
-# You can disable Spring Integration instrumentation by Sleuth as it's unnecessary
+# You should disable Spring Integration instrumentation by Sleuth as it's unnecessary
 spring.sleuth.integration.enabled=false
 ----
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/resources/application.properties
@@ -10,5 +10,5 @@ spring.sleuth.scheduled.enabled=false
 # Enable Pub/Sub tracing using this property
 spring.cloud.gcp.trace.pubsub.enabled=true
 
-# You should disable Spring Integration instrumentation by Sleuth as it's unnecessary
+# You should disable Spring Integration instrumentation by Sleuth as it's unnecessary when Pub/Sub tracing is enabled
 spring.sleuth.integration.enabled=false

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/resources/application.properties
@@ -10,5 +10,5 @@ spring.sleuth.scheduled.enabled=false
 # Enable Pub/Sub tracing using this property
 spring.cloud.gcp.trace.pubsub.enabled=true
 
-# You can disable Spring Integration instrumentation by Sleuth as it's unnecessary
-#spring.sleuth.integration.enabled=false
+# You should disable Spring Integration instrumentation by Sleuth as it's unnecessary
+spring.sleuth.integration.enabled=false

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/test/java/com/example/TraceSampleApplicationIntegrationTests.java
@@ -154,19 +154,11 @@ public class TraceSampleApplicationIntegrationTests {
 					+ ").");
 
 			assertThat(trace.getTraceId()).isEqualTo(uuidString);
-			/* The 25 expected spans are:
-			 *   get /, visit-meet-endpoint, get, get /meet, get, get /meet, get, get /meet,
-			 *   send-message-spring-integration, send, handle, handle, publish, send-message-pub-sub-template, publish,
-			 *   next-message, on-message, next-message, on-message, send, send, handle, handle, handle, handle
-			 *
-			 * Example of a bad run (notice that the last line only has one "send". Two are expected!).
-			 * 	Found trace! 148bcda619bd448ea6a718ca0f662bd2 with 24 spans (
-			 *  [get /, visit-meet-endpoint, get, get /meet, get, get /meet, get, get /meet,
-			 * 	send-message-spring-integration, send, handle, handle, publish, send-message-pub-sub-template, publish,
-			 * 	next-message, on-message, handle, handle, next-message, on-message, send, handle, handle]).
-			 */
-			// TODO: replace with =25 after fixing https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/597
-			assertThat(trace.getSpansCount()).isGreaterThanOrEqualTo(24);
+			// The 16 expected spans are:
+			// get /, visit-meet-endpoint, get, get /meet, get, get /meet, get, get /meet,
+			// send-message-spring-integration, publish, send-message-pub-sub-template, publish,
+			// next-message, on-message, next-message, on-message
+			assertThat(trace.getSpansCount()).isGreaterThanOrEqualTo(16);
 			log.debug("Trace spans match.");
 
 			// verify custom tags
@@ -181,8 +173,6 @@ public class TraceSampleApplicationIntegrationTests {
 							"get",
 							"get /meet",
 							"send-message-spring-integration",
-							"send",
-							"handle",
 							"publish",
 							"send-message-pub-sub-template",
 							"next-message",


### PR DESCRIPTION
There is little value in Spring Integration Sleuth support when you enable Pub/Sub trace instrumentation.

So, the recommended settings are:
```
spring.cloud.gcp.trace.pubsub.enabled=true
spring.sleuth.integration.enabled=false
```

This avoids the flakyness we observe with SI instrumentation.

This PR updates Trace sample to disable Spring Integration instrumentation, when Pub/Sub trace instrumentation is used.
Fixes flaky `TraceSampleApplicationIntegrationTests`.

Fixes: #597.