### PR TITLE
Separates firestore transaction manager into its own auto-configuration

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/FirestoreTransactionManagerAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/FirestoreTransactionManagerAutoConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.firestore;
+
+import com.google.cloud.spring.core.GcpProjectIdProvider;
+import com.google.cloud.spring.data.firestore.mapping.FirestoreClassMapper;
+import com.google.cloud.spring.data.firestore.transaction.ReactiveFirestoreTransactionManager;
+import com.google.firestore.v1.FirestoreGrpc;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Auto-configuration for {@link ReactiveFirestoreTransactionManager}.
+ *
+ * @author Biju Kunjummen
+ * @since 2.0.4
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(ReactiveFirestoreTransactionManager.class)
+@ConditionalOnProperty(value = "spring.cloud.gcp.firestore.enabled", matchIfMissing = true)
+@AutoConfigureBefore(TransactionAutoConfiguration.class)
+public class FirestoreTransactionManagerAutoConfiguration {
+
+	private static final String ROOT_PATH_FORMAT = "projects/%s/databases/(default)/documents";
+
+	private final String firestoreRootPath;
+
+	FirestoreTransactionManagerAutoConfiguration(GcpFirestoreProperties gcpFirestoreProperties,
+			GcpProjectIdProvider projectIdProvider) {
+		String projectId = (gcpFirestoreProperties.getProjectId() != null)
+				? gcpFirestoreProperties.getProjectId()
+				: projectIdProvider.getProjectId();
+
+		this.firestoreRootPath = String.format(ROOT_PATH_FORMAT, projectId);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ReactiveFirestoreTransactionManager firestoreTransactionManager(
+			FirestoreGrpc.FirestoreStub firestoreStub, FirestoreClassMapper classMapper) {
+		return new ReactiveFirestoreTransactionManager(firestoreStub, firestoreRootPath, classMapper);
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
@@ -50,6 +50,7 @@ import org.springframework.context.annotation.Configuration;
  * Provides classes to use with Cloud Firestore.
  *
  * @author Dmitry Solomakha
+ * @author Biju Kunjummen
  *
  * @since 1.2
  */
@@ -59,8 +60,6 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass({ Firestore.class })
 @EnableConfigurationProperties(GcpFirestoreProperties.class)
 public class GcpFirestoreAutoConfiguration {
-
-	private static final String ROOT_PATH_FORMAT = "projects/%s/databases/(default)/documents";
 
 	private static final UserAgentHeaderProvider USER_AGENT_HEADER_PROVIDER =
 			new UserAgentHeaderProvider(GcpFirestoreAutoConfiguration.class);
@@ -77,9 +76,7 @@ public class GcpFirestoreAutoConfiguration {
 			GcpProjectIdProvider projectIdProvider,
 			CredentialsProvider credentialsProvider) throws IOException {
 
-		this.projectId = (gcpFirestoreProperties.getProjectId() != null)
-				? gcpFirestoreProperties.getProjectId()
-				: projectIdProvider.getProjectId();
+		this.projectId = gcpFirestoreProperties.getResolvedProjectId(projectIdProvider);
 
 		if (gcpFirestoreProperties.getEmulator().isEnabled()) {
 			// if the emulator is enabled, create CredentialsProvider for this particular case.
@@ -92,7 +89,7 @@ public class GcpFirestoreAutoConfiguration {
 		}
 
 		this.hostPort = gcpFirestoreProperties.getHostPort();
-		this.firestoreRootPath = String.format(ROOT_PATH_FORMAT, this.projectId);
+		this.firestoreRootPath = gcpFirestoreProperties.getFirestoreRootPath(projectIdProvider);
 	}
 
 	@Bean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
@@ -31,7 +31,6 @@ import com.google.cloud.spring.data.firestore.FirestoreTemplate;
 import com.google.cloud.spring.data.firestore.mapping.FirestoreClassMapper;
 import com.google.cloud.spring.data.firestore.mapping.FirestoreDefaultClassMapper;
 import com.google.cloud.spring.data.firestore.mapping.FirestoreMappingContext;
-import com.google.cloud.spring.data.firestore.transaction.ReactiveFirestoreTransactionManager;
 import com.google.firestore.v1.FirestoreGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -152,14 +151,6 @@ public class GcpFirestoreAutoConfiguration {
 				FirestoreClassMapper classMapper, FirestoreMappingContext firestoreMappingContext) {
 			return new FirestoreTemplate(firestoreStub, GcpFirestoreAutoConfiguration.this.firestoreRootPath,
 					classMapper, firestoreMappingContext);
-		}
-
-		@Bean
-		@ConditionalOnMissingBean
-		public ReactiveFirestoreTransactionManager firestoreTransactionManager(
-				FirestoreGrpc.FirestoreStub firestoreStub, FirestoreClassMapper classMapper) {
-			return new ReactiveFirestoreTransactionManager(firestoreStub,
-					GcpFirestoreAutoConfiguration.this.firestoreRootPath, classMapper);
 		}
 
 		@Bean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreProperties.java
@@ -18,6 +18,7 @@ package com.google.cloud.spring.autoconfigure.firestore;
 
 import com.google.cloud.spring.core.Credentials;
 import com.google.cloud.spring.core.CredentialsSupplier;
+import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.core.GcpScope;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -27,14 +28,17 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * Properties for configuring Cloud Datastore.
  *
  * @author Dmitry Solomakha
- *
+ * @author Biju Kunjummen
  * @since 1.2
  */
 @ConfigurationProperties("spring.cloud.gcp.firestore")
 public class GcpFirestoreProperties implements CredentialsSupplier {
+	private static final String ROOT_PATH_FORMAT = "projects/%s/databases/(default)/documents";
 
-	/** Overrides the GCP OAuth2 credentials specified in the Core module.
-	 * Uses same URL as Datastore*/
+	/**
+	 * Overrides the GCP OAuth2 credentials specified in the Core module.
+	 * Uses same URL as Datastore
+	 */
 	@NestedConfigurationProperty
 	private final Credentials credentials = new Credentials(GcpScope.DATASTORE.getUrl());
 
@@ -57,6 +61,12 @@ public class GcpFirestoreProperties implements CredentialsSupplier {
 		return this.projectId;
 	}
 
+	public String getResolvedProjectId(GcpProjectIdProvider projectIdProvider) {
+		return (getProjectId() != null)
+				? getProjectId()
+				: projectIdProvider.getProjectId();
+	}
+
 	public void setProjectId(String projectId) {
 		this.projectId = projectId;
 	}
@@ -75,6 +85,10 @@ public class GcpFirestoreProperties implements CredentialsSupplier {
 
 	public void setEmulator(FirestoreEmulatorProperties emulator) {
 		this.emulator = emulator;
+	}
+
+	public String getFirestoreRootPath(GcpProjectIdProvider projectIdProvider) {
+		return String.format(ROOT_PATH_FORMAT, this.getResolvedProjectId(projectIdProvider));
 	}
 
 	public static class FirestoreEmulatorProperties {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationIntegrationTests.java
@@ -41,7 +41,8 @@ public class GcpFirestoreEmulatorAutoConfigurationIntegrationTests {
 					.withConfiguration(AutoConfigurations.of(
 							GcpFirestoreEmulatorAutoConfiguration.class,
 							GcpContextAutoConfiguration.class,
-							GcpFirestoreAutoConfiguration.class));
+							GcpFirestoreAutoConfiguration.class,
+							FirestoreTransactionManagerAutoConfiguration.class));
 
 	@BeforeClass
 	public static void checkToRun() {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/FirestoreDocumentationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/FirestoreDocumentationIntegrationTests.java
@@ -24,6 +24,7 @@ import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.WriteResult;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
+import com.google.cloud.spring.autoconfigure.firestore.FirestoreTransactionManagerAutoConfiguration;
 import com.google.cloud.spring.autoconfigure.firestore.GcpFirestoreAutoConfiguration;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -38,12 +39,12 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * @author Dmitry Solomakha
- *
  * @since 1.2
  */
 public class FirestoreDocumentationIntegrationTests {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(GcpContextAutoConfiguration.class,
+					FirestoreTransactionManagerAutoConfiguration.class,
 					GcpFirestoreAutoConfiguration.class));
 
 	@BeforeClass
@@ -114,14 +115,14 @@ class FirestoreExample {
 
 	//tag::read[]
 	User readDocumentToObject() throws ExecutionException, InterruptedException {
-			ApiFuture<DocumentSnapshot> documentFuture =
-					this.firestore.document("users/joe").get();
+		ApiFuture<DocumentSnapshot> documentFuture =
+				this.firestore.document("users/joe").get();
 
-			User user = documentFuture.get().toObject(User.class);
+		User user = documentFuture.get().toObject(User.class);
 
-			LOGGER.info("read: " + user);
+		LOGGER.info("read: " + user);
 
-			return user;
+		return user;
 	}
 	//end::read[]
 }


### PR DESCRIPTION
This PR is a fix for https://github.com/spring-cloud/spring-cloud-gcp/issues/2550 from the old repository location