### PR TITLE
Support new option for customizing MDC field name for traceId and spanId

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -132,8 +132,10 @@ a| This is used to generate fully qualified Cloud Trace ID format: `projects/[PR
 This format is required to correlate trace between Cloud Trace and Cloud Logging.
 
 If `projectId` is not set and cannot be determined, then it'll log `traceId` without the fully qualified format.
-| `includeTraceId` | `true` | Should the `traceId` be included
-| `includeSpanId` | `true` | Should the `spanId` be included
+| `traceIdMDCField` | `traceId` | The MDC field name for retrieving a trace id
+| `spanIdMDCField` | `spanId` | the MDC field name for retrieving a span id
+| `includeTraceId` | `true` | Should the trace id be included
+| `includeSpanId` | `true` | Should the span id be included
 | `includeLevel` | `true` | Should the severity be included
 | `includeThreadName` | `true` | Should the thread name be included
 | `includeMDC` | `true` | Should all MDC properties be included.
@@ -168,6 +170,8 @@ This is an example of such an Logback configuration:
       <layout class="com.google.cloud.spring.logging.StackdriverJsonLayout">
         <projectId>${projectId}</projectId>
 
+        <!--<traceIdMDCField>traceId</traceIdMDCField>-->
+        <!--<spanIdMDCField>spanId</spanIdMDCField>-->
         <!--<includeTraceId>true</includeTraceId>-->
         <!--<includeSpanId>true</includeSpanId>-->
         <!--<includeLevel>true</includeLevel>-->

--- a/spring-cloud-gcp-logging/src/main/resources/com/google/cloud/spring/logging/logback-json-appender.xml
+++ b/spring-cloud-gcp-logging/src/main/resources/com/google/cloud/spring/logging/logback-json-appender.xml
@@ -10,6 +10,8 @@ Stackdriver json-log format provided for import.
             <layout class="com.google.cloud.spring.logging.StackdriverJsonLayout">
                 <projectId>${projectId}</projectId>
 
+                <!--<traceIdMDCField>traceId</traceIdMDCField>-->
+                <!--<spanIdMDCField>spanId</spanIdMDCField>-->
                 <!--<includeTraceId>true</includeTraceId>-->
                 <!--<includeSpanId>true</includeSpanId>-->
                 <!--<includeLevel>true</includeLevel>-->

--- a/spring-cloud-gcp-logging/src/test/resources/logback-test.xml
+++ b/spring-cloud-gcp-logging/src/test/resources/logback-test.xml
@@ -44,12 +44,26 @@
 		</encoder>
 	</appender>
 
+	<appender name="CONSOLE_JSON_CUSTOM_MDC_FIELD" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+			<layout class="com.google.cloud.spring.logging.StackdriverJsonLayout">
+				<projectId>${projectId}</projectId>
+				<traceIdMDCField>trace_id</traceIdMDCField>
+				<spanIdMDCField>span_id</spanIdMDCField>
+			</layout>
+		</encoder>
+	</appender>
+
 	<logger name="StackdriverJsonLayoutServiceCtxLoggerTests" level="WARN">
 		<appender-ref ref="CONSOLE_JSON_SERVICE_CTX"/>
 	</logger>
 
 	<logger name="StackdriverJsonLayoutServiceCtxLoggerTestsMissingClass" level="WARN">
 		<appender-ref ref="CONSOLE_JSON_SERVICE_CTX_MISSING"/>
+	</logger>
+
+	<logger name="StackdriverJsonLayoutCustomMDCFieldTests" level="WARN">
+		<appender-ref ref="CONSOLE_JSON_CUSTOM_MDC_FIELD"/>
 	</logger>
 
 	<statusListener class="ch.qos.logback.core.status.NopStatusListener" />


### PR DESCRIPTION
I will suggestion to support new option for customizing MDC field name for traceId and spanId.
This PR's motivation is supporting easily that use together with the [opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation). The opentelemetry-java-instrumentation store a value to the MDC using [snake case field name(`trace_id` and `span_id`)](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/logger-mdc-instrumentation.md).