### PR TITLE
Spanner sample split fix

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-template-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-template-sample/pom.xml
@@ -50,12 +50,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>2.4.10</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
removing the spring-boot-autoconfigure from spanner-template-sample's pom.xml 