### PR TITLE
update mentions of 2.0.3 in docs to 2.0.4.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ You can check our project website https://spring.io/projects/spring-cloud-gcp[he
 For a deep dive into the project, refer to the Spring Cloud GCP Reference documentation below or the https://googleapis.dev/java/spring-cloud-gcp/latest/index.html[latest Javadocs].
 
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/reference/html/index.html[Spring Cloud GCP Latest]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/2.0.3/reference/html/index.html[Spring Cloud GCP 2.0.3]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/2.0.4/reference/html/index.html[Spring Cloud GCP 2.0.4]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/1.2.x/reference/html/index.html[Spring Cloud GCP 1.2.x]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/1.1.x/single/spring-cloud-gcp.html[Spring Cloud GCP 1.1.x]
 
@@ -71,7 +71,7 @@ This will allow you to not specify versions for any of the Maven dependencies an
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-dependencies</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/docs/src/main/asciidoc/migration-guide-1.x.adoc
+++ b/docs/src/main/asciidoc/migration-guide-1.x.adoc
@@ -42,7 +42,7 @@ To use the newly unbundled libraries, add the `spring-cloud-gcp-dependencies` bi
     <dependency>
       <groupId>com.google.cloud</groupId> <!--2-->
       <artifactId>spring-cloud-gcp-dependencies</artifactId>
-      <version>2.0.3</version>
+      <version>2.0.4</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>


### PR DESCRIPTION
Noticed we have a few mentions of version 2.0.3 in our docs, probably missed when releasing.