### PR TITLE
Keep two versions of createSubscriberStub in DefaultSubscriberFactory

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/pubsub/TracingSubscriberFactory.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/pubsub/TracingSubscriberFactory.java
@@ -48,6 +48,11 @@ final class TracingSubscriberFactory implements SubscriberFactory {
 	}
 
 	@Override
+	public SubscriberStub createSubscriberStub() {
+		return pubSubTracing.subscriberStub(delegate.createSubscriberStub());
+	}
+
+	@Override
 	public SubscriberStub createSubscriberStub(String subscriptionName) {
 		return pubSubTracing.subscriberStub(delegate.createSubscriberStub(subscriptionName));
 	}

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -82,9 +82,8 @@ public class PubSubConfiguration {
 			return this.subscription.get(fullyQualifiedSubscriptionKey);
 		}
 
-		Subscriber subscriberProperties = this.subscription.computeIfAbsent(fullyQualifiedSubscriptionKey,
+		return this.subscription.computeIfAbsent(fullyQualifiedSubscriptionKey,
 				k -> this.globalSubscriber);
-		return subscriberProperties;
 	}
 
 	/**

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -83,9 +83,8 @@ public class PubSubConfiguration {
 			return this.subscription.get(fullyQualifiedSubscriptionKey);
 		}
 
-		Subscriber subscriberProperties = this.subscription.computeIfAbsent(fullyQualifiedSubscriptionKey,
+		return this.subscription.computeIfAbsent(fullyQualifiedSubscriptionKey,
 				k -> this.globalSubscriber);
-		return subscriberProperties;
 	}
 
 	/**

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -84,7 +84,6 @@ public class PubSubConfiguration {
 
 		Subscriber subscriberProperties = this.subscription.computeIfAbsent(fullyQualifiedSubscriptionKey,
 				k -> this.globalSubscriber);
-		subscriberProperties.global = true;
 		return subscriberProperties;
 	}
 
@@ -264,11 +263,6 @@ public class PubSubConfiguration {
 	public static class Subscriber {
 
 		/**
-		 * Custom determines if the configuration is global or the default.
-		 */
-		private boolean global = false;
-
-		/**
 		 * Number of threads used by every subscriber.
 		 */
 		private Integer executorThreads;
@@ -302,10 +296,6 @@ public class PubSubConfiguration {
 		 * Flow control settings for subscriber factory.
 		 */
 		private final FlowControl flowControl = new FlowControl();
-
-		public boolean isGlobal() {
-			return global;
-		}
 
 		public Retry getRetry() {
 			return this.retry;

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -85,7 +85,6 @@ public class PubSubConfiguration {
 
 		Subscriber subscriberProperties = this.subscription.computeIfAbsent(fullyQualifiedSubscriptionKey,
 				k -> this.globalSubscriber);
-		subscriberProperties.global = true;
 		return subscriberProperties;
 	}
 
@@ -263,11 +262,6 @@ public class PubSubConfiguration {
 	 * Subscriber settings.
 	 */
 	public static class Subscriber {
-
-		/**
-		 * Custom determines if the configuration is global or the default.
-		 */
-		private boolean global = false;
 
 		/**
 		 * Number of threads used by every subscriber.

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
@@ -362,8 +362,7 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 	}
 
 	/**
-	 * Creates {@link ExecutorProvider} from provided threadPoolTaskScheduler (either global
-	 * or subscription-specific).
+	 * Creates {@link ExecutorProvider} given a subscription name.
 	 * @param subscriptionName subscription name
 	 * @return executor provider
 	 */
@@ -398,8 +397,8 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 
 	/**
 	 * Returns {@link ThreadPoolTaskScheduler} given a subscription name. If subscription name
-	 * is null or no subscription-specific scheduler for the subscription name is found then
-	 * return a global threadPoolTaskScheduler.
+	 * is null or subscription-specific scheduler for the subscription name is not found then
+	 * return a global threadPoolTaskScheduler, otherwise, return the subscription-specific scheduler.
 	 * @param subscriptionName subscription name
 	 * @return thread pool scheduler
 	 */

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
@@ -389,6 +389,7 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 		String fullyQualifiedName = PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, projectId)
 				.toString();
 		if (this.threadPoolTaskSchedulerMap.containsKey(fullyQualifiedName)) {
+			this.isGlobalScheduler = false;
 			return threadPoolTaskSchedulerMap.get(fullyQualifiedName);
 		}
 		this.isGlobalScheduler = true;

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/SubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/SubscriberFactory.java
@@ -65,6 +65,15 @@ public interface SubscriberFactory {
 			Boolean returnImmediately);
 
 	/**
+	 * Create a {@link SubscriberStub} that is needed to execute {@link PullRequest}s. This
+	 * method will not set subscription-specific settings.
+	 * @return the {@link SubscriberStub} used for executing {@link PullRequest}s.
+	 * @deprecated Use the new {@code createSubscriberStub(subscriptionName)} instead.
+	 */
+	@Deprecated
+	SubscriberStub createSubscriberStub();
+
+	/**
 	 * Create a {@link SubscriberStub} that is needed to execute {@link PullRequest}s.
 	 * @param subscriptionName the subscription name
 	 * @return the {@link SubscriberStub} used for executing {@link PullRequest}s

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/SubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/SubscriberFactory.java
@@ -66,7 +66,7 @@ public interface SubscriberFactory {
 
 	/**
 	 * Create a {@link SubscriberStub} that is needed to execute {@link PullRequest}s. This
-	 * method will not set subscription-specific settings.
+	 * method will only set global settings.
 	 * @return the {@link SubscriberStub} used for executing {@link PullRequest}s.
 	 * @deprecated Use the new {@code createSubscriberStub(subscriptionName)} instead.
 	 */

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
@@ -369,24 +369,6 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testSubscriberMapProperties_isGlobalIfAbsentFromMap() {
-		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
-
-		assertThat(pubSubConfiguration.getSubscription()).doesNotContainKey("subscription-name");
-		assertThat(pubSubConfiguration.getSubscriber("subscription-name", "projectId").isGlobal()).isTrue();
-	}
-
-	@Test
-	public void testSubscriberMapProperties_isNotGlobalIfPresentInMap() {
-		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
-		pubSubConfiguration.getSubscription().put("subscription-name", new PubSubConfiguration.Subscriber());
-
-		assertThat(pubSubConfiguration.getSubscription()).containsKey("subscription-name");
-		assertThat(pubSubConfiguration.getSubscription()).hasSize(1);
-		assertThat(pubSubConfiguration.getSubscriber("subscription-name", "projectId").isGlobal()).isFalse();
-	}
-
-	@Test
 	public void testDefaultPublisherProperties() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Publisher publisher = pubSubConfiguration.getPublisher();

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -324,28 +324,6 @@ public class DefaultSubscriberFactoryTests {
 	}
 
 	@Test
-	public void testIsGlobalScheduler_subscriptionNameIsNull_isGlobal() {
-		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
-		assertThat(factory.isGlobalScheduler(null)).isTrue();
-	}
-
-	@Test
-	public void testIsGlobalScheduler_schedulerNotPresentInMap_isGlobal() {
-		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
-		assertThat(factory.isGlobalScheduler("subscription-name")).isTrue();
-	}
-
-	@Test
-	public void testIsGlobalScheduler_schedulerPresentInMap_isNotGlobal() {
-		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
-		ConcurrentHashMap<String, ThreadPoolTaskScheduler> threadPoolSchedulerMap = new ConcurrentHashMap<>();
-		threadPoolSchedulerMap.put("projects/project/subscriptions/subscription-name", mockScheduler);
-		factory.setThreadPoolTaskSchedulerMap(threadPoolSchedulerMap);
-
-		assertThat(factory.isGlobalScheduler("subscription-name")).isFalse();
-	}
-
-	@Test
 	public void testGetRetrySettings_userProvidedBean() {
 		RetrySettings expectedRetrySettings = RetrySettings.newBuilder()
 				.setTotalTimeout(Duration.ofSeconds(10))

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -324,6 +324,28 @@ public class DefaultSubscriberFactoryTests {
 	}
 
 	@Test
+	public void testIsGlobalScheduler_subscriptionNameIsNull_isGlobal() {
+		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
+		assertThat(factory.isGlobalScheduler(null)).isTrue();
+	}
+
+	@Test
+	public void testIsGlobalScheduler_schedulerNotPresentInMap_isGlobal() {
+		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
+		assertThat(factory.isGlobalScheduler("subscription-name")).isTrue();
+	}
+
+	@Test
+	public void testIsGlobalScheduler_schedulerPresentInMap_isNotGlobal() {
+		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
+		ConcurrentHashMap<String, ThreadPoolTaskScheduler> threadPoolSchedulerMap = new ConcurrentHashMap<>();
+		threadPoolSchedulerMap.put("projects/project/subscriptions/subscription-name", mockScheduler);
+		factory.setThreadPoolTaskSchedulerMap(threadPoolSchedulerMap);
+
+		assertThat(factory.isGlobalScheduler("subscription-name")).isFalse();
+	}
+
+	@Test
 	public void testGetRetrySettings_userProvidedBean() {
 		RetrySettings expectedRetrySettings = RetrySettings.newBuilder()
 				.setTotalTimeout(Duration.ofSeconds(10))

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -91,10 +91,9 @@ public class DefaultSubscriberFactoryTests {
 
 	@Mock
 	private ThreadPoolTaskScheduler mockGlobalScheduler;
+
 	@Mock
 	private HealthTrackerRegistry healthTrackerRegistry;
-	@Mock
-	private ExecutorProvider executorProvider;
 
 	/**
 	 * used to check exception messages and types.

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -194,9 +194,9 @@ public class DefaultSubscriberFactoryTests {
 		factory.setThreadPoolTaskSchedulerMap(threadPoolSchedulerMap);
 		factory.setGlobalScheduler(mockGlobalScheduler);
 
-		ExecutorProvider executorProviderForCustom1 = factory.getExecutorProvider("customSubscription1");
 		ExecutorProvider executorProviderForDefault1 = factory.getExecutorProvider("defaultSubscription1");
 		ExecutorProvider executorProviderForDefault2 = factory.getExecutorProvider("defaultSubscription2");
+		ExecutorProvider executorProviderForCustom1 = factory.getExecutorProvider("customSubscription1");
 
 		// Verify that only two executor providers are created
 		assertThat(executorProviderForCustom1).isNotNull();


### PR DESCRIPTION
Fixes #603

In addition to maintaining backwards compatibility, this PR removes the `global` boolean from PubSubConfiguration which used to determine whether a configuration, specifically the executor threads property, was global or subscription specific. Since it is possible to have a mix of global and subscription-specific properties (as discovered in #605), this boolean wasn't fully accurate.  Now, this is determined through the presence of a scheduler in the thread pool scheduler map.