### PR TITLE
Register subscriber flow control settings as beans

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -25,6 +25,7 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.auth.Credentials;
+import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.pubsub.core.PubSubConfiguration;
 import com.google.cloud.spring.pubsub.support.DefaultSubscriberFactory;
@@ -843,6 +844,22 @@ public class GcpPubSubAutoConfigurationTests {
 					.isEqualTo(expectedGlobalSettings);
 		});
 	}
+
+	@Test
+	public void createSubscriberStub_flowControlSettings_noPropertiesSet() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
+				.withUserConfiguration(TestConfig.class);
+		contextRunner.run(ctx -> {
+			DefaultSubscriberFactory subscriberFactory = ctx
+					.getBean("defaultSubscriberFactory", DefaultSubscriberFactory.class);
+			Subscriber subscriber = subscriberFactory.createSubscriber("subscription-name", (message, consumer) -> {
+			});
+			assertThat(subscriber.getFlowControlSettings())
+					.isEqualTo(Subscriber.Builder.getDefaultFlowControlSettings());
+		});
+	}
+
 
 	static class TestConfig {
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -629,6 +629,7 @@ public class GcpPubSubAutoConfigurationTests {
 			DefaultSubscriberFactory subscriberFactory = ctx
 					.getBean("defaultSubscriberFactory", DefaultSubscriberFactory.class);
 			assertThat(subscriberFactory.getFlowControlSettings("name")).isSameAs(flowControlSettings);
+			assertThat(ctx.containsBean("globalSubscriberFlowControlSettings")).isFalse();
 		});
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spring.autoconfigure.pubsub.it;
 
+import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
@@ -151,6 +152,11 @@ public class PubSubAutoConfigurationIntegrationTests {
 			GcpPubSubProperties gcpPubSubProperties = context.getBean(GcpPubSubProperties.class);
 			PubSubConfiguration.FlowControl flowControl = gcpPubSubProperties
 					.computeSubscriberFlowControlSettings(subscriptionName, projectIdProvider.getProjectId());
+			FlowControlSettings flowControlSettings = FlowControlSettings.newBuilder().setMaxOutstandingElementCount(1L)
+					.setMaxOutstandingRequestBytes(1L)
+					.setLimitExceededBehavior(FlowController.LimitExceededBehavior.Ignore).build();
+			assertThat((FlowControlSettings) context.getBean("subscriberFlowControlSettings-test-sub-2"))
+					.isEqualTo(flowControlSettings);
 			assertThat(flowControl.getMaxOutstandingElementCount()).isEqualTo(1L);
 			assertThat(flowControl.getMaxOutstandingRequestBytes()).isEqualTo(1L);
 			assertThat(flowControl.getLimitExceededBehavior()).isEqualTo(FlowController.LimitExceededBehavior.Ignore);


### PR DESCRIPTION
Part 1 of #671 

This PR registers global and subscription-specific flow control settings as beans in `GcpPubSubAutoConfiguration`. However, note that if a custom bean is provided then the global and subscription-specific beans won't be created.
