### PR TITLE
Expose StackdriverSender.serverResponseTimeoutMs via a config property.

### DIFF
--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -80,7 +80,7 @@ All configurations are optional:
 | `spring.cloud.gcp.trace.max-outbound-size` | Maximum size for outbound messages | No |
 | `spring.cloud.gcp.trace.wait-for-ready` | https://github.com/grpc/grpc/blob/main/doc/wait-for-ready.md[Waits for the channel to be ready] in case of a transient failure | No | `false`
 | `spring.cloud.gcp.trace.messageTimeout` | Timeout in seconds before pending spans will be sent in batches to GCP Cloud Trace. (previously `spring.zipkin.messageTimeout`) | No | 1
-| `spring.cloud.gcp.trace.serverResponseTimeoutMs` | Server response timeout in millis. | No | `5000`
+| `spring.cloud.gcp.trace.server-response-timeout-ms` | Server response timeout in millis. | No | `5000`
 | `spring.cloud.gcp.trace.pubsub.enabled` | (Experimental) Auto-configure Pub/Sub instrumentation for Trace. | No | `false`
 |===
 

--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -80,6 +80,7 @@ All configurations are optional:
 | `spring.cloud.gcp.trace.max-outbound-size` | Maximum size for outbound messages | No |
 | `spring.cloud.gcp.trace.wait-for-ready` | https://github.com/grpc/grpc/blob/main/doc/wait-for-ready.md[Waits for the channel to be ready] in case of a transient failure | No | `false`
 | `spring.cloud.gcp.trace.messageTimeout` | Timeout in seconds before pending spans will be sent in batches to GCP Cloud Trace. (previously `spring.zipkin.messageTimeout`) | No | 1
+| `spring.cloud.gcp.trace.serverResponseTimeoutMs` | Server response timeout in millis. | No | `5000`
 | `spring.cloud.gcp.trace.pubsub.enabled` | (Experimental) Auto-configure Pub/Sub instrumentation for Trace. | No | `false`
 |===
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/GcpTraceProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/GcpTraceProperties.java
@@ -89,7 +89,7 @@ public class GcpTraceProperties implements CredentialsSupplier {
 	/**
 	 * Timeout in seconds for server response when sending traces.
 	 */
-	private Long serverResponseTimeoutMs = 5000L;
+	private Long serverResponseTimeoutMs;
 
 	public String getProjectId() {
 		return this.projectId;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/GcpTraceProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/GcpTraceProperties.java
@@ -87,7 +87,7 @@ public class GcpTraceProperties implements CredentialsSupplier {
 	private int messageTimeout = 1;
 
 	/**
-	 * Timeout in seconds for server response. Ref: https://github.com/spring-cloud/spring-cloud-gcp/issues/1617.
+	 * Timeout in seconds for server response when sending traces.
 	 */
 	private Long serverResponseTimeoutMs = 5000L;
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/GcpTraceProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/GcpTraceProperties.java
@@ -86,6 +86,11 @@ public class GcpTraceProperties implements CredentialsSupplier {
 	 */
 	private int messageTimeout = 1;
 
+	/**
+	 * Timeout in seconds for server response. Ref: https://github.com/spring-cloud/spring-cloud-gcp/issues/1617.
+	 */
+	private Long serverResponseTimeoutMs = 5000L;
+
 	public String getProjectId() {
 		return this.projectId;
 	}
@@ -160,5 +165,13 @@ public class GcpTraceProperties implements CredentialsSupplier {
 
 	public void setMessageTimeout(int messageTimeout) {
 		this.messageTimeout = messageTimeout;
+	}
+
+	public Long getServerResponseTimeoutMs() {
+		return serverResponseTimeoutMs;
+	}
+
+	public void setServerResponseTimeoutMs(Long serverResponseTimeoutMs) {
+		this.serverResponseTimeoutMs = serverResponseTimeoutMs;
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -235,6 +235,7 @@ public class StackdriverTraceAutoConfiguration {
 
 		return StackdriverSender.newBuilder(channel)
 				.projectId(this.finalProjectIdProvider.getProjectId())
+				.serverResponseTimeoutMs(traceProperties.getServerResponseTimeoutMs())
 				.callOptions(callOptions)
 				.build();
 	}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -52,6 +52,7 @@ import zipkin2.reporter.Sender;
 import zipkin2.reporter.brave.ZipkinSpanHandler;
 import zipkin2.reporter.stackdriver.StackdriverEncoder;
 import zipkin2.reporter.stackdriver.StackdriverSender;
+import zipkin2.reporter.stackdriver.StackdriverSender.Builder;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -73,6 +74,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
  * @author Tim Ysewyn
+ * @author Vinesh Prasanna M
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties({ GcpTraceProperties.class })
@@ -233,11 +235,15 @@ public class StackdriverTraceAutoConfiguration {
 			}
 		}
 
-		return StackdriverSender.newBuilder(channel)
+		final Builder builder = StackdriverSender.newBuilder(channel)
 				.projectId(this.finalProjectIdProvider.getProjectId())
-				.serverResponseTimeoutMs(traceProperties.getServerResponseTimeoutMs())
-				.callOptions(callOptions)
-				.build();
+				.callOptions(callOptions);
+
+		if (traceProperties.getServerResponseTimeoutMs() != null) {
+			builder.serverResponseTimeoutMs(traceProperties.getServerResponseTimeoutMs());
+		}
+
+		return builder.build();
 	}
 
 	@Bean

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -137,7 +137,7 @@ public class StackdriverTraceAutoConfigurationTests {
 	@Test
 	public void testServerResponseTimeout() {
 		this.contextRunner
-				.withPropertyValues("spring.cloud.gcp.trace.serverResponseTimeoutMs=1000")
+				.withPropertyValues("spring.cloud.gcp.trace.server-response-timeout-ms=1000")
 				.withBean(
 						StackdriverTraceAutoConfiguration.SPAN_HANDLER_BEAN_NAME,
 						SpanHandler.class,

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -38,11 +38,13 @@ import com.google.devtools.cloudtrace.v2.BatchWriteSpansRequest;
 import com.google.devtools.cloudtrace.v2.Span;
 import com.google.devtools.cloudtrace.v2.TraceServiceGrpc;
 import com.google.protobuf.Empty;
+import io.grpc.CallOptions;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 import zipkin2.Call;
@@ -52,6 +54,7 @@ import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
+import zipkin2.reporter.stackdriver.StackdriverSender;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -78,6 +81,8 @@ import static org.mockito.Mockito.when;
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
  * @author Tim Ysewyn
+ * @author Elena Felder
+ * @author Vinesh Prasanna M
  */
 public class StackdriverTraceAutoConfigurationTests {
 
@@ -104,6 +109,48 @@ public class StackdriverTraceAutoConfigurationTests {
 			assertThat(context.getBean(StackdriverTraceAutoConfiguration.SENDER_BEAN_NAME, Sender.class)).isNotNull();
 			assertThat(context.getBean(ManagedChannel.class)).isNotNull();
 		});
+	}
+
+	@Test
+	public void testDefaultConfig() {
+		this.contextRunner
+				.withBean(
+						StackdriverTraceAutoConfiguration.SPAN_HANDLER_BEAN_NAME,
+						SpanHandler.class,
+						() ->  SpanHandler.NOOP)
+				.run(context -> {
+					assertThat(context.getBean(StackdriverTraceAutoConfiguration.SENDER_BEAN_NAME, Sender.class))
+							.isNotNull()
+							.isInstanceOf(StackdriverSender.class);
+					final StackdriverSender sender =
+							(StackdriverSender) context.getBean(StackdriverTraceAutoConfiguration.SENDER_BEAN_NAME, Sender.class);
+					final CallOptions callOptions = (CallOptions) FieldUtils.readField(sender, "callOptions", true);
+					assertThat(callOptions).isNotNull();
+					assertThat(callOptions.getMaxInboundMessageSize()).isNull();
+					assertThat(callOptions.getMaxOutboundMessageSize()).isNull();
+					assertThat(callOptions.getCompressor()).isNull();
+					assertThat(callOptions.getAuthority()).isNull();
+					assertThat(callOptions.isWaitForReady()).isFalse();
+		});
+	}
+
+	@Test
+	public void testServerResponseTimeout() {
+		this.contextRunner
+				.withPropertyValues("spring.cloud.gcp.trace.serverResponseTimeoutMs=1000")
+				.withBean(
+						StackdriverTraceAutoConfiguration.SPAN_HANDLER_BEAN_NAME,
+						SpanHandler.class,
+						() ->  SpanHandler.NOOP)
+				.run(context -> {
+					assertThat(context.getBean(StackdriverTraceAutoConfiguration.SENDER_BEAN_NAME, Sender.class))
+							.isNotNull()
+							.isInstanceOf(StackdriverSender.class);
+					final StackdriverSender sender =
+							(StackdriverSender) context.getBean(StackdriverTraceAutoConfiguration.SENDER_BEAN_NAME, Sender.class);
+					assertThat(FieldUtils.readField(sender, "serverResponseTimeoutMs", true))
+							.isEqualTo(1000L);
+				});
 	}
 
 	@Test

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -131,6 +131,8 @@ public class StackdriverTraceAutoConfigurationTests {
 					assertThat(callOptions.getCompressor()).isNull();
 					assertThat(callOptions.getAuthority()).isNull();
 					assertThat(callOptions.isWaitForReady()).isFalse();
+					assertThat(FieldUtils.readField(sender, "serverResponseTimeoutMs", true))
+							.isEqualTo(5000L);
 		});
 	}
 


### PR DESCRIPTION
Allows configuring the server response waiting timeout.

This PR addresses  https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/563
See also: https://github.com/spring-cloud/spring-cloud-gcp/issues/1617