### PR TITLE
Register executor provider as a bean

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -60,6 +60,7 @@ import com.google.cloud.spring.pubsub.support.PubSubSubscriptionUtils;
 import com.google.cloud.spring.pubsub.support.PublisherFactory;
 import com.google.cloud.spring.pubsub.support.SubscriberFactory;
 import com.google.cloud.spring.pubsub.support.converter.PubSubMessageConverter;
+import com.google.pubsub.v1.ProjectSubscriptionName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.threeten.bp.Duration;
@@ -108,11 +109,15 @@ public class GcpPubSubAutoConfiguration {
 
 	private final ConcurrentHashMap<String, FlowControlSettings> subscriberFlowControlSettingsMap = new ConcurrentHashMap<>();
 
+	private final ConcurrentHashMap<String, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
+
 	private final ApplicationContext applicationContext;
 
 	private ThreadPoolTaskScheduler globalScheduler;
 
 	private FlowControlSettings globalFlowControlSettings;
+
+	private ExecutorProvider globalExecutorProvider;
 
 	public GcpPubSubAutoConfiguration(GcpPubSubProperties gcpPubSubProperties,
 			GcpProjectIdProvider gcpProjectIdProvider,
@@ -217,14 +222,13 @@ public class GcpPubSubAutoConfiguration {
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(this.finalProjectIdProvider,
 				this.gcpPubSubProperties);
 
-		factory.setThreadPoolTaskSchedulerMap(this.threadPoolTaskSchedulerMap);
-		factory.setGlobalScheduler(this.globalScheduler);
-
 		if (executorProvider.isPresent()) {
 			logger.warn(
 					"The subscriberExecutorProvider bean is being deprecated. Please use application.properties to configure properties");
 			factory.setExecutorProvider(executorProvider.get());
 		}
+		factory.setExecutorProviderMap(this.executorProviderMap);
+		factory.setGlobalExecutorProvider(this.globalExecutorProvider);
 
 		factory.setCredentialsProvider(this.finalCredentialsProvider);
 		factory.setHeaderProvider(this.headerProvider);
@@ -395,13 +399,12 @@ public class GcpPubSubAutoConfiguration {
 	public void registerSubscriberSettings() {
 		GenericApplicationContext context = (GenericApplicationContext) this.applicationContext;
 		registerSubscriberThreadPoolSchedulerBeans(context);
+		registerExecutorProviderBeans(context);
 		registerSubscriberFlowControlSettingsBeans(context);
 	}
 
 	private void registerSubscriberThreadPoolSchedulerBeans(GenericApplicationContext context) {
-		Integer globalExecutorThreads = this.gcpPubSubProperties.getSubscriber().getExecutorThreads();
-		Integer numThreads = globalExecutorThreads != null ? globalExecutorThreads
-				: PubSubConfiguration.DEFAULT_EXECUTOR_THREADS;
+		Integer numThreads = getGlobalExecutorThreads();
 		this.globalScheduler = createAndRegisterSchedulerBean(numThreads, "global-gcp-pubsub-subscriber",
 				"globalPubSubSubscriberThreadPoolScheduler", context);
 		registerSelectiveSchedulerBeans(context);
@@ -422,6 +425,17 @@ public class GcpPubSubAutoConfiguration {
 		createAndRegisterSelectiveFlowControlSettings(context);
 	}
 
+	private void registerExecutorProviderBeans(GenericApplicationContext context) {
+		if (context.containsBean("subscriberExecutorProvider")) {
+			return;
+		}
+		if (this.globalScheduler != null) {
+			this.globalExecutorProvider = createAndRegisterExecutorProvider("globalSubscriberExecutorProvider",
+					this.globalScheduler, context);
+		}
+		createAndRegisterSelectiveExecutorProvider(context);
+	}
+
 	/**
 	 * Creates and registers {@link ThreadPoolTaskScheduler} for subscription-specific
 	 * configurations.
@@ -438,9 +452,7 @@ public class GcpPubSubAutoConfiguration {
 				String beanName = "threadPoolScheduler_" + subscriptionName;
 				ThreadPoolTaskScheduler selectiveScheduler = createAndRegisterSchedulerBean(selectiveExecutorThreads,
 						threadName, beanName, context);
-				String fullyQualifiedName = PubSubSubscriptionUtils
-						.toProjectSubscriptionName(subscriptionName, this.finalProjectIdProvider.getProjectId()).toString();
-				this.threadPoolTaskSchedulerMap.putIfAbsent(fullyQualifiedName, selectiveScheduler);
+				this.threadPoolTaskSchedulerMap.putIfAbsent(subscriptionName, selectiveScheduler);
 			}
 		}
 	}
@@ -481,20 +493,57 @@ public class GcpPubSubAutoConfiguration {
 	private void createAndRegisterSelectiveFlowControlSettings(GenericApplicationContext context) {
 		Map<String, PubSubConfiguration.Subscriber> subscriberMap = this.gcpPubSubProperties.getSubscription();
 		for (Map.Entry<String, PubSubConfiguration.Subscriber> subscription : subscriberMap.entrySet()) {
-			String subscriptionName = subscription.getKey();
+			ProjectSubscriptionName fullyQualifiedName = PubSubSubscriptionUtils
+					.toProjectSubscriptionName(subscription.getKey(), this.finalProjectIdProvider.getProjectId());
+			String subscriptionName = fullyQualifiedName.getSubscription();
 			PubSubConfiguration.FlowControl flowControl = this.gcpPubSubProperties.computeSubscriberFlowControlSettings(
 					subscriptionName,
 					this.finalProjectIdProvider.getProjectId());
 			FlowControlSettings flowControlSettings = buildFlowControlSettings(flowControl);
 			if (flowControlSettings != null && !flowControlSettings.equals(this.globalFlowControlSettings)) {
-				String fullyQualifiedName = PubSubSubscriptionUtils
-						.toProjectSubscriptionName(subscriptionName, this.finalProjectIdProvider.getProjectId()).toString();
-				this.subscriberFlowControlSettingsMap.putIfAbsent(fullyQualifiedName, flowControlSettings);
+				this.subscriberFlowControlSettingsMap.putIfAbsent(fullyQualifiedName.toString(), flowControlSettings);
 				String beanName = "subscriberFlowControlSettings-" + subscriptionName;
 				context.registerBeanDefinition(beanName,
 						BeanDefinitionBuilder.genericBeanDefinition(FlowControlSettings.class, () -> flowControlSettings)
 								.getBeanDefinition());
 			}
 		}
+	}
+
+	private void createAndRegisterSelectiveExecutorProvider(GenericApplicationContext context) {
+		for (Map.Entry<String, ThreadPoolTaskScheduler> schedulerSet : this.threadPoolTaskSchedulerMap.entrySet()) {
+			String subscriptionName = schedulerSet.getKey();
+			String fullyQualifiedName = PubSubSubscriptionUtils
+					.toProjectSubscriptionName(subscriptionName, this.finalProjectIdProvider.getProjectId()).toString();
+			if (!this.executorProviderMap.containsKey(fullyQualifiedName)
+					&& !hasSameGlobalAndSelectiveSettings(subscriptionName)) {
+				ThreadPoolTaskScheduler scheduler = schedulerSet.getValue();
+				ExecutorProvider executorProvider = createAndRegisterExecutorProvider(
+						"subscriberExecutorProvider-" + subscriptionName, scheduler, context);
+				this.executorProviderMap.putIfAbsent(fullyQualifiedName, executorProvider);
+			}
+		}
+	}
+
+	private ExecutorProvider createAndRegisterExecutorProvider(String beanName, ThreadPoolTaskScheduler scheduler,
+			GenericApplicationContext context) {
+		scheduler.initialize();
+		ExecutorProvider executor = FixedExecutorProvider.create(scheduler.getScheduledExecutor());
+		context.registerBeanDefinition(beanName,
+				BeanDefinitionBuilder.genericBeanDefinition(ExecutorProvider.class, () -> executor)
+						.getBeanDefinition());
+		return executor;
+	}
+
+	private boolean hasSameGlobalAndSelectiveSettings(String subscriptionName) {
+		Integer globalNumThreads = getGlobalExecutorThreads();
+		Integer selectiveNumThreads = this.gcpPubSubProperties
+				.getSubscriber(subscriptionName, this.finalProjectIdProvider.getProjectId()).getExecutorThreads();
+		return selectiveNumThreads.equals(globalNumThreads);
+	}
+
+	private Integer getGlobalExecutorThreads() {
+		Integer numThreads = this.gcpPubSubProperties.getSubscriber().getExecutorThreads();
+		return numThreads != null ? numThreads : PubSubConfiguration.DEFAULT_EXECUTOR_THREADS;
 	}
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -25,6 +25,7 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.auth.Credentials;
+import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.pubsub.core.PubSubConfiguration;
 import com.google.cloud.spring.pubsub.support.DefaultSubscriberFactory;
@@ -843,6 +844,22 @@ public class GcpPubSubAutoConfigurationTests {
 					.isEqualTo(expectedGlobalSettings);
 		});
 	}
+
+	@Test
+	public void createSubscriberStub_flowControlSettings_noPropertiesSet() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
+				.withUserConfiguration(TestConfig.class);
+		contextRunner.run(ctx -> {
+			DefaultSubscriberFactory subscriberFactory = ctx
+					.getBean("defaultSubscriberFactory", DefaultSubscriberFactory.class);
+			Subscriber subscriber = subscriberFactory.createSubscriber("subscription-name", (message, consumer) -> {
+			});
+			assertThat(subscriber.getFlowControlSettings())
+					.isEqualTo(Subscriber.Builder.getDefaultFlowControlSettings());
+		});
+	}
+
 
 	static class TestConfig {
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -629,6 +629,7 @@ public class GcpPubSubAutoConfigurationTests {
 			DefaultSubscriberFactory subscriberFactory = ctx
 					.getBean("defaultSubscriberFactory", DefaultSubscriberFactory.class);
 			assertThat(subscriberFactory.getFlowControlSettings("name")).isSameAs(flowControlSettings);
+			assertThat(ctx.containsBean("globalSubscriberFlowControlSettings")).isFalse();
 		});
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -200,7 +200,8 @@ public class GcpPubSubAutoConfigurationTests {
 
 			assertThat(FieldUtils.readField(globalSchedulerBean, "poolSize", true))
 					.isEqualTo(4);
-			assertThat(globalSchedulerBean).isNotNull();
+			assertThat(globalSchedulerBean.getThreadNamePrefix()).isEqualTo("global-gcp-pubsub-subscriber");
+			assertThat(globalSchedulerBean.isDaemon()).isTrue();
 		});
 	}
 
@@ -280,7 +281,10 @@ public class GcpPubSubAutoConfigurationTests {
 			DefaultSubscriberFactory factory = (DefaultSubscriberFactory) ctx.getBean("defaultSubscriberFactory");
 			ExecutorProvider selectiveExecutorProvider = (ExecutorProvider) ctx
 					.getBean("subscriberExecutorProvider-subscription-name");
+			ExecutorProvider globalExecutorProvider = (ExecutorProvider) ctx
+					.getBean("globalSubscriberExecutorProvider");
 
+			assertThat(globalExecutorProvider).isNotNull();
 			assertThat(selectiveExecutorProvider).isNotNull();
 			assertThat(factory.getExecutorProvider("subscription-name")).isSameAs(selectiveExecutorProvider);
 		});
@@ -348,7 +352,7 @@ public class GcpPubSubAutoConfigurationTests {
 		contextRunner.run(ctx -> {
 			DefaultSubscriberFactory factory = (DefaultSubscriberFactory) ctx.getBean("defaultSubscriberFactory");
 
-			// Verify that global thread pool task scheduler is used
+			// Verify that global executor provider is created and used
 			ExecutorProvider globalExecutorProvider = (ExecutorProvider) ctx
 					.getBean("globalSubscriberExecutorProvider");
 			assertThat(ctx.containsBean("subscriberExecutorProvider-subscription-name")).isFalse();

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spring.autoconfigure.pubsub.it;
 
+import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
@@ -151,6 +152,11 @@ public class PubSubAutoConfigurationIntegrationTests {
 			GcpPubSubProperties gcpPubSubProperties = context.getBean(GcpPubSubProperties.class);
 			PubSubConfiguration.FlowControl flowControl = gcpPubSubProperties
 					.computeSubscriberFlowControlSettings(subscriptionName, projectIdProvider.getProjectId());
+			FlowControlSettings flowControlSettings = FlowControlSettings.newBuilder().setMaxOutstandingElementCount(1L)
+					.setMaxOutstandingRequestBytes(1L)
+					.setLimitExceededBehavior(FlowController.LimitExceededBehavior.Ignore).build();
+			assertThat((FlowControlSettings) context.getBean("subscriberFlowControlSettings-test-sub-2"))
+					.isEqualTo(flowControlSettings);
 			assertThat(flowControl.getMaxOutstandingElementCount()).isEqualTo(1L);
 			assertThat(flowControl.getMaxOutstandingRequestBytes()).isEqualTo(1L);
 			assertThat(flowControl.getLimitExceededBehavior()).isEqualTo(FlowController.LimitExceededBehavior.Ignore);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -116,6 +116,8 @@ public class PubSubAutoConfigurationIntegrationTests {
 					.isNotNull();
 			assertThat((ExecutorProvider) context.getBean("subscriberExecutorProvider-test-sub-1"))
 					.isNotNull();
+			assertThat((ExecutorProvider) context.getBean("globalSubscriberExecutorProvider"))
+					.isNotNull();
 			assertThat(gcpPubSubProperties.getSubscriber().getRetryableCodes())
 					.isEqualTo(new Code[] { Code.INTERNAL });
 
@@ -174,6 +176,8 @@ public class PubSubAutoConfigurationIntegrationTests {
 			assertThat((ThreadPoolTaskScheduler) context.getBean("globalPubSubSubscriberThreadPoolScheduler"))
 					.isNotNull();
 			assertThat((ExecutorProvider) context.getBean("subscriberExecutorProvider-test-sub-2"))
+					.isNotNull();
+			assertThat((ExecutorProvider) context.getBean("globalSubscriberExecutorProvider"))
 					.isNotNull();
 
 			pubSubAdmin.deleteSubscription(subscriptionName);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -18,6 +18,7 @@ package com.google.cloud.spring.autoconfigure.pubsub.it;
 
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
+import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
 import com.google.cloud.spring.autoconfigure.pubsub.GcpPubSubAutoConfiguration;
@@ -113,6 +114,8 @@ public class PubSubAutoConfigurationIntegrationTests {
 			assertThat(scheduler.isDaemon()).isTrue();
 			assertThat((ThreadPoolTaskScheduler) context.getBean("globalPubSubSubscriberThreadPoolScheduler"))
 					.isNotNull();
+			assertThat((ExecutorProvider) context.getBean("subscriberExecutorProvider-test-sub-1"))
+					.isNotNull();
 			assertThat(gcpPubSubProperties.getSubscriber().getRetryableCodes())
 					.isEqualTo(new Code[] { Code.INTERNAL });
 
@@ -169,6 +172,8 @@ public class PubSubAutoConfigurationIntegrationTests {
 			assertThat(scheduler.getThreadNamePrefix()).isEqualTo("gcp-pubsub-subscriber-test-sub-2");
 			assertThat(scheduler.isDaemon()).isTrue();
 			assertThat((ThreadPoolTaskScheduler) context.getBean("globalPubSubSubscriberThreadPoolScheduler"))
+					.isNotNull();
+			assertThat((ExecutorProvider) context.getBean("subscriberExecutorProvider-test-sub-2"))
 					.isNotNull();
 
 			pubSubAdmin.deleteSubscription(subscriptionName);

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubTestBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubTestBinder.java
@@ -43,7 +43,6 @@ import org.springframework.cloud.stream.binder.AbstractTestBinder;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
  * Tests the binder for Pub/Sub.
@@ -92,8 +91,6 @@ public class PubSubTestBinder extends AbstractTestBinder<PubSubMessageChannelBin
 		}
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		DefaultSubscriberFactory subscriberFactory = new DefaultSubscriberFactory(projectIdProvider, pubSubConfiguration);
-		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-		subscriberFactory.setGlobalScheduler(scheduler);
 		subscriberFactory.setChannelProvider(transportChannelProvider);
 		subscriberFactory.setCredentialsProvider(NoCredentialsProvider.create());
 

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
@@ -89,7 +89,7 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 
 	private FlowControlSettings globalFlowControlSettings;
 
-	private ConcurrentHashMap<String, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
+	private ConcurrentMap<String, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
 
 	private ExecutorProvider globalExecutorProvider;
 
@@ -542,7 +542,7 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 	}
 
 	public void setExecutorProviderMap(
-			ConcurrentHashMap<String, ExecutorProvider> executorProviderMap) {
+			ConcurrentMap<String, ExecutorProvider> executorProviderMap) {
 		this.executorProviderMap = executorProviderMap;
 	}
 

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
@@ -17,7 +17,6 @@
 package com.google.cloud.spring.pubsub.support;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
@@ -552,10 +551,6 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 
 	public ExecutorProvider getGlobalExecutorProvider() {
 		return this.globalExecutorProvider;
-	}
-
-	public Map<String, ExecutorProvider> getExecutorProviderMap() {
-		return this.executorProviderMap;
 	}
 
 	public void setFlowControlSettingsMap(ConcurrentMap<String, FlowControlSettings> flowControlSettingsMap) {

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -186,7 +186,7 @@ public class DefaultSubscriberFactoryTests {
 		factory.setExecutorProviderMap(executorProviderMap);
 
 		assertThat(factory
-				.getExecutorProvider("subscription-name")).isEqualTo(mockExecutorProvider);
+				.getExecutorProvider("subscription-name")).isSameAs(mockExecutorProvider);
 	}
 
 	@Test
@@ -200,7 +200,7 @@ public class DefaultSubscriberFactoryTests {
 
 		assertThat(factory
 				.getExecutorProvider("projects/project1/subscriptions/subscription-name"))
-						.isEqualTo(mockGlobalExecutorProvider);
+						.isSameAs(mockGlobalExecutorProvider);
 	}
 
 	@Test
@@ -208,7 +208,7 @@ public class DefaultSubscriberFactoryTests {
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 		factory.setExecutorProvider(mockGlobalExecutorProvider);
 		assertThat(factory
-				.getExecutorProvider("subscription-name")).isEqualTo(mockGlobalExecutorProvider);
+				.getExecutorProvider("subscription-name")).isSameAs(mockGlobalExecutorProvider);
 	}
 
 	@Test

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -48,8 +48,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.threeten.bp.Duration;
 
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -72,6 +70,9 @@ public class DefaultSubscriberFactoryTests {
 	private ExecutorProvider mockExecutorProvider;
 
 	@Mock
+	private ExecutorProvider mockGlobalExecutorProvider;
+
+	@Mock
 	private TransportChannel mockTransportChannel;
 
 	@Mock
@@ -85,12 +86,6 @@ public class DefaultSubscriberFactoryTests {
 
 	@Mock
 	private PubSubConfiguration.Subscriber mockSubscriber;
-
-	@Mock
-	private ThreadPoolTaskScheduler mockScheduler;
-
-	@Mock
-	private ThreadPoolTaskScheduler mockGlobalScheduler;
 
 	@Mock
 	private HealthTrackerRegistry healthTrackerRegistry;
@@ -178,170 +173,42 @@ public class DefaultSubscriberFactoryTests {
 	public void testGetExecutorProvider_userProvidedBean() {
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 		factory.setExecutorProvider(mockExecutorProvider);
-
 		assertThat(factory.getExecutorProvider("name"))
 				.isSameAs(mockExecutorProvider);
 	}
 
 	@Test
-	public void testGetExecutorProvider_allSubscribersWithDefaultConfig_oneCreated() {
-		GcpProjectIdProvider projectIdProvider = () -> "project";
-		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
-		factory.setGlobalScheduler(mockGlobalScheduler);
-
-		ExecutorProvider executorProviderForSub1 = factory.getExecutorProvider("defaultSubscription1");
-		ExecutorProvider executorProviderForSub2 = factory.getExecutorProvider("defaultSubscription2");
-
-		// Verify that only global executor provider is created
-		assertThat(executorProviderForSub1).isNotNull();
-		assertThat(executorProviderForSub2).isNotNull();
-		assertThat(factory.getExecutorProviderMap()).isEmpty();
-		assertThat(factory.getDefaultExecutorProvider()).isNotNull();
-	}
-
-	@Test
-	public void testGetExecutorProvider_allSubscribersWithCustomConfigs_manyCreated() {
-		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
-		ConcurrentHashMap<String, ThreadPoolTaskScheduler> threadPoolSchedulerMap = new ConcurrentHashMap<>();
-		threadPoolSchedulerMap.put("projects/project/subscriptions/customSubscription1", mockScheduler);
-		threadPoolSchedulerMap.put("projects/project/subscriptions/customSubscription2", mockScheduler);
-		factory.setThreadPoolTaskSchedulerMap(threadPoolSchedulerMap);
-
-		ExecutorProvider executorProviderForSub1 = factory.getExecutorProvider("customSubscription1");
-		ExecutorProvider executorProviderForSub2 = factory.getExecutorProvider("customSubscription2");
-
-		// Verify that two executor providers are created
-		assertThat(executorProviderForSub1).isNotNull();
-		assertThat(executorProviderForSub2).isNotNull();
-		assertThat(factory.getExecutorProviderMap()).hasSize(2);
-	}
-
-	@Test
-	public void testGetExecutorProvider_subscribersWithDefaultAndCustomConfigs() {
-		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
-		ConcurrentHashMap<String, ThreadPoolTaskScheduler> threadPoolSchedulerMap = new ConcurrentHashMap<>();
-		threadPoolSchedulerMap.put("projects/project/subscriptions/customSubscription1", mockScheduler);
-		factory.setThreadPoolTaskSchedulerMap(threadPoolSchedulerMap);
-		factory.setGlobalScheduler(mockGlobalScheduler);
-
-		ExecutorProvider executorProviderForDefault1 = factory.getExecutorProvider("defaultSubscription1");
-		ExecutorProvider executorProviderForDefault2 = factory.getExecutorProvider("defaultSubscription2");
-		ExecutorProvider executorProviderForCustom1 = factory.getExecutorProvider("customSubscription1");
-
-		// Verify that one subscription-specific and a global executor provider are created.
-		assertThat(executorProviderForCustom1).isNotNull();
-		assertThat(executorProviderForDefault1).isNotNull();
-		assertThat(executorProviderForDefault2).isNotNull();
-		assertThat(factory.getExecutorProviderMap()).hasSize(1);
-		assertThat(factory.getDefaultExecutorProvider()).isNotNull();
-	}
-
-	@Test
-	public void testGetExecutorProvider_schedulerNotPresent_isNull() {
+	public void testGetExecutorProvider_presentInMap() {
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
-		ExecutorProvider executorProvider = factory.getExecutorProvider("subscription-name");
+		ConcurrentHashMap<String, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
+		executorProviderMap.put("projects/project/subscriptions/subscription-name", mockExecutorProvider);
+		factory.setExecutorProviderMap(executorProviderMap);
 
-		assertThat(factory.fetchThreadPoolTaskScheduler("subscription-name")).isNull();
-		assertThat(executorProvider).isNull();
+		assertThat(factory
+				.getExecutorProvider("subscription-name")).isEqualTo(mockExecutorProvider);
 	}
 
 	@Test
-	public void testBuildSubscriberStubSettings_executorProvider_pickUserProvidedBean() throws IOException {
-		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", new PubSubConfiguration());
-		factory.setExecutorProvider(mockExecutorProvider);
-
-		SubscriberStubSettings subscriberStubSettings = factory.buildGlobalSubscriberStubSettings();
-
-		assertThat(subscriberStubSettings.getBackgroundExecutorProvider()).isEqualTo(mockExecutorProvider);
-	}
-
-	@Test
-	public void testBuildSubscriberStubSettings_executorProvider_pickGlobalConfiguration() throws IOException {
-		GcpProjectIdProvider projectIdProvider = () -> "project";
-		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
-		factory.setGlobalScheduler(mockGlobalScheduler);
-
-		SubscriberStubSettings subscriberStubSettings = factory.buildGlobalSubscriberStubSettings();
-		ExecutorProvider executorProvider = subscriberStubSettings.getBackgroundExecutorProvider();
-
-		// Verify that only global executor provider is created
-		assertThat(executorProvider).isNotNull();
-		assertThat(factory.getDefaultExecutorProvider()).isNotNull();
-	}
-
-	@Test
-	public void testFetchThreadPoolTaskScheduler_presentInMap() {
+	public void testGetExecutorProvider_fullyQualifiedNameNotInMap_pickGlobal() {
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
-		ConcurrentHashMap<String, ThreadPoolTaskScheduler> threadPoolSchedulerMap = new ConcurrentHashMap<>();
-		threadPoolSchedulerMap.put("projects/project/subscriptions/subscription-name", mockScheduler);
-		factory.setThreadPoolTaskSchedulerMap(threadPoolSchedulerMap);
-		when(mockScheduler.getThreadNamePrefix()).thenReturn("my-thread-name");
-		when(mockScheduler.getPoolSize()).thenReturn(2);
-		when(mockScheduler.isDaemon()).thenReturn(true);
+		ConcurrentHashMap<String, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
+		executorProviderMap.put("projects/project/subscriptions/subscription-name", mockExecutorProvider);
+		factory.setExecutorProviderMap(executorProviderMap);
+		factory.setExecutorProvider(mockGlobalExecutorProvider);
 
-		ThreadPoolTaskScheduler threadPoolTaskScheduler = factory
-				.fetchThreadPoolTaskScheduler("subscription-name");
-
-		assertThat(
-				threadPoolTaskScheduler.getThreadNamePrefix())
-						.isEqualTo("my-thread-name");
-		assertThat(
-				threadPoolTaskScheduler.getPoolSize())
-						.isEqualTo(2);
-		assertThat(
-				threadPoolTaskScheduler.isDaemon())
-						.isTrue();
+		assertThat(factory
+				.getExecutorProvider("projects/project1/subscriptions/subscription-name"))
+						.isEqualTo(mockGlobalExecutorProvider);
 	}
 
 	@Test
-	public void testFetchThreadPoolTaskScheduler_fullyQualifiedNameNotInMap_pickGlobal() {
+	public void testGetExecutorProvider_notPresentInMap_pickGlobal() {
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
-
-		ConcurrentHashMap<String, ThreadPoolTaskScheduler> threadPoolSchedulerMap = new ConcurrentHashMap<>();
-		threadPoolSchedulerMap.put("projects/project/subscriptions/subscription-name", mockScheduler);
-		factory.setThreadPoolTaskSchedulerMap(threadPoolSchedulerMap);
-		factory.setGlobalScheduler(mockGlobalScheduler);
-		when(mockGlobalScheduler.getThreadNamePrefix()).thenReturn("global-thread-name");
-		when(mockGlobalScheduler.getPoolSize()).thenReturn(2);
-		when(mockGlobalScheduler.isDaemon()).thenReturn(true);
-
-		ThreadPoolTaskScheduler threadPoolTaskScheduler = factory
-				.fetchThreadPoolTaskScheduler("projects/project1/subscriptions/subscription-name");
-
-		assertThat(
-				threadPoolTaskScheduler.getThreadNamePrefix())
-						.isEqualTo("global-thread-name");
-		assertThat(
-				threadPoolTaskScheduler.getPoolSize())
-						.isEqualTo(2);
-		assertThat(
-				threadPoolTaskScheduler.isDaemon())
-						.isTrue();
-	}
-
-	@Test
-	public void testFetchThreadPoolTaskScheduler_notPresentInMap_pickGlobal() {
-		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
-
-		factory.setGlobalScheduler(mockGlobalScheduler);
-		when(mockGlobalScheduler.getThreadNamePrefix()).thenReturn("my-thread-name");
-		when(mockGlobalScheduler.getPoolSize()).thenReturn(2);
-		when(mockGlobalScheduler.isDaemon()).thenReturn(true);
-
-		ThreadPoolTaskScheduler threadPoolTaskScheduler = factory
-				.fetchThreadPoolTaskScheduler("subscription-name");
-
-		assertThat(
-				threadPoolTaskScheduler.getThreadNamePrefix())
-						.isEqualTo("my-thread-name");
-		assertThat(
-				threadPoolTaskScheduler.getPoolSize())
-						.isEqualTo(2);
-		assertThat(
-				threadPoolTaskScheduler.isDaemon())
-						.isTrue();
+		factory.setExecutorProvider(mockGlobalExecutorProvider);
+		assertThat(factory
+				.getExecutorProvider("subscription-name")).isEqualTo(mockGlobalExecutorProvider);
 	}
 
 	@Test
@@ -468,7 +335,6 @@ public class DefaultSubscriberFactoryTests {
 		GcpProjectIdProvider projectIdProvider = () -> "project";
 		DefaultSubscriberFactory factory = new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
 		factory.setCredentialsProvider(this.credentialsProvider);
-		factory.setGlobalScheduler(mockScheduler);
 		FlowControlSettings flowControlSettings = FlowControlSettings.newBuilder()
 				.setLimitExceededBehavior(FlowController.LimitExceededBehavior.Ignore).build();
 		factory.setGlobalFlowControlSettings(flowControlSettings);


### PR DESCRIPTION
Part 2 of #671

If a custom executor provider bean is provided then global or selective executor provider beans are not created/registered.