### PR TITLE
Register subscriber retry settings as beans

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -251,6 +251,8 @@ public class GcpPubSubAutoConfiguration {
 					"The subscriberRetrySettings bean is being deprecated. Please use application.properties to configure properties");
 			factory.setSubscriberStubRetrySettings(retrySettings.getIfAvailable());
 		}
+		factory.setRetrySettingsMap(this.subscriberRetrySettingsMap);
+		factory.setGlobalRetrySettings(this.globalRetrySettings);
 		if (this.gcpPubSubProperties.getSubscriber().getRetryableCodes() != null) {
 			factory.setRetryableCodes(gcpPubSubProperties.getSubscriber().getRetryableCodes());
 		}
@@ -556,8 +558,7 @@ public class GcpPubSubAutoConfiguration {
 	private void createAndRegisterSelectiveRetrySettings(GenericApplicationContext context) {
 		Map<String, PubSubConfiguration.Subscriber> subscriberMap = this.gcpPubSubProperties.getSubscription();
 		for (Map.Entry<String, PubSubConfiguration.Subscriber> subscription : subscriberMap.entrySet()) {
-			ProjectSubscriptionName fullyQualifiedName = PubSubSubscriptionUtils
-					.toProjectSubscriptionName(subscription.getKey(), this.finalProjectIdProvider.getProjectId());
+			ProjectSubscriptionName fullyQualifiedName = getFullSubscriptionName(subscription.getKey());
 			String subscriptionName = fullyQualifiedName.getSubscription();
 			PubSubConfiguration.Retry retry = this.gcpPubSubProperties.computeSubscriberRetrySettings(
 					subscriptionName,

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -778,7 +778,6 @@ public class GcpPubSubAutoConfigurationTests {
 				.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
 				.withPropertyValues(
 						"spring.cloud.gcp.pubsub.subscriber.retry.total-timeout-seconds=10",
-						"spring.cloud.gcp.pubsub.subscription.subscription-name.retry.total-timeout-seconds=1",
 						"spring.cloud.gcp.pubsub.subscription.subscription-name.retry.initial-retry-delay-seconds=2",
 						"spring.cloud.gcp.pubsub.subscription.subscription-name.retry.retry-delay-multiplier=3",
 						"spring.cloud.gcp.pubsub.subscription.subscription-name.retry.max-retry-delay-seconds=4",
@@ -794,7 +793,7 @@ public class GcpPubSubAutoConfigurationTests {
 			GcpProjectIdProvider projectIdProvider = ctx.getBean(GcpProjectIdProvider.class);
 			PubSubConfiguration.Retry retry = gcpPubSubProperties
 					.computeSubscriberRetrySettings("subscription-name", projectIdProvider.getProjectId());
-			assertThat(retry.getTotalTimeoutSeconds()).isEqualTo(1L);
+			assertThat(retry.getTotalTimeoutSeconds()).isEqualTo(10L);
 			assertThat(retry.getInitialRetryDelaySeconds()).isEqualTo(2L);
 			assertThat(retry.getRetryDelayMultiplier()).isEqualTo(3);
 			assertThat(retry.getMaxRetryDelaySeconds()).isEqualTo(4L);
@@ -807,7 +806,7 @@ public class GcpPubSubAutoConfigurationTests {
 			DefaultSubscriberFactory subscriberFactory = ctx
 					.getBean("defaultSubscriberFactory", DefaultSubscriberFactory.class);
 			RetrySettings expectedRetrySettingsForSubscriptionName = RetrySettings.newBuilder()
-					.setTotalTimeout(Duration.ofSeconds(1L))
+					.setTotalTimeout(Duration.ofSeconds(10L))
 					.setInitialRetryDelay(Duration.ofSeconds(2L))
 					.setRetryDelayMultiplier(3)
 					.setMaxRetryDelay(Duration.ofSeconds(4L))

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -188,7 +188,6 @@ public class GcpPubSubAutoConfigurationTests {
 		});
 	}
 
-
 	@Test
 	public void threadPoolScheduler_noConfigurationSet_globalCreated() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -485,8 +484,7 @@ public class GcpPubSubAutoConfigurationTests {
 						"spring.cloud.gcp.pubsub.subscriber.max-ack-extension-period=5",
 						"spring.cloud.gcp.pubsub.subscriber.parallel-pull-count=10",
 						"spring.cloud.gcp.pubsub.subscriber.pull-endpoint=other-endpoint",
-						"spring.cloud.gcp.pubsub.subscription.subscription-name.executor-threads=4"
-						)
+						"spring.cloud.gcp.pubsub.subscription.subscription-name.executor-threads=4")
 				.withUserConfiguration(TestConfig.class);
 
 		contextRunner.run(ctx -> {
@@ -774,7 +772,6 @@ public class GcpPubSubAutoConfigurationTests {
 		});
 	}
 
-
 	@Test
 	public void retrySettings_subsetOfProperties_pickGlobalWhenSelectiveNotSpecified() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -909,7 +906,8 @@ public class GcpPubSubAutoConfigurationTests {
 					.setMaxOutstandingElementCount(11L)
 					.setMaxOutstandingRequestBytes(12L)
 					.setLimitExceededBehavior(FlowController.LimitExceededBehavior.Ignore).build();
-			assertThat(subscriberFactory.getFlowControlSettings("subscription-name")).isEqualTo(expectedFlowControlForSubscriptionName);
+			assertThat(subscriberFactory.getFlowControlSettings("subscription-name"))
+					.isEqualTo(expectedFlowControlForSubscriptionName);
 			assertThat(ctx.getBean("subscriberFlowControlSettings-subscription-name", FlowControlSettings.class))
 					.isEqualTo(expectedFlowControlForSubscriptionName);
 		});

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -18,8 +18,8 @@ package com.google.cloud.spring.autoconfigure.pubsub.it;
 
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
-import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
 import com.google.cloud.spring.autoconfigure.pubsub.GcpPubSubAutoConfiguration;

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
@@ -19,7 +19,6 @@ package com.google.cloud.spring.pubsub.support;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Consumer;
 
 import com.google.api.core.ApiClock;
 import com.google.api.gax.batching.FlowControlSettings;
@@ -488,14 +487,6 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 			return this.flowControlSettingsMap.get(fullyQualifiedName);
 		}
 		return this.globalFlowControlSettings;
-	}
-
-	private <T> boolean ifSet(T property, Consumer<T> consumer) {
-		if (property != null) {
-			consumer.accept(property);
-			return true;
-		}
-		return false;
 	}
 
 	Duration getMaxAckExtensionPeriod(String subscriptionName) {


### PR DESCRIPTION
Part 3 for #638

This PR registers global and subscription-specific retry settings as beans in GcpPubSubAutoConfiguration. However, note that if a custom bean is provided then the global and subscription-specific beans won't be created.