### PR TITLE
Bring in brave tests locally to bypass assertj errors.

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/PropagationSetterTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/PropagationSetterTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// Copied from: https://github.com/openzipkin/brave/blob/master/brave-tests/src/main/java/brave/test/propagation/PropagationSetterTest.java
 // Brought this class internally as temporary fix
 // for assertj related test errors to unblock other upgrades.
 public abstract class PropagationSetterTest<R> {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/PropagationSetterTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/PropagationSetterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.trace.pubsub;
+
+import brave.propagation.Propagation;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Brought this class internally as temporary fix
+// for assertj related test errors to unblock other upgrades.
+public abstract class PropagationSetterTest<R> {
+	protected final Propagation<String> propagation = Propagation.B3_STRING;
+
+	protected abstract R request();
+
+	protected abstract Propagation.Setter<R, String> setter();
+
+	protected abstract Iterable<String> read(R request, String key);
+
+	@Test
+	public void set() {
+		setter().put(request(), "X-B3-TraceId", "48485a3953bb6124");
+
+		assertThat(read(request(), "X-B3-TraceId"))
+				.containsExactly("48485a3953bb6124");
+	}
+
+	@Test
+	public void set128() {
+		setter().put(request(), "X-B3-TraceId", "463ac35c9f6413ad48485a3953bb6124");
+
+		assertThat(read(request(), "X-B3-TraceId"))
+				.containsExactly("463ac35c9f6413ad48485a3953bb6124");
+	}
+
+	@Test
+	public void setTwoKeys() {
+		setter().put(request(), "X-B3-TraceId", "463ac35c9f6413ad48485a3953bb6124");
+		setter().put(request(), "X-B3-SpanId", "48485a3953bb6124");
+
+		assertThat(read(request(), "X-B3-TraceId"))
+				.containsExactly("463ac35c9f6413ad48485a3953bb6124");
+		assertThat(read(request(), "X-B3-SpanId"))
+				.containsExactly("48485a3953bb6124");
+	}
+
+	@Test
+	public void reset() {
+		setter().put(request(), "X-B3-TraceId", "48485a3953bb6124");
+		setter().put(request(), "X-B3-TraceId", "463ac35c9f6413ad");
+
+		assertThat(read(request(), "X-B3-TraceId"))
+				.containsExactly("463ac35c9f6413ad");
+	}
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/PubSubConsumerRequestSetterTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/PubSubConsumerRequestSetterTest.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import brave.propagation.Propagation;
-import brave.test.propagation.PropagationSetterTest;
 import com.google.pubsub.v1.PubsubMessage;
 
 public class PubSubConsumerRequestSetterTest extends PropagationSetterTest<PubSubConsumerRequest> {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/PubSubProducerRequestSetterTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/PubSubProducerRequestSetterTest.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import brave.propagation.Propagation;
-import brave.test.propagation.PropagationSetterTest;
 import com.google.pubsub.v1.PubsubMessage;
 
 public class PubSubProducerRequestSetterTest extends PropagationSetterTest<PubSubProducerRequest> {


### PR DESCRIPTION
This is to **temporarily** fix and unblock for upgrading purposes. Fix unit test failures:
```
Error:    PubSubConsumerRequestSetterTest>PropagationSetterTest.reset:59 » NoSuchMethod ...
Error:    PubSubConsumerRequestSetterTest>PropagationSetterTest.set:34 » NoSuchMethod or...
Error:    PubSubConsumerRequestSetterTest>PropagationSetterTest.set128:41 » NoSuchMethod
Error:    PubSubConsumerRequestSetterTest>PropagationSetterTest.setTwoKeys:49 » NoSuchMethod
Error:    PubSubProducerRequestSetterTest>PropagationSetterTest.reset:59 » NoSuchMethod ...
Error:    PubSubProducerRequestSetterTest>PropagationSetterTest.set:34 » NoSuchMethod or...
Error:    PubSubProducerRequestSetterTest>PropagationSetterTest.set128:41 » NoSuchMethod
Error:    PubSubProducerRequestSetterTest>PropagationSetterTest.setTwoKeys:49 » NoSuchMethod
```
These fails are triggered by transitive `assertj` dependency upgrade (3.18.1 to 3.21.0) from `brave`
```
[INFO] com.google.cloud:spring-cloud-gcp-autoconfigure:jar:3.0.0-SNAPSHOT
[INFO] \- io.zipkin.brave:brave-tests:jar:5.13.2:test
[INFO]    \- org.assertj:assertj-core:jar:3.21.0:test

```
