### PR TITLE
Add subscription-specific settings for retryableCodes

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -243,10 +243,6 @@ public class GcpPubSubAutoConfiguration {
 					"The subscriberRetrySettings bean is being deprecated. Please use application.properties to configure properties");
 			factory.setSubscriberStubRetrySettings(retrySettings.getIfAvailable());
 		}
-		if (this.gcpPubSubProperties.getSubscriber().getRetryableCodes() != null) {
-			factory.setRetryableCodes(gcpPubSubProperties.getSubscriber().getRetryableCodes());
-		}
-
 		healthTrackerRegistry.ifAvailable(factory::setHealthTrackerRegistry);
 
 		return factory;

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -183,13 +183,14 @@ public class GcpPubSubAutoConfigurationTests {
 			GcpProjectIdProvider projectIdProvider = ctx.getBean(GcpProjectIdProvider.class);
 			DefaultSubscriberFactory defaultSubscriberFactory = ctx.getBean("defaultSubscriberFactory",
 					DefaultSubscriberFactory.class);
+			Code[] expectedRetryableCodes = new Code[] { Code.UNKNOWN, Code.ABORTED, Code.UNAVAILABLE, Code.INTERNAL };
 
 			assertThat(properties.getSubscriber().getRetryableCodes())
-					.isEqualTo(new Code[] { Code.UNKNOWN, Code.ABORTED, Code.UNAVAILABLE, Code.INTERNAL });
+					.isEqualTo(expectedRetryableCodes);
 			assertThat(properties.computeRetryableCodes("subscription-name", projectIdProvider.getProjectId()))
-					.isEqualTo(new Code[] { Code.UNKNOWN, Code.ABORTED, Code.UNAVAILABLE, Code.INTERNAL });
+					.isEqualTo(expectedRetryableCodes);
 			assertThat(defaultSubscriberFactory.getRetryableCodes("subscription-name"))
-					.isEqualTo(new Code[] { Code.UNKNOWN, Code.ABORTED, Code.UNAVAILABLE, Code.INTERNAL });
+					.isEqualTo(expectedRetryableCodes);
 		});
 	}
 
@@ -207,6 +208,7 @@ public class GcpPubSubAutoConfigurationTests {
 					DefaultSubscriberFactory.class);
 			assertThat(defaultSubscriberFactory.getRetryableCodes("subscription-name"))
 					.isEqualTo(new Code[] { Code.UNKNOWN, Code.ABORTED, Code.UNAVAILABLE, Code.INTERNAL });
+			assertThat(defaultSubscriberFactory.getRetryableCodes("other")).isNull();
 		});
 	}
 
@@ -225,6 +227,7 @@ public class GcpPubSubAutoConfigurationTests {
 					DefaultSubscriberFactory.class);
 			assertThat(defaultSubscriberFactory.getRetryableCodes("subscription-name"))
 					.isEqualTo(new Code[] { Code.UNKNOWN, Code.ABORTED, Code.UNAVAILABLE });
+			assertThat(defaultSubscriberFactory.getRetryableCodes("other")).isEqualTo(new Code[] { Code.INTERNAL });
 		});
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -122,6 +122,7 @@ public class GcpPubSubAutoConfigurationTests {
 			DefaultSubscriberFactory defaultSubscriberFactory = ctx.getBean("defaultSubscriberFactory", DefaultSubscriberFactory.class);
 			assertThat(FieldUtils.readField(defaultSubscriberFactory, "retryableCodes", true))
 					.isNull();
+			assertThat(defaultSubscriberFactory.getRetryableCodes("subscription-name")).isNull();
 		});
 	}
 
@@ -133,9 +134,15 @@ public class GcpPubSubAutoConfigurationTests {
 				.withPropertyValues("spring.cloud.gcp.pubsub.subscriber.retryableCodes=");
 
 		contextRunner.run(ctx -> {
+			GcpPubSubProperties properties = ctx.getBean(GcpPubSubProperties.class);
+			GcpProjectIdProvider projectIdProvider = ctx.getBean(GcpProjectIdProvider.class);
+			DefaultSubscriberFactory defaultSubscriberFactory = ctx.getBean("defaultSubscriberFactory",
+					DefaultSubscriberFactory.class);
 
-			DefaultSubscriberFactory defaultSubscriberFactory = ctx.getBean("defaultSubscriberFactory", DefaultSubscriberFactory.class);
-			assertThat(FieldUtils.readField(defaultSubscriberFactory, "retryableCodes", true))
+			assertThat(properties.getSubscriber().getRetryableCodes()).isEqualTo(new Code[] {});
+			assertThat(properties.computeRetryableCodes("subscription-name", projectIdProvider.getProjectId()))
+					.isEqualTo(new Code[] {});
+			assertThat(defaultSubscriberFactory.getRetryableCodes("subscription-name"))
 					.isEqualTo(new Code[] {});
 		});
 	}
@@ -148,9 +155,16 @@ public class GcpPubSubAutoConfigurationTests {
 				.withPropertyValues("spring.cloud.gcp.pubsub.subscriber.retryableCodes=INTERNAL");
 
 		contextRunner.run(ctx -> {
+			GcpPubSubProperties properties = ctx.getBean(GcpPubSubProperties.class);
+			GcpProjectIdProvider projectIdProvider = ctx.getBean(GcpProjectIdProvider.class);
+			DefaultSubscriberFactory defaultSubscriberFactory = ctx.getBean("defaultSubscriberFactory",
+					DefaultSubscriberFactory.class);
 
-			DefaultSubscriberFactory defaultSubscriberFactory = ctx.getBean("defaultSubscriberFactory", DefaultSubscriberFactory.class);
-			assertThat(FieldUtils.readField(defaultSubscriberFactory, "retryableCodes", true))
+			assertThat(properties.getSubscriber().getRetryableCodes())
+					.isEqualTo(new Code[] { Code.INTERNAL });
+			assertThat(properties.computeRetryableCodes("subscription-name", projectIdProvider.getProjectId()))
+					.isEqualTo(new Code[] { Code.INTERNAL });
+			assertThat(defaultSubscriberFactory.getRetryableCodes("subscription-name"))
 					.isEqualTo(new Code[] { Code.INTERNAL });
 		});
 	}
@@ -160,13 +174,74 @@ public class GcpPubSubAutoConfigurationTests {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 				.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
 				.withUserConfiguration(TestConfig.class)
-				.withPropertyValues("spring.cloud.gcp.pubsub.subscriber.retryableCodes=UNKNOWN,ABORTED,UNAVAILABLE,INTERNAL");
+				.withPropertyValues(
+						"spring.cloud.gcp.pubsub.subscriber.retryableCodes=UNKNOWN,ABORTED,UNAVAILABLE,INTERNAL");
+
+		contextRunner.run(ctx -> {
+			GcpPubSubProperties properties = ctx.getBean(GcpPubSubProperties.class);
+			GcpProjectIdProvider projectIdProvider = ctx.getBean(GcpProjectIdProvider.class);
+			DefaultSubscriberFactory defaultSubscriberFactory = ctx.getBean("defaultSubscriberFactory",
+					DefaultSubscriberFactory.class);
+
+			assertThat(properties.getSubscriber().getRetryableCodes())
+					.isEqualTo(new Code[] { Code.UNKNOWN, Code.ABORTED, Code.UNAVAILABLE, Code.INTERNAL });
+			assertThat(properties.computeRetryableCodes("subscription-name", projectIdProvider.getProjectId()))
+					.isEqualTo(new Code[] { Code.UNKNOWN, Code.ABORTED, Code.UNAVAILABLE, Code.INTERNAL });
+			assertThat(defaultSubscriberFactory.getRetryableCodes("subscription-name"))
+					.isEqualTo(new Code[] { Code.UNKNOWN, Code.ABORTED, Code.UNAVAILABLE, Code.INTERNAL });
+		});
+	}
+
+	@Test
+	public void retryableCodes_selectiveConfigurationSet() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
+				.withUserConfiguration(TestConfig.class)
+				.withPropertyValues(
+						"spring.cloud.gcp.pubsub.subscription.subscription-name.retryableCodes=UNKNOWN,ABORTED,UNAVAILABLE,INTERNAL");
 
 		contextRunner.run(ctx -> {
 
-			DefaultSubscriberFactory defaultSubscriberFactory = ctx.getBean("defaultSubscriberFactory", DefaultSubscriberFactory.class);
-			assertThat(FieldUtils.readField(defaultSubscriberFactory, "retryableCodes", true))
+			DefaultSubscriberFactory defaultSubscriberFactory = ctx.getBean("defaultSubscriberFactory",
+					DefaultSubscriberFactory.class);
+			assertThat(defaultSubscriberFactory.getRetryableCodes("subscription-name"))
 					.isEqualTo(new Code[] { Code.UNKNOWN, Code.ABORTED, Code.UNAVAILABLE, Code.INTERNAL });
+		});
+	}
+
+	@Test
+	public void retryableCodes_globalAndSelectiveConfigurationSet_selectiveTakesPrecedence() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
+				.withUserConfiguration(TestConfig.class)
+				.withPropertyValues(
+						"spring.cloud.gcp.pubsub.subscriber.retryableCodes=INTERNAL",
+						"spring.cloud.gcp.pubsub.subscription.subscription-name.retryableCodes=UNKNOWN,ABORTED,UNAVAILABLE");
+
+		contextRunner.run(ctx -> {
+
+			DefaultSubscriberFactory defaultSubscriberFactory = ctx.getBean("defaultSubscriberFactory",
+					DefaultSubscriberFactory.class);
+			assertThat(defaultSubscriberFactory.getRetryableCodes("subscription-name"))
+					.isEqualTo(new Code[] { Code.UNKNOWN, Code.ABORTED, Code.UNAVAILABLE });
+		});
+	}
+
+	@Test
+	public void retryableCodes_globalAndDifferentSelectiveConfigurationSet_pickGlobal() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(GcpPubSubAutoConfiguration.class))
+				.withUserConfiguration(TestConfig.class)
+				.withPropertyValues(
+						"spring.cloud.gcp.pubsub.subscriber.retryableCodes=INTERNAL",
+						"spring.cloud.gcp.pubsub.subscription.subscription-name.pull-counts=2");
+
+		contextRunner.run(ctx -> {
+
+			DefaultSubscriberFactory defaultSubscriberFactory = ctx.getBean("defaultSubscriberFactory",
+					DefaultSubscriberFactory.class);
+			assertThat(defaultSubscriberFactory.getRetryableCodes("subscription-name"))
+					.isEqualTo(new Code[] { Code.INTERNAL });
 		});
 	}
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -57,6 +57,7 @@ public class PubSubAutoConfigurationIntegrationTests {
 					"spring.cloud.gcp.pubsub.subscription.test-sub-1.retry.initial-rpc-timeout-seconds=600",
 					"spring.cloud.gcp.pubsub.subscription.test-sub-1.retry.rpc-timeout-multiplier=1",
 					"spring.cloud.gcp.pubsub.subscription.test-sub-1.retry.max-rpc-timeout-seconds=600",
+					"spring.cloud.gcp.pubsub.subscription.test-sub-1.retryableCodes=INTERNAL",
 					"spring.cloud.gcp.pubsub.subscription.test-sub-2.executor-threads=1",
 					"spring.cloud.gcp.pubsub.subscription.test-sub-2.max-ack-extension-period=0",
 					"spring.cloud.gcp.pubsub.subscription.test-sub-2.parallel-pull-count=1",
@@ -113,7 +114,7 @@ public class PubSubAutoConfigurationIntegrationTests {
 			assertThat(scheduler.isDaemon()).isTrue();
 			assertThat((ThreadPoolTaskScheduler) context.getBean("globalPubSubSubscriberThreadPoolScheduler"))
 					.isNotNull();
-			assertThat(gcpPubSubProperties.getSubscriber().getRetryableCodes())
+			assertThat(gcpPubSubProperties.computeRetryableCodes("test-sub-1", projectIdProvider.getProjectId()))
 					.isEqualTo(new Code[] { Code.INTERNAL });
 
 			pubSubAdmin.deleteSubscription(subscriptionName);

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -133,6 +133,21 @@ public class PubSubConfiguration {
 		return parallelPullCount != null ? parallelPullCount : this.globalSubscriber.getParallelPullCount();
 	}
 
+
+	/**
+	 * Retrieves collection of retryable codes from configuration. The subscription-specific
+	 * property takes precedence if both global and subscription-specific properties are set.
+	 * If subscription-specific configuration is not set then the global configuration is
+	 * picked.
+	 * @param subscriptionName subscription name
+	 * @param projectId project id
+	 * @return retryable codes
+	 */
+	public Code[] computeRetryableCodes(String subscriptionName, String projectId) {
+		Code[] retryableCodes = getSubscriber(subscriptionName, projectId).getRetryableCodes();
+		return retryableCodes != null ? retryableCodes : this.globalSubscriber.getRetryableCodes();
+	}
+
 	/**
 	 * Computes the max extension period. The subscription-specific property takes precedence
 	 * if both global and subscription-specific properties are set. If none are set then the

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
@@ -364,9 +364,10 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 			applyGlobalRetrySettings(subscriberStubSettings);
 		}
 
-		if (this.retryableCodes != null) {
-			subscriberStubSettings.pullSettings().setRetryableCodes(
-					this.retryableCodes);
+		Code[] codes = this.retryableCodes != null ? this.retryableCodes
+				: this.pubSubConfiguration.getSubscriber().getRetryableCodes();
+		if (codes != null) {
+			subscriberStubSettings.pullSettings().setRetryableCodes(codes);
 		}
 
 		return subscriberStubSettings.build();
@@ -405,9 +406,9 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 			subscriberStubSettings.pullSettings().setRetrySettings(retrySettings);
 		}
 
-		if (this.retryableCodes != null) {
-			subscriberStubSettings.pullSettings().setRetryableCodes(
-					this.retryableCodes);
+		Code[] codes = getRetryableCodes(subscriptionName);
+		if (codes != null) {
+			subscriberStubSettings.pullSettings().setRetryableCodes(codes);
 		}
 
 		return subscriberStubSettings.build();
@@ -432,12 +433,6 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 		if (this.apiClock != null) {
 			subscriberStubSettings.setClock(this.apiClock);
 		}
-
-		if (this.retryableCodes != null) {
-			subscriberStubSettings.pullSettings().setRetryableCodes(
-					this.retryableCodes);
-		}
-
 		return subscriberStubSettings;
 	}
 
@@ -600,6 +595,13 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 			return this.pullEndpoint;
 		}
 		return this.pubSubConfiguration.computePullEndpoint(subscriptionName, projectId);
+	}
+
+	public Code[] getRetryableCodes(String subscriptionName) {
+		if (this.retryableCodes != null) {
+			return this.retryableCodes;
+		}
+		return this.pubSubConfiguration.computeRetryableCodes(subscriptionName, projectId);
 	}
 
 	public void setThreadPoolTaskSchedulerMap(

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
@@ -344,6 +344,29 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
+	public void testComputeRetryableCodes_returnsGlobal() {
+		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
+		PubSubConfiguration.Subscriber globalSubscriber = pubSubConfiguration.getSubscriber();
+
+		globalSubscriber.setRetryableCodes(new Code[] { Code.INTERNAL });
+
+		assertThat(pubSubConfiguration.computeRetryableCodes("subscription-name", "projectId"))
+				.containsExactly(Code.INTERNAL);
+	}
+
+	@Test
+	public void testComputeRetryableCodes_returnCustom() {
+		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
+		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
+		subscriber.setRetryableCodes(new Code[] { Code.INTERNAL });
+		pubSubConfiguration.getSubscription().put("projects/projectId/subscriptions/subscription-name",
+				subscriber);
+
+		assertThat(pubSubConfiguration.computeRetryableCodes("subscription-name", "projectId"))
+				.containsExactly(Code.INTERNAL);
+	}
+
+	@Test
 	public void testSubscriberMapProperties_defaultOrGlobal_addToMap() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 


### PR DESCRIPTION
We recently introduced support for overriding retryableCodes in pull settings (#670). However, this property can only be set globally. This PR enables subscription-specific configuration. 
The `retryableCodes` configuration can be set in the following manner:

Global
```
spring.cloud.gcp.pubsub.subscriber.retryableCodes=INTERNAL, ABORTED
```
Subscription-specific
```
spring.cloud.gcp.pubsub.subscription.mySubscription.retryableCodes=INTERNAL, ABORTED
```