### PR TITLE
Unblock integration tests: fix to respect `-Dit.pubsub-emulator` settings

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubEmulator.java
@@ -34,7 +34,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -51,7 +53,7 @@ import static org.junit.Assume.assumeTrue;
  *
  * @since 1.1
  */
-public class PubSubEmulator extends ExternalResource {
+public class PubSubEmulator implements BeforeAllCallback, AfterAllCallback {
 
 	private static final Path EMULATOR_CONFIG_DIR = Paths.get(System.getProperty("user.home")).resolve(
 			Paths.get(".config", "gcloud", "emulators", "pubsub"));
@@ -88,7 +90,7 @@ public class PubSubEmulator extends ExternalResource {
 	 * @throws InterruptedException if process is stopped while waiting to retry.
 	 */
 	@Override
-	protected void before() throws IOException, InterruptedException {
+	public void beforeAll(ExtensionContext extensionContext) throws IOException, InterruptedException {
 
 		assumeTrue("PubSubEmulator rule disabled. Please enable with -Dit.pubsub-emulator.", this.enableTests);
 
@@ -105,7 +107,7 @@ public class PubSubEmulator extends ExternalResource {
 	 * Any failure is logged and ignored since it's not critical to the tests' operation.
 	 */
 	@Override
-	protected void after() {
+	public void afterAll(ExtensionContext extensionContext) throws Exception {
 		findAndDestroyEmulator();
 	}
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
@@ -18,10 +18,10 @@ package com.google.cloud.spring.stream.binder.pubsub;
 
 import com.google.cloud.spring.stream.binder.pubsub.properties.PubSubConsumerProperties;
 import com.google.cloud.spring.stream.binder.pubsub.properties.PubSubProducerProperties;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.cloud.stream.binder.AbstractBinderTests;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
@@ -37,14 +37,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Elena Felder
  * @author Artem Bilan
  */
-public class PubSubMessageChannelBinderEmulatorIntegrationTests extends
+@ExtendWith(PubSubEmulator.class)
+class PubSubMessageChannelBinderEmulatorIntegrationTests extends
 		AbstractBinderTests<PubSubTestBinder, ExtendedConsumerProperties<PubSubConsumerProperties>,
 				ExtendedProducerProperties<PubSubProducerProperties>> {
 
 	/**
 	 * The emulator instance, shared across tests.
 	 */
-	@ClassRule
 	public static PubSubEmulator emulator = new PubSubEmulator();
 
 	@Override
@@ -78,8 +78,8 @@ public class PubSubMessageChannelBinderEmulatorIntegrationTests extends
 	}
 
 	@Test
-	@Ignore("Looks like there is no Kryo support in SCSt")
-	public void testSendPojoReceivePojoKryoWithStreamListener() {
+	@Disabled("Looks like there is no Kryo support in SCSt")
+	void testSendPojoReceivePojoKryoWithStreamListener() {
 		// Dummy assertion to appease SonarCloud.
 		assertThat(emulator.getEmulatorHostPort()).isNotNull();
 	}


### PR DESCRIPTION
This is PR brings `PubSubMessageChannelBinderEmulatorIntegrationTests` to junit 5 to avoid mis-match with the abstract test class it inherit from. This test has been running with all modules's integration tests regardless of the `-Dit.pubsub-emulator` settings.
This is step 1 of #707 and should unblock and reveal any further issues on it test for other modules.