### PR TITLE
update spring boot version for samples

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.3</version>
+		<version>2.6.0-RC1</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
Update sample pom to match spring boot 2.6. 
This should fix `ConfigSampleApplicationIntegrationTests` and `TraceSampleApplicationIntegrationTests`.

Need to merge and rerun tests after #708 gets merged in.