### PR TITLE
spring cloud gcp data spanner tests migration(JUnit4 to JUnit5)

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
@@ -33,8 +33,8 @@ import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentProperty;
 import com.google.cloud.spring.data.spanner.core.mapping.Table;
 import com.google.spanner.v1.TypeCode;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,14 +46,14 @@ import static org.mockito.Mockito.when;
  *
  * @author Chengyuan Zhao
  */
-public class SpannerSchemaUtilsTests {
+ class SpannerSchemaUtilsTests {
 
 	private SpannerSchemaUtils spannerSchemaUtils;
 
 	private SpannerEntityProcessor spannerEntityProcessor;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	 void setUp() {
 		SpannerMappingContext spannerMappingContext = new SpannerMappingContext();
 		this.spannerSchemaUtils = new SpannerSchemaUtils(spannerMappingContext,
 				new ConverterAwareMappingSpannerEntityProcessor(spannerMappingContext),
@@ -63,14 +63,14 @@ public class SpannerSchemaUtilsTests {
 	}
 
 	@Test
-	public void getDropDdlTest() {
+	 void getDropDdlTest() {
 		assertThat(this.spannerSchemaUtils.getDropTableDdlString(TestEntity.class))
 				.isEqualTo("DROP TABLE custom_test_table");
 	}
 
 	@Test
 
-	public void getCreateDdlTest() {
+	 void getCreateDdlTest() {
 		String ddlResult = "CREATE TABLE custom_test_table ( id STRING(MAX) , id3 INT64 , "
 				+ "id_2 STRING(MAX) , bytes2 BYTES(MAX) , custom_col FLOAT64 NOT NULL , "
 				+ "other STRING(333) , "
@@ -86,77 +86,77 @@ public class SpannerSchemaUtilsTests {
 	}
 
 	@Test
-	public void createDdlString() {
+	 void createDdlString() {
 		assertColumnDdl(String.class, null,
 				"id", null, OptionalLong.empty(),
 				"id STRING(MAX)");
 	}
 
 	@Test
-	public void createDdlStringCustomLength() {
+	 void createDdlStringCustomLength() {
 		assertColumnDdl(String.class, null,
 				"id", null, OptionalLong.of(333L),
 				"id STRING(333)");
 	}
 
 	@Test
-	public void createDdlBytesMax() {
+	 void createDdlBytesMax() {
 		assertColumnDdl(ByteArray.class, null,
 				"bytes", null, OptionalLong.empty(),
 				"bytes BYTES(MAX)");
 	}
 
 	@Test
-	public void createDdlBytesCustomLength() {
+	 void createDdlBytesCustomLength() {
 		assertColumnDdl(ByteArray.class, null,
 				"bytes", null, OptionalLong.of(333L),
 				"bytes BYTES(333)");
 	}
 
 	@Test
-	public void ddlForListOfByteArray() {
+	 void ddlForListOfByteArray() {
 		assertColumnDdl(List.class, ByteArray.class,
 				"bytesList", null, OptionalLong.of(111L),
 				"bytesList ARRAY<BYTES(111)>");
 	}
 
 	@Test
-	public void ddlForDoubleArray() {
+	 void ddlForDoubleArray() {
 		assertColumnDdl(double[].class, null,
 				"doubles", null, OptionalLong.of(111L),
 				"doubles ARRAY<FLOAT64>");
 	}
 
 	@Test
-	public void ddlForNumericList() {
+	 void ddlForNumericList() {
 		assertColumnDdl(List.class, BigDecimal.class,
 				"bigDecimals", null, OptionalLong.empty(),
 				"bigDecimals ARRAY<NUMERIC>");
 	}
 
 	@Test
-	public void createDdlNumeric() {
+	 void createDdlNumeric() {
 		assertColumnDdl(BigDecimal.class, null,
 				"bigDecimal", null, OptionalLong.empty(),
 				"bigDecimal NUMERIC");
 	}
 
 	@Test
-	public void ddlForListOfListOfIntegers() {
+	 void ddlForListOfListOfIntegers() {
 		assertColumnDdl(List.class, Integer.class,
 				"integerList", null, OptionalLong.empty(),
 				"integerList ARRAY<INT64>");
 	}
 
 	@Test
-	public void ddlForListOfListOfDoubles() {
+	 void ddlForListOfListOfDoubles() {
 		assertColumnDdl(List.class, Double.class,
 				"doubleList", null, OptionalLong.empty(),
 				"doubleList ARRAY<FLOAT64>");
 	}
 
 	@Test
-	public void createDdlForJson() {
+	 void createDdlForJson() {
 		assertColumnDdl(JsonColumn.class, null,
 				"jsonCol", Type.Code.JSON, OptionalLong.empty(),
 				"jsonCol JSON");
@@ -183,7 +183,7 @@ public class SpannerSchemaUtilsTests {
 	}
 
 	@Test
-	public void getIdTest() {
+	 void getIdTest() {
 		TestEntity t = new TestEntity();
 		t.id = "aaa";
 		t.embeddedColumns = new EmbeddedColumns();
@@ -200,7 +200,7 @@ public class SpannerSchemaUtilsTests {
 	}
 
 	@Test
-	public void getCreateDdlHierarchyTest() {
+	 void getCreateDdlHierarchyTest() {
 		List<String> createStrings = this.spannerSchemaUtils
 				.getCreateTableDdlStringsForInterleavedHierarchy(ParentEntity.class);
 		assertThat(createStrings).containsExactly(
@@ -217,7 +217,7 @@ public class SpannerSchemaUtilsTests {
 	}
 
 	@Test
-	public void getDropDdlHierarchyTest() {
+	 void getDropDdlHierarchyTest() {
 		List<String> dropStrings = this.spannerSchemaUtils
 				.getDropTableDdlStringsForInterleavedHierarchy(ParentEntity.class);
 		assertThat(dropStrings).containsExactly(

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
@@ -46,14 +46,14 @@ import static org.mockito.Mockito.when;
  *
  * @author Chengyuan Zhao
  */
- class SpannerSchemaUtilsTests {
+class SpannerSchemaUtilsTests {
 
 	private SpannerSchemaUtils spannerSchemaUtils;
 
 	private SpannerEntityProcessor spannerEntityProcessor;
 
 	@BeforeEach
-	 void setUp() {
+	void setUp() {
 		SpannerMappingContext spannerMappingContext = new SpannerMappingContext();
 		this.spannerSchemaUtils = new SpannerSchemaUtils(spannerMappingContext,
 				new ConverterAwareMappingSpannerEntityProcessor(spannerMappingContext),
@@ -63,14 +63,13 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void getDropDdlTest() {
+	void getDropDdlTest() {
 		assertThat(this.spannerSchemaUtils.getDropTableDdlString(TestEntity.class))
 				.isEqualTo("DROP TABLE custom_test_table");
 	}
 
 	@Test
-
-	 void getCreateDdlTest() {
+	void getCreateDdlTest() {
 		String ddlResult = "CREATE TABLE custom_test_table ( id STRING(MAX) , id3 INT64 , "
 				+ "id_2 STRING(MAX) , bytes2 BYTES(MAX) , custom_col FLOAT64 NOT NULL , "
 				+ "other STRING(333) , "
@@ -86,84 +85,83 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void createDdlString() {
+	void createDdlString() {
 		assertColumnDdl(String.class, null,
 				"id", null, OptionalLong.empty(),
 				"id STRING(MAX)");
 	}
 
 	@Test
-	 void createDdlStringCustomLength() {
+	void createDdlStringCustomLength() {
 		assertColumnDdl(String.class, null,
 				"id", null, OptionalLong.of(333L),
 				"id STRING(333)");
 	}
 
 	@Test
-	 void createDdlBytesMax() {
+	void createDdlBytesMax() {
 		assertColumnDdl(ByteArray.class, null,
 				"bytes", null, OptionalLong.empty(),
 				"bytes BYTES(MAX)");
 	}
 
 	@Test
-	 void createDdlBytesCustomLength() {
+	void createDdlBytesCustomLength() {
 		assertColumnDdl(ByteArray.class, null,
 				"bytes", null, OptionalLong.of(333L),
 				"bytes BYTES(333)");
 	}
 
 	@Test
-	 void ddlForListOfByteArray() {
+	void ddlForListOfByteArray() {
 		assertColumnDdl(List.class, ByteArray.class,
 				"bytesList", null, OptionalLong.of(111L),
 				"bytesList ARRAY<BYTES(111)>");
 	}
 
 	@Test
-	 void ddlForDoubleArray() {
+	void ddlForDoubleArray() {
 		assertColumnDdl(double[].class, null,
 				"doubles", null, OptionalLong.of(111L),
 				"doubles ARRAY<FLOAT64>");
 	}
 
 	@Test
-	 void ddlForNumericList() {
+	void ddlForNumericList() {
 		assertColumnDdl(List.class, BigDecimal.class,
 				"bigDecimals", null, OptionalLong.empty(),
 				"bigDecimals ARRAY<NUMERIC>");
 	}
 
 	@Test
-	 void createDdlNumeric() {
+	void createDdlNumeric() {
 		assertColumnDdl(BigDecimal.class, null,
 				"bigDecimal", null, OptionalLong.empty(),
 				"bigDecimal NUMERIC");
 	}
 
 	@Test
-	 void ddlForListOfListOfIntegers() {
+	void ddlForListOfListOfIntegers() {
 		assertColumnDdl(List.class, Integer.class,
 				"integerList", null, OptionalLong.empty(),
 				"integerList ARRAY<INT64>");
 	}
 
 	@Test
-	 void ddlForListOfListOfDoubles() {
+	void ddlForListOfListOfDoubles() {
 		assertColumnDdl(List.class, Double.class,
 				"doubleList", null, OptionalLong.empty(),
 				"doubleList ARRAY<FLOAT64>");
 	}
 
 	@Test
-	 void createDdlForJson() {
+	void createDdlForJson() {
 		assertColumnDdl(JsonColumn.class, null,
 				"jsonCol", Type.Code.JSON, OptionalLong.empty(),
 				"jsonCol JSON");
 	}
 
-	private void assertColumnDdl(Class clazz, Class innerClazz, String name, Type.Code code,
-			OptionalLong length, String expectedDDL) {
+	private void assertColumnDdl(Class clazz, Class innerClazz, String name, Type.Code code, OptionalLong length, String expectedDDL) {
 		SpannerPersistentProperty spannerPersistentProperty = mock(SpannerPersistentProperty.class);
 
 		// @formatter:off
@@ -179,11 +177,11 @@ import static org.mockito.Mockito.when;
 		assertThat(
 				this.spannerSchemaUtils.getColumnDdlString(
 						spannerPersistentProperty, this.spannerEntityProcessor))
-								.isEqualTo(expectedDDL);
+				.isEqualTo(expectedDDL);
 	}
 
 	@Test
-	 void getIdTest() {
+	void getIdTest() {
 		TestEntity t = new TestEntity();
 		t.id = "aaa";
 		t.embeddedColumns = new EmbeddedColumns();
@@ -200,7 +198,7 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void getCreateDdlHierarchyTest() {
+	void getCreateDdlHierarchyTest() {
 		List<String> createStrings = this.spannerSchemaUtils
 				.getCreateTableDdlStringsForInterleavedHierarchy(ParentEntity.class);
 		assertThat(createStrings).containsExactly(
@@ -217,7 +215,7 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void getDropDdlHierarchyTest() {
+	void getDropDdlHierarchyTest() {
 		List<String> dropStrings = this.spannerSchemaUtils
 				.getDropTableDdlStringsForInterleavedHierarchy(ParentEntity.class);
 		assertThat(dropStrings).containsExactly(

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
  * @author Chengyuan Zhao
  * @author Balint Pato
  */
- class ConverterAwareMappingSpannerEntityProcessorTests {
+class ConverterAwareMappingSpannerEntityProcessorTests {
 
 	private static final Offset<Double> DELTA = Offset.offset(0.00001);
 
@@ -97,13 +97,13 @@ import static org.mockito.Mockito.when;
 	};
 
 	@BeforeEach
-	 void setUp() {
+	void setUp() {
 		this.spannerEntityProcessor = new ConverterAwareMappingSpannerEntityProcessor(
 				new SpannerMappingContext());
 	}
 
 	@Test
-	 void customTimeConverter() {
+	void customTimeConverter() {
 		ConverterAwareMappingSpannerEntityProcessor processorWithCustomConverters =
 				new ConverterAwareMappingSpannerEntityProcessor(new SpannerMappingContext(),
 						Collections.singletonList(LOCAL_DATE_TIME_WRITE_CONVERTER),
@@ -130,7 +130,7 @@ import static org.mockito.Mockito.when;
 
 
 	@Test
-	 void canConvertDefaultTypesNoCustomConverters() {
+	void canConvertDefaultTypesNoCustomConverters() {
 		ConverterAwareMappingSpannerEntityProcessor converter = new ConverterAwareMappingSpannerEntityProcessor(
 				new SpannerMappingContext());
 
@@ -140,7 +140,7 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void canConvertDefaultTypesCustomConverters() {
+	void canConvertDefaultTypesCustomConverters() {
 		ConverterAwareMappingSpannerEntityProcessor converter = new ConverterAwareMappingSpannerEntityProcessor(
 				new SpannerMappingContext(),
 				Collections.singletonList(JAVA_TO_SPANNER),
@@ -153,7 +153,7 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void timestampCorrespondingType() {
+	void timestampCorrespondingType() {
 		ConverterAwareMappingSpannerEntityProcessor converter = new ConverterAwareMappingSpannerEntityProcessor(
 				new SpannerMappingContext());
 
@@ -163,7 +163,7 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void timestampIterableCorrespondingType() {
+	void timestampIterableCorrespondingType() {
 		ConverterAwareMappingSpannerEntityProcessor converter = new ConverterAwareMappingSpannerEntityProcessor(
 				new SpannerMappingContext());
 
@@ -172,8 +172,7 @@ import static org.mockito.Mockito.when;
 		assertThat(spannerJavaType).isEqualTo(Timestamp.class);
 	}
 
-	private void verifyCanConvert(ConverterAwareMappingSpannerEntityProcessor converter,
-			Class<?> javaType, Class<?> spannerType) {
+	private void verifyCanConvert(ConverterAwareMappingSpannerEntityProcessor converter, Class<?> javaType, Class<?> spannerType) {
 		SpannerWriteConverter writeConverter = converter.getWriteConverter();
 		SpannerReadConverter readConverter = converter.getReadConverter();
 
@@ -182,7 +181,7 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void mapToListTest() {
+	void mapToListTest() {
 		List<Double> doubleList = Collections.singletonList(3.33);
 		List<String> stringList = Collections.singletonList("string");
 		List<Instant> instants = Arrays.asList(Instant.ofEpochSecond(111),
@@ -309,7 +308,7 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void mapToListPartialColumnsTest() {
+	void mapToListPartialColumnsTest() {
 		List<Double> doubleList = new ArrayList<>();
 		doubleList.add(3.33);
 		List<String> stringList = new ArrayList<>();

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
@@ -35,8 +35,8 @@ import com.google.cloud.spanner.Value;
 import com.google.cloud.spring.data.spanner.core.convert.TestEntities.TestEntity;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import org.assertj.core.data.Offset;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.NonNull;
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
  * @author Chengyuan Zhao
  * @author Balint Pato
  */
-public class ConverterAwareMappingSpannerEntityProcessorTests {
+ class ConverterAwareMappingSpannerEntityProcessorTests {
 
 	private static final Offset<Double> DELTA = Offset.offset(0.00001);
 
@@ -96,14 +96,14 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 		}
 	};
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	 void setUp() {
 		this.spannerEntityProcessor = new ConverterAwareMappingSpannerEntityProcessor(
 				new SpannerMappingContext());
 	}
 
 	@Test
-	public void customTimeConverter() {
+	 void customTimeConverter() {
 		ConverterAwareMappingSpannerEntityProcessor processorWithCustomConverters =
 				new ConverterAwareMappingSpannerEntityProcessor(new SpannerMappingContext(),
 						Collections.singletonList(LOCAL_DATE_TIME_WRITE_CONVERTER),
@@ -130,7 +130,7 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 
 
 	@Test
-	public void canConvertDefaultTypesNoCustomConverters() {
+	 void canConvertDefaultTypesNoCustomConverters() {
 		ConverterAwareMappingSpannerEntityProcessor converter = new ConverterAwareMappingSpannerEntityProcessor(
 				new SpannerMappingContext());
 
@@ -140,7 +140,7 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 	}
 
 	@Test
-	public void canConvertDefaultTypesCustomConverters() {
+	 void canConvertDefaultTypesCustomConverters() {
 		ConverterAwareMappingSpannerEntityProcessor converter = new ConverterAwareMappingSpannerEntityProcessor(
 				new SpannerMappingContext(),
 				Collections.singletonList(JAVA_TO_SPANNER),
@@ -153,7 +153,7 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 	}
 
 	@Test
-	public void timestampCorrespondingType() {
+	 void timestampCorrespondingType() {
 		ConverterAwareMappingSpannerEntityProcessor converter = new ConverterAwareMappingSpannerEntityProcessor(
 				new SpannerMappingContext());
 
@@ -163,7 +163,7 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 	}
 
 	@Test
-	public void timestampIterableCorrespondingType() {
+	 void timestampIterableCorrespondingType() {
 		ConverterAwareMappingSpannerEntityProcessor converter = new ConverterAwareMappingSpannerEntityProcessor(
 				new SpannerMappingContext());
 
@@ -182,7 +182,7 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 	}
 
 	@Test
-	public void mapToListTest() {
+	 void mapToListTest() {
 		List<Double> doubleList = Collections.singletonList(3.33);
 		List<String> stringList = Collections.singletonList("string");
 		List<Instant> instants = Arrays.asList(Instant.ofEpochSecond(111),
@@ -309,7 +309,7 @@ public class ConverterAwareMappingSpannerEntityProcessorTests {
 	}
 
 	@Test
-	public void mapToListPartialColumnsTest() {
+	 void mapToListPartialColumnsTest() {
 		List<Double> doubleList = new ArrayList<>();
 		doubleList.add(3.33);
 		List<String> stringList = new ArrayList<>();

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/SpannerStructReadMethodCoverageTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/SpannerStructReadMethodCoverageTests.java
@@ -25,7 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.google.cloud.spanner.Struct;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Chengyuan Zhao
  */
-public class SpannerStructReadMethodCoverageTests {
+ class SpannerStructReadMethodCoverageTests {
 
 	private static final Set<String> DISREGARDED_METHOD_NAMES = Collections.unmodifiableSet(new HashSet<String>(
 		Arrays.asList("getColumnIndex", "getStructList", "getColumnType", "getValue")
@@ -42,7 +42,7 @@ public class SpannerStructReadMethodCoverageTests {
 
 	// Checks that the converter is aware of all Spanner struct getter types
 	@Test
-	public void allKnownMappingTypesTest() throws NoSuchFieldException {
+	 void allKnownMappingTypesTest() throws NoSuchFieldException {
 		for (Method method : Struct.class.getMethods()) {
 			String methodName = method.getName();
 			// ignoring private methods, ones not named like a getter. Getters must also

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/SpannerStructReadMethodCoverageTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/SpannerStructReadMethodCoverageTests.java
@@ -34,15 +34,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Chengyuan Zhao
  */
- class SpannerStructReadMethodCoverageTests {
+class SpannerStructReadMethodCoverageTests {
 
 	private static final Set<String> DISREGARDED_METHOD_NAMES = Collections.unmodifiableSet(new HashSet<String>(
-		Arrays.asList("getColumnIndex", "getStructList", "getColumnType", "getValue")
+			Arrays.asList("getColumnIndex", "getStructList", "getColumnType", "getValue")
 	));
 
 	// Checks that the converter is aware of all Spanner struct getter types
 	@Test
-	 void allKnownMappingTypesTest() throws NoSuchFieldException {
+	void allKnownMappingTypesTest() throws NoSuchFieldException {
 		for (Method method : Struct.class.getMethods()) {
 			String methodName = method.getName();
 			// ignoring private methods, ones not named like a getter. Getters must also

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/SpannerWriteMethodCoverageTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/SpannerWriteMethodCoverageTests.java
@@ -23,7 +23,8 @@ import java.lang.reflect.ParameterizedType;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.ValueBinder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,11 +33,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Chengyuan Zhao
  */
-public class SpannerWriteMethodCoverageTests {
+ class SpannerWriteMethodCoverageTests {
 
 	// Checks that the converter is aware of all Cloud Spanner mutation binder types
 	@Test
-	public void allKnownMappingTypesTest() throws NoSuchFieldException {
+	 void allKnownMappingTypesTest() throws NoSuchFieldException {
 		for (Method method : ValueBinder.class.getMethods()) {
 
 			String methodName = method.getName();

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/SpannerWriteMethodCoverageTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/SpannerWriteMethodCoverageTests.java
@@ -33,11 +33,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Chengyuan Zhao
  */
- class SpannerWriteMethodCoverageTests {
+class SpannerWriteMethodCoverageTests {
 
 	// Checks that the converter is aware of all Cloud Spanner mutation binder types
 	@Test
-	 void allKnownMappingTypesTest() throws NoSuchFieldException {
+	void allKnownMappingTypesTest() throws NoSuchFieldException {
 		for (Method method : ValueBinder.class.getMethods()) {
 
 			String methodName = method.getName();

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
@@ -37,7 +37,7 @@ import com.google.spanner.v1.TypeCode;
  * @author Chengyuan Zhao
  * @author Balint Pato
  */
- class TestEntities {
+class TestEntities {
 
 	/**
 	 * Test domain type holding properties with many types and key components.

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
@@ -37,7 +37,7 @@ import com.google.spanner.v1.TypeCode;
  * @author Chengyuan Zhao
  * @author Balint Pato
  */
-public class TestEntities {
+ class TestEntities {
 
 	/**
 	 * Test domain type holding properties with many types and key components.

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerConvertersTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerConvertersTest.java
@@ -33,66 +33,66 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Chengyuan Zhao
  */
- class SpannerConvertersTest {
+class SpannerConvertersTest {
 
 	@Test
-	 void localDateTimeConversionTest() {
+	void localDateTimeConversionTest() {
 		LocalDateTime dateTime = LocalDateTime.now();
 		assertThat(SpannerConverters.TIMESTAMP_LOCAL_DATE_TIME_CONVERTER
 				.convert(SpannerConverters.LOCAL_DATE_TIME_TIMESTAMP_CONVERTER.convert(dateTime))).isEqualTo(dateTime);
 	}
 
 	@Test
-	 void localDateTimeConversionPreEpochTest() {
+	void localDateTimeConversionPreEpochTest() {
 		LocalDateTime dateTime = LocalDateTime.of(600, 12, 1, 2, 3, 4, 5);
 		assertThat(SpannerConverters.TIMESTAMP_LOCAL_DATE_TIME_CONVERTER
 				.convert(SpannerConverters.LOCAL_DATE_TIME_TIMESTAMP_CONVERTER.convert(dateTime))).isEqualTo(dateTime);
 	}
 
 	@Test
-	 void dateConversionTest() {
+	void dateConversionTest() {
 		Timestamp timestamp = Timestamp.now();
 		assertThat(SpannerConverters.DATE_TIMESTAMP_CONVERTER
 				.convert(SpannerConverters.TIMESTAMP_DATE_CONVERTER.convert(timestamp))).isEqualTo(timestamp);
 	}
 
 	@Test
-	 void dateConversionPreEpochTest() {
+	void dateConversionPreEpochTest() {
 		java.util.Date timestamp = java.util.Date.from(Instant.ofEpochSecond(-12345678, -123));
 		assertThat(SpannerConverters.TIMESTAMP_DATE_CONVERTER
 				.convert(SpannerConverters.DATE_TIMESTAMP_CONVERTER.convert(timestamp))).isEqualTo(timestamp);
 	}
 
 	@Test
-	 void localDateConversionTest() {
+	void localDateConversionTest() {
 		LocalDate localDate = LocalDate.now();
 		assertThat(SpannerConverters.TIMESTAMP_LOCAL_DATE_CONVERTER
 				.convert(SpannerConverters.LOCAL_DATE_TIMESTAMP_CONVERTER.convert(localDate))).isEqualTo(localDate);
 	}
 
 	@Test
-	 void localDateConversionPreEpochTest() {
+	void localDateConversionPreEpochTest() {
 		LocalDate localDate = LocalDate.of(600, 12, 1);
 		assertThat(SpannerConverters.TIMESTAMP_LOCAL_DATE_CONVERTER
 				.convert(SpannerConverters.LOCAL_DATE_TIMESTAMP_CONVERTER.convert(localDate))).isEqualTo(localDate);
 	}
 
 	@Test
-	 void sqlDateConversionTest() {
+	void sqlDateConversionTest() {
 		Date date = Date.fromYearMonthDay(2018, 3, 29);
 		assertThat(SpannerConverters.JAVA_SQL_TO_SPANNER_DATE_CONVERTER
 				.convert(SpannerConverters.SPANNER_TO_JAVA_SQL_DATE_CONVERTER.convert(date))).isEqualTo(date);
 	}
 
 	@Test
-	 void timestampInstantConversionTest() {
+	void timestampInstantConversionTest() {
 		Timestamp timestamp = Timestamp.ofTimeMicroseconds(12345678);
 		assertThat(SpannerConverters.INSTANT_TIMESTAMP_CONVERTER
 				.convert(SpannerConverters.TIMESTAMP_INSTANT_CONVERTER.convert(timestamp))).isEqualTo(timestamp);
 	}
 
 	@Test
-	 void timestampConversionTest() {
+	void timestampConversionTest() {
 		Timestamp timestamp = Timestamp.ofTimeMicroseconds(-12345678);
 		assertThat(SpannerConverters.JAVA_TO_SPANNER_TIMESTAMP_CONVERTER
 				.convert(SpannerConverters.SPANNER_TO_JAVA_TIMESTAMP_CONVERTER.convert(timestamp)))
@@ -100,10 +100,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 	}
 
 	@Test
-	 void bytesConversionTest() {
+	void bytesConversionTest() {
 		ByteArray byteArray = ByteArray.copyFrom("some bytes");
 		assertThat(SpannerConverters.JAVA_TO_SPANNER_BYTE_ARRAY_CONVERTER
 				.convert(SpannerConverters.SPANNER_TO_JAVA_BYTE_ARRAY_CONVERTER.convert(byteArray)))
-						.isEqualTo(byteArray);
+				.isEqualTo(byteArray);
 	}
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerConvertersTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerConvertersTest.java
@@ -24,7 +24,7 @@ import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spring.data.spanner.core.convert.SpannerConverters;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,66 +33,66 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Chengyuan Zhao
  */
-public class SpannerConvertersTest {
+ class SpannerConvertersTest {
 
 	@Test
-	public void localDateTimeConversionTest() {
+	 void localDateTimeConversionTest() {
 		LocalDateTime dateTime = LocalDateTime.now();
 		assertThat(SpannerConverters.TIMESTAMP_LOCAL_DATE_TIME_CONVERTER
 				.convert(SpannerConverters.LOCAL_DATE_TIME_TIMESTAMP_CONVERTER.convert(dateTime))).isEqualTo(dateTime);
 	}
 
 	@Test
-	public void localDateTimeConversionPreEpochTest() {
+	 void localDateTimeConversionPreEpochTest() {
 		LocalDateTime dateTime = LocalDateTime.of(600, 12, 1, 2, 3, 4, 5);
 		assertThat(SpannerConverters.TIMESTAMP_LOCAL_DATE_TIME_CONVERTER
 				.convert(SpannerConverters.LOCAL_DATE_TIME_TIMESTAMP_CONVERTER.convert(dateTime))).isEqualTo(dateTime);
 	}
 
 	@Test
-	public void dateConversionTest() {
+	 void dateConversionTest() {
 		Timestamp timestamp = Timestamp.now();
 		assertThat(SpannerConverters.DATE_TIMESTAMP_CONVERTER
 				.convert(SpannerConverters.TIMESTAMP_DATE_CONVERTER.convert(timestamp))).isEqualTo(timestamp);
 	}
 
 	@Test
-	public void dateConversionPreEpochTest() {
+	 void dateConversionPreEpochTest() {
 		java.util.Date timestamp = java.util.Date.from(Instant.ofEpochSecond(-12345678, -123));
 		assertThat(SpannerConverters.TIMESTAMP_DATE_CONVERTER
 				.convert(SpannerConverters.DATE_TIMESTAMP_CONVERTER.convert(timestamp))).isEqualTo(timestamp);
 	}
 
 	@Test
-	public void localDateConversionTest() {
+	 void localDateConversionTest() {
 		LocalDate localDate = LocalDate.now();
 		assertThat(SpannerConverters.TIMESTAMP_LOCAL_DATE_CONVERTER
 				.convert(SpannerConverters.LOCAL_DATE_TIMESTAMP_CONVERTER.convert(localDate))).isEqualTo(localDate);
 	}
 
 	@Test
-	public void localDateConversionPreEpochTest() {
+	 void localDateConversionPreEpochTest() {
 		LocalDate localDate = LocalDate.of(600, 12, 1);
 		assertThat(SpannerConverters.TIMESTAMP_LOCAL_DATE_CONVERTER
 				.convert(SpannerConverters.LOCAL_DATE_TIMESTAMP_CONVERTER.convert(localDate))).isEqualTo(localDate);
 	}
 
 	@Test
-	public void sqlDateConversionTest() {
+	 void sqlDateConversionTest() {
 		Date date = Date.fromYearMonthDay(2018, 3, 29);
 		assertThat(SpannerConverters.JAVA_SQL_TO_SPANNER_DATE_CONVERTER
 				.convert(SpannerConverters.SPANNER_TO_JAVA_SQL_DATE_CONVERTER.convert(date))).isEqualTo(date);
 	}
 
 	@Test
-	public void timestampInstantConversionTest() {
+	 void timestampInstantConversionTest() {
 		Timestamp timestamp = Timestamp.ofTimeMicroseconds(12345678);
 		assertThat(SpannerConverters.INSTANT_TIMESTAMP_CONVERTER
 				.convert(SpannerConverters.TIMESTAMP_INSTANT_CONVERTER.convert(timestamp))).isEqualTo(timestamp);
 	}
 
 	@Test
-	public void timestampConversionTest() {
+	 void timestampConversionTest() {
 		Timestamp timestamp = Timestamp.ofTimeMicroseconds(-12345678);
 		assertThat(SpannerConverters.JAVA_TO_SPANNER_TIMESTAMP_CONVERTER
 				.convert(SpannerConverters.SPANNER_TO_JAVA_TIMESTAMP_CONVERTER.convert(timestamp)))
@@ -100,7 +100,7 @@ public class SpannerConvertersTest {
 	}
 
 	@Test
-	public void bytesConversionTest() {
+	 void bytesConversionTest() {
 		ByteArray byteArray = ByteArray.copyFrom("some bytes");
 		assertThat(SpannerConverters.JAVA_TO_SPANNER_BYTE_ARRAY_CONVERTER
 				.convert(SpannerConverters.SPANNER_TO_JAVA_BYTE_ARRAY_CONVERTER.convert(byteArray)))

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/event/AfterExecuteDmlEventTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/event/AfterExecuteDmlEventTest.java
@@ -26,10 +26,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Chengyuan Zhao
  */
- class AfterExecuteDmlEventTest {
+class AfterExecuteDmlEventTest {
 
 	@Test
-	 void equalsHashcodeTest() {
+	void equalsHashcodeTest() {
 		AfterExecuteDmlEvent afterExecuteDmlEventa1 = new AfterExecuteDmlEvent(Statement.of("a"), 1L);
 		AfterExecuteDmlEvent afterExecuteDmlEventa1x = new AfterExecuteDmlEvent(Statement.of("a"), 1L);
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/event/AfterExecuteDmlEventTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/event/AfterExecuteDmlEventTest.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spring.data.spanner.core.mapping.event;
 
 import com.google.cloud.spanner.Statement;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,10 +26,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Chengyuan Zhao
  */
-public class AfterExecuteDmlEventTest {
+ class AfterExecuteDmlEventTest {
 
 	@Test
-	public void equalsHashcodeTest() {
+	 void equalsHashcodeTest() {
 		AfterExecuteDmlEvent afterExecuteDmlEventa1 = new AfterExecuteDmlEvent(Statement.of("a"), 1L);
 		AfterExecuteDmlEvent afterExecuteDmlEventa1x = new AfterExecuteDmlEvent(Statement.of("a"), 1L);
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/event/BeforeExecuteDmlEventTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/event/BeforeExecuteDmlEventTest.java
@@ -26,10 +26,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Chengyuan Zhao
  */
- class BeforeExecuteDmlEventTest {
+class BeforeExecuteDmlEventTest {
 
 	@Test
-	 void equalsHashcodeTest() {
+	void equalsHashcodeTest() {
 		BeforeExecuteDmlEvent beforeExecuteDmlEvent = new BeforeExecuteDmlEvent(Statement.of("a"));
 		BeforeExecuteDmlEvent beforeExecuteDmlEvent1 = new BeforeExecuteDmlEvent(Statement.of("a"));
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/event/BeforeExecuteDmlEventTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/event/BeforeExecuteDmlEventTest.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spring.data.spanner.core.mapping.event;
 
 import com.google.cloud.spanner.Statement;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,10 +26,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Chengyuan Zhao
  */
-public class BeforeExecuteDmlEventTest {
+ class BeforeExecuteDmlEventTest {
 
 	@Test
-	public void equalsHashcodeTest() {
+	 void equalsHashcodeTest() {
 		BeforeExecuteDmlEvent beforeExecuteDmlEvent = new BeforeExecuteDmlEvent(Statement.of("a"));
 		BeforeExecuteDmlEvent beforeExecuteDmlEvent1 = new BeforeExecuteDmlEvent(Statement.of("a"));
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.when;
  * @author Chengyuan Zhao
  * @author Roman Solodovnichenko
  */
- class SpannerQueryLookupStrategyTests {
+class SpannerQueryLookupStrategyTests {
 
 	private SpannerTemplate spannerTemplate;
 
@@ -76,7 +76,7 @@ import static org.mockito.Mockito.when;
 
 	@BeforeEach
 	@SuppressWarnings("BadAnnotationImplementation")
-	 void initMocks() {
+	void initMocks() {
 		this.spannerMappingContext = new SpannerMappingContext();
 		this.spannerTemplate = mock(SpannerTemplate.class);
 		this.queryMethod = mock(SpannerQueryMethod.class);
@@ -103,7 +103,7 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void resolveSqlQueryTest() {
+	void resolveSqlQueryTest() {
 		String queryName = "fakeNamedQueryName";
 		String query = "fake query";
 		when(this.queryMethod.getNamedQueryName()).thenReturn(queryName);
@@ -135,7 +135,7 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void resolvePartTreeQueryTest() {
+	void resolvePartTreeQueryTest() {
 		String queryName = "fakeNamedQueryName";
 		when(this.queryMethod.getNamedQueryName()).thenReturn(queryName);
 		NamedQueries namedQueries = mock(NamedQueries.class);
@@ -161,7 +161,7 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void getChildrenRowsQueryTest() {
+	void getChildrenRowsQueryTest() {
 		TestEntity t = new TestEntity();
 		t.id = "key";
 		t.id2 = "key2";
@@ -177,7 +177,7 @@ import static org.mockito.Mockito.when;
 	}
 
 	@Test
-	 void getColumnsStringForSelectTest() {
+	void getColumnsStringForSelectTest() {
 		TestEntity t = new TestEntity();
 		t.id = "key";
 		t.id2 = "key2";
@@ -195,7 +195,7 @@ import static org.mockito.Mockito.when;
 
 	@Test
 	@SuppressWarnings("unchecked")
-	 void getColumnsStringForSelectMultipleTest() {
+	void getColumnsStringForSelectMultipleTest() {
 		final SpannerPersistentEntity<TestEntity> entity = (SpannerPersistentEntity<TestEntity>)
 				this.spannerMappingContext.getPersistentEntity(TestEntity.class);
 		Statement childrenRowsQuery = SpannerStatementQueryExecutor.buildQuery(

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
@@ -32,8 +32,8 @@ import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentEntity;
 import com.google.cloud.spring.data.spanner.core.mapping.Table;
 import com.google.cloud.spring.data.spanner.core.mapping.Where;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.data.repository.core.NamedQueries;
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.when;
  * @author Chengyuan Zhao
  * @author Roman Solodovnichenko
  */
-public class SpannerQueryLookupStrategyTests {
+ class SpannerQueryLookupStrategyTests {
 
 	private SpannerTemplate spannerTemplate;
 
@@ -74,9 +74,9 @@ public class SpannerQueryLookupStrategyTests {
 
 	private SpelExpressionParser spelExpressionParser;
 
-	@Before
+	@BeforeEach
 	@SuppressWarnings("BadAnnotationImplementation")
-	public void initMocks() {
+	 void initMocks() {
 		this.spannerMappingContext = new SpannerMappingContext();
 		this.spannerTemplate = mock(SpannerTemplate.class);
 		this.queryMethod = mock(SpannerQueryMethod.class);
@@ -103,7 +103,7 @@ public class SpannerQueryLookupStrategyTests {
 	}
 
 	@Test
-	public void resolveSqlQueryTest() {
+	 void resolveSqlQueryTest() {
 		String queryName = "fakeNamedQueryName";
 		String query = "fake query";
 		when(this.queryMethod.getNamedQueryName()).thenReturn(queryName);
@@ -135,7 +135,7 @@ public class SpannerQueryLookupStrategyTests {
 	}
 
 	@Test
-	public void resolvePartTreeQueryTest() {
+	 void resolvePartTreeQueryTest() {
 		String queryName = "fakeNamedQueryName";
 		when(this.queryMethod.getNamedQueryName()).thenReturn(queryName);
 		NamedQueries namedQueries = mock(NamedQueries.class);
@@ -161,7 +161,7 @@ public class SpannerQueryLookupStrategyTests {
 	}
 
 	@Test
-	public void getChildrenRowsQueryTest() {
+	 void getChildrenRowsQueryTest() {
 		TestEntity t = new TestEntity();
 		t.id = "key";
 		t.id2 = "key2";
@@ -177,7 +177,7 @@ public class SpannerQueryLookupStrategyTests {
 	}
 
 	@Test
-	public void getColumnsStringForSelectTest() {
+	 void getColumnsStringForSelectTest() {
 		TestEntity t = new TestEntity();
 		t.id = "key";
 		t.id2 = "key2";
@@ -195,7 +195,7 @@ public class SpannerQueryLookupStrategyTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void getColumnsStringForSelectMultipleTest() {
+	 void getColumnsStringForSelectMultipleTest() {
 		final SpannerPersistentEntity<TestEntity> entity = (SpannerPersistentEntity<TestEntity>)
 				this.spannerMappingContext.getPersistentEntity(TestEntity.class);
 		Statement childrenRowsQuery = SpannerStatementQueryExecutor.buildQuery(

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryFactoryBeanTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryFactoryBeanTests.java
@@ -33,7 +33,8 @@ import static org.mockito.Mockito.mock;
  *
  * @author Chengyuan Zhao
  */
- class SpannerRepositoryFactoryBeanTests {
+
+class SpannerRepositoryFactoryBeanTests {
 
 	private SpannerRepositoryFactoryBean<SpannerRepository<Object, Key>, Object, Key>
 			spannerRepositoryFactoryBean;
@@ -44,7 +45,7 @@ import static org.mockito.Mockito.mock;
 
 	@BeforeEach
 	@SuppressWarnings("unchecked")
-	 void setUp() {
+	void setUp() {
 		this.spannerMappingContext = new SpannerMappingContext();
 		this.spannerTemplate = mock(SpannerTemplate.class);
 		this.spannerRepositoryFactoryBean = new SpannerRepositoryFactoryBean(
@@ -55,7 +56,7 @@ import static org.mockito.Mockito.mock;
 	}
 
 	@Test
-	 void createRepositoryFactoryTest() {
+	void createRepositoryFactoryTest() {
 		RepositoryFactorySupport factory = this.spannerRepositoryFactoryBean
 				.createRepositoryFactory();
 		assertThat(factory).isInstanceOf(SpannerRepositoryFactory.class);

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryFactoryBeanTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryFactoryBeanTests.java
@@ -20,8 +20,8 @@ import com.google.cloud.spanner.Key;
 import com.google.cloud.spring.data.spanner.core.SpannerTemplate;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.cloud.spring.data.spanner.repository.SpannerRepository;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Chengyuan Zhao
  */
-public class SpannerRepositoryFactoryBeanTests {
+ class SpannerRepositoryFactoryBeanTests {
 
 	private SpannerRepositoryFactoryBean<SpannerRepository<Object, Key>, Object, Key>
 			spannerRepositoryFactoryBean;
@@ -42,9 +42,9 @@ public class SpannerRepositoryFactoryBeanTests {
 
 	private SpannerTemplate spannerTemplate;
 
-	@Before
+	@BeforeEach
 	@SuppressWarnings("unchecked")
-	public void setUp() {
+	 void setUp() {
 		this.spannerMappingContext = new SpannerMappingContext();
 		this.spannerTemplate = mock(SpannerTemplate.class);
 		this.spannerRepositoryFactoryBean = new SpannerRepositoryFactoryBean(
@@ -55,7 +55,7 @@ public class SpannerRepositoryFactoryBeanTests {
 	}
 
 	@Test
-	public void createRepositoryFactoryTest() {
+	 void createRepositoryFactoryTest() {
 		RepositoryFactorySupport factory = this.spannerRepositoryFactoryBean
 				.createRepositoryFactory();
 		assertThat(factory).isInstanceOf(SpannerRepositoryFactory.class);


### PR DESCRIPTION
Migrated the following tests from JUnit4 to JUnit5 in 

**module: spring-cloud-gcp-data-spanner**
1. SpannerSchemaUtilsTests.java
2. SpannerStructReadMethodCoverageTests
3. SpannerWriteMethodCoverageTests.java
4. TestEntities.java
5. SpannerQueryLookupStrategyTests.java
6. SpannerRepositoryFactoryBeanTests.java
7. AfterExecuteDmlEventTest
8. BeforeExecuteDmlEventTest
9. ConverterAwareMappingSpannerEntityProcessorTests
10. SpannerConvertersTest
