### PR TITLE
spring cloud gcp data firestore tests migration(JUnit4 to JUnit5)

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
@@ -38,8 +38,8 @@ import com.google.firestore.v1.StructuredQuery;
 import com.google.firestore.v1.Value;
 import com.google.firestore.v1.Write;
 import io.grpc.stub.StreamObserver;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -63,15 +63,15 @@ public class FirestoreTemplateTests {
 
 	private static final String parent = "projects/my-project/databases/(default)/documents";
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		FirestoreMappingContext mappingContext = new FirestoreMappingContext();
 		this.firestoreTemplate = new FirestoreTemplate(this.firestoreStub, this.parent,
 				new FirestoreDefaultClassMapper(mappingContext), mappingContext);
 	}
 
 	@Test
-	public void findAllTest() {
+	void findAllTest() {
 		mockRunQueryMethod();
 
 		StepVerifier.create(this.firestoreTemplate.findAll(TestEntity.class))
@@ -91,7 +91,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void saveAllTest() {
+	void saveAllTest() {
 		mockCommitMethod();
 
 		StepVerifier.create(
@@ -112,7 +112,7 @@ public class FirestoreTemplateTests {
 
 
 	@Test
-	public void updateTimeVersionSaveTest() {
+	void updateTimeVersionSaveTest() {
 		mockCommitMethod();
 
 		Timestamp expectedUpdateTime = Timestamp.ofTimeMicroseconds(123456789);
@@ -139,7 +139,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void updateTimeVersionUpdateTest() {
+	void updateTimeVersionUpdateTest() {
 		mockCommitMethod();
 
 		Timestamp expectedUpdateTime = Timestamp.ofTimeMicroseconds(123456789);
@@ -174,7 +174,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void updateTimeSaveTest() {
+	void updateTimeSaveTest() {
 		mockCommitMethod();
 
 		Timestamp expectedUpdateTime = Timestamp.ofTimeMicroseconds(123456789);
@@ -198,7 +198,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void deleteTest() {
+	void deleteTest() {
 		mockCommitMethod();
 
 		StepVerifier.create(
@@ -216,7 +216,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void deleteByIdTest() {
+	void deleteByIdTest() {
 		mockCommitMethod();
 		Flux<String> idPublisher = Flux.just("e1", "e2");
 		StepVerifier.create(
@@ -246,7 +246,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void findByIdTest() {
+	void findByIdTest() {
 		doAnswer(invocation -> {
 			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onNext(buildDocument("e1", 100L));
@@ -267,7 +267,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void findByIdErrorTest() {
+	void findByIdErrorTest() {
 		doAnswer(invocation -> {
 			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onError(new RuntimeException("Firestore error"));
@@ -289,7 +289,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void findByIdNotFoundTest() {
+	void findByIdNotFoundTest() {
 		doAnswer(invocation -> {
 			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onError(new RuntimeException("NOT_FOUND: Document"));
@@ -308,7 +308,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void findAllByIdTest() {
+	void findAllByIdTest() {
 		GetDocumentRequest request1 = GetDocumentRequest.newBuilder()
 				.setName(this.parent + "/testEntities/e1")
 				.build();
@@ -353,7 +353,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void countTest() {
+	void countTest() {
 		mockRunQueryMethod();
 
 		StepVerifier.create(this.firestoreTemplate.count(TestEntity.class)).expectNext(2L).verifyComplete();
@@ -377,7 +377,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void countWithQueryTest() {
+	void countWithQueryTest() {
 		mockRunQueryMethod();
 
 		StructuredQuery.Builder builder = StructuredQuery.newBuilder();
@@ -417,7 +417,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void existsByIdTest() {
+	void existsByIdTest() {
 		GetDocumentRequest request = GetDocumentRequest.newBuilder()
 				.setName(this.parent + "/testEntities/" + "e1")
 				.setMask(DocumentMask.newBuilder().addFieldPaths("__name__").build())
@@ -439,7 +439,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void existsByIdNotFoundTest() {
+	void existsByIdNotFoundTest() {
 		GetDocumentRequest request = GetDocumentRequest.newBuilder()
 				.setName(this.parent + "/testEntities/" + "e1")
 				.setMask(DocumentMask.newBuilder().addFieldPaths("__name__").build())
@@ -462,7 +462,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void withParentTest_entityReference() {
+	void withParentTest_entityReference() {
 		doAnswer(invocation -> {
 			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onNext(buildDocument("e1", 100L));
@@ -483,7 +483,7 @@ public class FirestoreTemplateTests {
 	}
 
 	@Test
-	public void withParentTest_idClassReference() {
+	void withParentTest_idClassReference() {
 		doAnswer(invocation -> {
 			StreamObserver<com.google.firestore.v1.Document> streamObserver = invocation.getArgument(1);
 			streamObserver.onNext(buildDocument("e1", 100L));

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
@@ -29,10 +29,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class SimpleFirestoreReactiveRepositoryTests {
+class SimpleFirestoreReactiveRepositoryTests {
 
 	@Test
-	public void deleteAllById() {
+	void deleteAllById() {
 		FirestoreTemplate mockTemplate = mock(FirestoreTemplate.class);
 		SimpleFirestoreReactiveRepository<String> repository = new SimpleFirestoreReactiveRepository<>(mockTemplate,
 				String.class);

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/UtilTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/UtilTests.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spring.data.firestore;
 
 import com.google.cloud.spring.data.firestore.util.Util;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,10 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Dmitry Solomakha
  * @since 1.2
  */
-public class UtilTests {
+class UtilTests {
 
 	@Test
-	public void extractDatabasePathTest() {
+	void extractDatabasePathTest() {
 		String actualDbPath = "projects/MY_PROJECT/databases/MY_DB_ID";
 		String extractedDbPath = Util.extractDatabasePath(actualDbPath + "/abc/def");
 

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/mapping/FirestorePersistentEntityImplTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/mapping/FirestorePersistentEntityImplTests.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spring.data.firestore.mapping;
 
 import com.google.cloud.spring.data.firestore.Document;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.data.util.ClassTypeInformation;
 
@@ -28,17 +28,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Daniel Zou
  */
-public class FirestorePersistentEntityImplTests {
+class FirestorePersistentEntityImplTests {
 
 	@Test
-	public void testSetCollectionName() {
+	void testSetCollectionName() {
 		FirestorePersistentEntity<Student> firestorePersistentEntity = new FirestorePersistentEntityImpl<>(
 				ClassTypeInformation.from(Student.class));
 		assertThat(firestorePersistentEntity.collectionName()).isEqualTo("student");
 	}
 
 	@Test
-	public void testInferCollectionName() {
+	void testInferCollectionName() {
 		FirestorePersistentEntity<Employee> firestorePersistentEntity = new FirestorePersistentEntityImpl<>(
 				ClassTypeInformation.from(Employee.class));
 		assertThat(firestorePersistentEntity.collectionName()).isEqualTo("employee_table");

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/repository/query/PartTreeFirestoreQueryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/repository/query/PartTreeFirestoreQueryTests.java
@@ -27,7 +27,7 @@ import com.google.cloud.spring.data.firestore.mapping.FirestoreDefaultClassMappe
 import com.google.cloud.spring.data.firestore.mapping.FirestoreMappingContext;
 import com.google.firestore.v1.StructuredQuery;
 import com.google.firestore.v1.Value;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -42,7 +42,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PartTreeFirestoreQueryTests {
+class PartTreeFirestoreQueryTests {
 	private FirestoreClassMapper classMapper = new FirestoreDefaultClassMapper(new FirestoreMappingContext());
 
 	private static final User TEST_USER = new User("Hello", 23);
@@ -54,7 +54,7 @@ public class PartTreeFirestoreQueryTests {
 	private FirestoreQueryMethod queryMethod = mock(FirestoreQueryMethod.class);
 
 	@Test
-	public void testPartTreeQuery() {
+	void testPartTreeQuery() {
 		PartTreeFirestoreQuery partTreeFirestoreQuery = createPartTreeQuery("findByAgeAndNameIsNullAndHomeAddress_country", invocation -> {
 			StructuredQuery.Builder actualBuilder = invocation.getArgument(0);
 			Class clazz = invocation.getArgument(1);
@@ -97,7 +97,7 @@ public class PartTreeFirestoreQueryTests {
 	}
 
 	@Test
-	public void testPartTreeQuery_queryById() {
+	void testPartTreeQuery_queryById() {
 		when(this.firestoreTemplate.buildResourceName(any(), any())).thenReturn("full/reference/path/to/document");
 
 		PartTreeFirestoreQuery partTreeFirestoreQuery = createPartTreeQuery("findByAgeAndName", invocation -> {
@@ -134,7 +134,7 @@ public class PartTreeFirestoreQueryTests {
 	}
 
 	@Test
-	public void testPartTreeQueryCount() {
+	void testPartTreeQueryCount() {
 		PartTreeFirestoreQuery partTreeFirestoreQuery = setUpPartTreeFirestoreQuery("countByAgeGreaterThan");
 
 		when(this.firestoreTemplate.count(any(), any())).thenAnswer(invocation -> {
@@ -166,7 +166,7 @@ public class PartTreeFirestoreQueryTests {
 	}
 
 	@Test
-	public void testPartTreeQueryParameterException() {
+	void testPartTreeQueryParameterException() {
 		PartTreeFirestoreQuery partTreeFirestoreQuery =
 				createPartTreeQuery("findByAge");
 		assertThatThrownBy(() -> partTreeFirestoreQuery.execute(new Object[] {}))
@@ -175,7 +175,7 @@ public class PartTreeFirestoreQueryTests {
 	}
 
 	@Test
-	public void testPartTreeQueryFilterException() {
+	void testPartTreeQueryFilterException() {
 		assertThatThrownBy(() -> createPartTreeQuery("findByAgeBetweenAndNameRegex"))
 				.isInstanceOf(FirestoreDataException.class)
 				.hasMessage("Unsupported predicate keywords: " +
@@ -185,7 +185,7 @@ public class PartTreeFirestoreQueryTests {
 	}
 
 	@Test
-	public void testPartTreeQueryOrException() {
+	void testPartTreeQueryOrException() {
 		assertThatThrownBy(() -> createPartTreeQuery("findByAgeOrName"))
 				.isInstanceOf(FirestoreDataException.class)
 				.hasMessage("Cloud Firestore doesn't support 'OR' (method name: findByAgeOrName)");


### PR DESCRIPTION
Migrated the following tests from JUnit4 to JUnit5 :

**module: spring-cloud-gcp-data-firestore**

1. FirestorePersistentEntityImplTests.java
2. PartTreeFirestoreQueryTests.java
3. FirestoreTemplateTests.java
4. SimpleFirestoreReactiveRepositoryTests.java
5. UtilTests.java
