### PR TITLE
Fix secret manager it test setup to work with spring boot 2.6

### DIFF
--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerPropertySourceIntegrationTests.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 public class SecretManagerPropertySourceIntegrationTests {
 
 	private ConfigurableApplicationContext context =
-			new SpringApplicationBuilder(TestConfiguration.class)
+			new SpringApplicationBuilder(SecretManagerTestConfiguration.class, TestConfiguration.class)
 					.web(WebApplicationType.NONE)
 					.properties("spring.cloud.bootstrap.enabled=true")
 					.run();


### PR DESCRIPTION
The test were failing at value injection to TestConfiguration due to missing converter. This failure only affects integration test as its setup does not rely on auto-configuration.
 
This change explicitly provides SecretManagerTestConfiguration as source when building context so that the custom converter gets picked up.
