### PR TITLE
spring cloud gcp data datastore tests migration(JUnit4 to JUnit5)

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversionsTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversionsTests.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import com.google.cloud.spring.data.datastore.core.mapping.DatastoreDataException;
 import com.google.cloud.spring.data.datastore.core.mapping.DatastoreMappingContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.core.convert.converter.Converter;
 
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Elena Felder
  * @since 1.1
  */
-public class TwoStepsConversionsTests {
+class TwoStepsConversionsTests {
 
 	private final DatastoreMappingContext datastoreMappingContext = new DatastoreMappingContext();
 
@@ -47,14 +47,14 @@ public class TwoStepsConversionsTests {
 			new DatastoreCustomConversions(Arrays.asList()), null, this.datastoreMappingContext);
 
 	@Test
-	public void convertOnReadReturnsNullWhenConvertingNullSimpleValue() {
+	void convertOnReadReturnsNullWhenConvertingNullSimpleValue() {
 
 		assertThat(this.twoStepsConversions.<String>convertOnRead(null, null, String.class))
 				.isNull();
 	}
 
 	@Test
-	public void convertOnReadConvertsCollectionAndElementTypesCorrectly() {
+	void convertOnReadConvertsCollectionAndElementTypesCorrectly() {
 
 		List<String> okayList = new ArrayList<>();
 		okayList.add("128");
@@ -67,7 +67,7 @@ public class TwoStepsConversionsTests {
 	}
 
 	@Test
-	public void convertOnReadConvertsSimpleElementTypesCorrectly() {
+	void convertOnReadConvertsSimpleElementTypesCorrectly() {
 
 		Integer result = this.twoStepsConversions.<Integer>convertOnRead("512", null, Integer.class);
 		assertThat(result)
@@ -76,7 +76,7 @@ public class TwoStepsConversionsTests {
 	}
 
 	@Test
-	public void convertOnReadFailsOnIncompatibleTypes() {
+	void convertOnReadFailsOnIncompatibleTypes() {
 		assertThatThrownBy(() -> {
 			this.twoStepsConversions.<String>convertOnRead(3, null, String.class);
 		}).isInstanceOf(DatastoreDataException.class)
@@ -85,7 +85,7 @@ public class TwoStepsConversionsTests {
 
 
 	@Test
-	public void convertOnReadUsesCustomConverter() {
+	void convertOnReadUsesCustomConverter() {
 		List<String> numberNames = Arrays.asList("zero", "one", "two", "three", "four", "five");
 		Converter<Long, String> converter = new Converter<Long, String>() {
 			@Override

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/mapping/DatastoreMappingContextTests.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spring.data.datastore.core.mapping;
 
 import com.google.cloud.Timestamp;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.util.ClassTypeInformation;
@@ -34,9 +34,9 @@ import static org.mockito.Mockito.verifyZeroInteractions;
  *
  * @author Chengyuan Zhao
  */
-public class DatastoreMappingContextTests {
+class DatastoreMappingContextTests {
 	@Test
-	public void testApplicationContextPassing() {
+	void testApplicationContextPassing() {
 		DatastorePersistentEntityImpl mockEntity = mock(
 				DatastorePersistentEntityImpl.class);
 		DatastoreMappingContext context = createDatastoreMappingContextWith(mockEntity);
@@ -49,7 +49,7 @@ public class DatastoreMappingContextTests {
 	}
 
 	@Test
-	public void testApplicationContextIsNotSet() {
+	void testApplicationContextIsNotSet() {
 		DatastorePersistentEntityImpl mockEntity = mock(
 				DatastorePersistentEntityImpl.class);
 		DatastoreMappingContext context = createDatastoreMappingContextWith(mockEntity);
@@ -60,7 +60,7 @@ public class DatastoreMappingContextTests {
 	}
 
 	@Test
-	public void testGetInvalidEntity() {
+	void testGetInvalidEntity() {
 		DatastorePersistentEntityImpl mockEntity = mock(
 				DatastorePersistentEntityImpl.class);
 		DatastoreMappingContext context = createDatastoreMappingContextWith(mockEntity);
@@ -71,7 +71,7 @@ public class DatastoreMappingContextTests {
 	}
 
 	@Test
-	public void testTimestampNotAnEntity() {
+	void testTimestampNotAnEntity() {
 		// Datastore native types like Timestamp should be considered simple type and no an entity
 		DatastoreMappingContext context = new DatastoreMappingContext();
 		assertThatThrownBy(() -> context.getDatastorePersistentEntity(Timestamp.class))

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/util/KeyUtilTest.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/util/KeyUtilTest.java
@@ -18,14 +18,14 @@ package com.google.cloud.spring.data.datastore.core.util;
 
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.PathElement;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class KeyUtilTest {
+class KeyUtilTest {
 
 	@Test
-	public void testRemoveAncestors_NamedKeys() {
+	void testRemoveAncestors_NamedKeys() {
 		Key namedKey = Key.newBuilder("project", "person", "Smith")
 				.addAncestor(PathElement.of("person", "GrandParent"))
 				.addAncestor(PathElement.of("person", "Parent"))
@@ -36,7 +36,7 @@ public class KeyUtilTest {
 	}
 
 	@Test
-	public void testRemoveAncestors_IdKeys() {
+	void testRemoveAncestors_IdKeys() {
 		Key idKey = Key.newBuilder("project", "person", 46L)
 				.addAncestor(PathElement.of("person", 22L))
 				.addAncestor(PathElement.of("person", 18L))

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/util/SliceUtilTest.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/util/SliceUtilTest.java
@@ -19,7 +19,7 @@ package com.google.cloud.spring.data.datastore.core.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.cloud.spring.data.datastore.core.util.SliceUtil.sliceAndExecute;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,9 +27,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Dmitry Solomakha
  */
-public class SliceUtilTest {
+class SliceUtilTest {
 	@Test
-	public void sliceAndExecuteTest() {
+	void sliceAndExecuteTest() {
 		Integer[] elements = getIntegers(7);
 		List<Integer[]> slices = new ArrayList<>();
 		sliceAndExecute(elements, 3, slice -> {
@@ -39,7 +39,7 @@ public class SliceUtilTest {
 	}
 
 	@Test
-	public void sliceAndExecuteEvenTest() {
+	void sliceAndExecuteEvenTest() {
 		Integer[] elements = getIntegers(6);
 		List<Integer[]> slices = new ArrayList<>();
 		sliceAndExecute(elements, 3, slice -> {
@@ -49,7 +49,7 @@ public class SliceUtilTest {
 	}
 
 	@Test
-	public void sliceAndExecuteEmptyTest() {
+	void sliceAndExecuteEmptyTest() {
 		Integer[] elements = getIntegers(0);
 		List<Integer[]> slices = new ArrayList<>();
 		sliceAndExecute(elements, 3, slice -> {

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/DatastoreQueryLookupStrategyTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/DatastoreQueryLookupStrategyTests.java
@@ -20,8 +20,8 @@ import java.util.Optional;
 
 import com.google.cloud.spring.data.datastore.core.DatastoreTemplate;
 import com.google.cloud.spring.data.datastore.core.mapping.DatastoreMappingContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.data.repository.core.NamedQueries;
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
  *
  * @author Chengyuan Zhao
  */
-public class DatastoreQueryLookupStrategyTests {
+class DatastoreQueryLookupStrategyTests {
 
 	private DatastoreTemplate datastoreTemplate;
 
@@ -57,8 +57,8 @@ public class DatastoreQueryLookupStrategyTests {
 
 	private QueryMethodEvaluationContextProvider evaluationContextProvider;
 
-	@Before
-	public void initMocks() {
+	@BeforeEach
+	void initMocks() {
 		this.datastoreTemplate = mock(DatastoreTemplate.class);
 		this.datastoreMappingContext = new DatastoreMappingContext();
 		this.queryMethod = mock(DatastoreQueryMethod.class);
@@ -67,7 +67,7 @@ public class DatastoreQueryLookupStrategyTests {
 	}
 
 	@Test
-	public void resolveSqlQueryTest() {
+	void resolveSqlQueryTest() {
 		String queryName = "fakeNamedQueryName";
 		String query = "fake query";
 		when(this.queryMethod.getNamedQueryName()).thenReturn(queryName);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQueryTests.java
@@ -42,8 +42,8 @@ import com.google.cloud.spring.data.datastore.core.mapping.DatastoreMappingConte
 import com.google.cloud.spring.data.datastore.core.mapping.Entity;
 import com.google.cloud.spring.data.datastore.core.mapping.Field;
 import org.assertj.core.data.Offset;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.data.annotation.Id;
@@ -74,7 +74,7 @@ import static org.mockito.Mockito.when;
  *
  * @author Chengyuan Zhao
  */
-public class GqlDatastoreQueryTests {
+class GqlDatastoreQueryTests {
 
 	/** Constant for which if two doubles are within DELTA, they are considered equal. */
 	private static final Offset<Double> DELTA = Offset.offset(0.00001);
@@ -91,8 +91,8 @@ public class GqlDatastoreQueryTests {
 
 	private QueryMethodEvaluationContextProvider evaluationContextProvider;
 
-	@Before
-	public void initMocks() {
+	@BeforeEach
+	void initMocks() {
 		this.queryMethod = mock(DatastoreQueryMethod.class);
 		this.datastoreTemplate = mock(DatastoreTemplate.class);
 		this.datastoreEntityConverter = mock(DatastoreEntityConverter.class);
@@ -112,7 +112,7 @@ public class GqlDatastoreQueryTests {
 	}
 
 	@Test
-	public void compoundNameConventionTest() {
+	void compoundNameConventionTest() {
 
 		String gql = "SELECT * FROM "
 				+ "|com.google.cloud.spring.data.datastore."
@@ -211,7 +211,7 @@ public class GqlDatastoreQueryTests {
 	}
 
 	@Test
-	public void pageableTest() {
+	void pageableTest() {
 
 		String gql = "SELECT * FROM trades WHERE price=@price";
 
@@ -249,7 +249,7 @@ public class GqlDatastoreQueryTests {
 	}
 
 	@Test
-	public void pageableTestSort() {
+	void pageableTestSort() {
 
 		String gql = "SELECT * FROM trades WHERE price=@price";
 
@@ -286,7 +286,7 @@ public class GqlDatastoreQueryTests {
 	}
 
 	@Test
-	public void pageableTestSlice() {
+	void pageableTestSlice() {
 
 		String gql = "SELECT * FROM trades WHERE price=@price";
 
@@ -340,7 +340,7 @@ public class GqlDatastoreQueryTests {
 	}
 
 	@Test
-	public void pageableTestPage() {
+	void pageableTestPage() {
 
 		String gql = "SELECT * FROM trades WHERE price=@price";
 		String expected = "SELECT * FROM trades WHERE price=@price LIMIT @limit OFFSET @offset";
@@ -398,7 +398,7 @@ public class GqlDatastoreQueryTests {
 	}
 
 	@Test
-	public void pageableTestPageCursor() {
+	void pageableTestPageCursor() {
 		String gql = "SELECT * FROM trades WHERE price=@price";
 		String expected = "SELECT * FROM trades WHERE price=@price LIMIT @limit OFFSET @offset";
 
@@ -449,7 +449,7 @@ public class GqlDatastoreQueryTests {
 	}
 
 	@Test
-	public void streamResultTest() {
+	void streamResultTest() {
 		Mockito.<Class>when(this.queryMethod.getReturnedObjectType()).thenReturn(Trade.class);
 		Parameters parameters = mock(Parameters.class);
 		when(this.queryMethod.getParameters()).thenReturn(parameters);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/support/DatastoreRepositoryFactoryBeanTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/support/DatastoreRepositoryFactoryBeanTests.java
@@ -19,8 +19,8 @@ package com.google.cloud.spring.data.datastore.repository.support;
 import com.google.cloud.spring.data.datastore.core.DatastoreTemplate;
 import com.google.cloud.spring.data.datastore.core.mapping.DatastoreMappingContext;
 import com.google.cloud.spring.data.datastore.repository.DatastoreRepository;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Chengyuan Zhao
  */
-public class DatastoreRepositoryFactoryBeanTests {
+class DatastoreRepositoryFactoryBeanTests {
 
 	private DatastoreRepositoryFactoryBean<Object, String> datastoreRepositoryFactoryBean;
 
@@ -40,8 +40,8 @@ public class DatastoreRepositoryFactoryBeanTests {
 
 	private DatastoreTemplate datastoreTemplate = mock(DatastoreTemplate.class);
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 		this.datastoreRepositoryFactoryBean = new DatastoreRepositoryFactoryBean(
 				DatastoreRepository.class);
 		this.datastoreRepositoryFactoryBean
@@ -50,7 +50,7 @@ public class DatastoreRepositoryFactoryBeanTests {
 	}
 
 	@Test
-	public void createRepositoryFactoryTest() {
+	void createRepositoryFactoryTest() {
 		RepositoryFactorySupport factory = this.datastoreRepositoryFactoryBean
 				.createRepositoryFactory();
 		assertThat(factory.getClass()).isEqualTo(DatastoreRepositoryFactory.class);


### PR DESCRIPTION
Migrated the following tests from JUnit4 to JUnit5 :

module: spring-cloud-gcp-data-datastore

1. TwoStepsConversionsTests
2. DatastoreMappingContextTests
3. KeyUtilTest.java
4. SliceUtilTest.java
5. DatastoreQueryLookupStrategyTests.java
6. GqlDatastoreQueryTests.java
7. DatastoreRepositoryFactoryBeanTests.java