### PR TITLE
spring cloud gcp core tests migration(JUnit4 to JUnit5)

### DIFF
--- a/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/DefaultCredentialsProviderTests.java
+++ b/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/DefaultCredentialsProviderTests.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,17 +31,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
  */
-public class DefaultCredentialsProviderTests {
+class DefaultCredentialsProviderTests {
 
 	@Test
-	public void testResolveScopesDefaultScopes() {
+	void testResolveScopesDefaultScopes() {
 		List<String> scopes = DefaultCredentialsProvider.resolveScopes(null);
 		assertThat(scopes.size()).isGreaterThan(1);
 		assertThat(scopes).contains(GcpScope.PUBSUB.getUrl());
 	}
 
 	@Test
-	public void testResolveScopesOverrideScopes() {
+	void testResolveScopesOverrideScopes() {
 		List<String> scopes = DefaultCredentialsProvider.resolveScopes(Collections.singletonList("myscope"));
 		assertThat(scopes)
 				.hasSize(1)
@@ -49,7 +49,7 @@ public class DefaultCredentialsProviderTests {
 	}
 
 	@Test
-	public void testResolveScopesStarterScopesPlaceholder() {
+	void testResolveScopesStarterScopesPlaceholder() {
 		List<String> scopes = DefaultCredentialsProvider.resolveScopes(Arrays.asList("DEFAULT_SCOPES", "myscope"));
 		assertThat(scopes)
 				.hasSize(GcpScope.values().length + 1)

--- a/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/UserAgentHeaderProviderTests.java
+++ b/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/UserAgentHeaderProviderTests.java
@@ -18,7 +18,7 @@ package com.google.cloud.spring.core;
 
 import java.util.regex.Pattern;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mike Eltsufin
  * @author Chengyuan Zhao
  */
-public class UserAgentHeaderProviderTests {
+class UserAgentHeaderProviderTests {
 
 	static final String USER_AGENT_HEADER_NAME = "user-agent";
 
@@ -37,7 +37,7 @@ public class UserAgentHeaderProviderTests {
 	 * This test is check if the generated user-agent header is in the right format.
 	 */
 	@Test
-	public void testGetHeaders() {
+	void testGetHeaders() {
 		UserAgentHeaderProvider subject = new UserAgentHeaderProvider(this.getClass());
 
 		String versionRegex = ".*"; // no version verification because we don't have JAR MANIFEST

--- a/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/MapBuilderTests.java
+++ b/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/MapBuilderTests.java
@@ -18,7 +18,7 @@ package com.google.cloud.spring.core.util;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,10 +28,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Elena Felder
  */
-public class MapBuilderTests {
+class MapBuilderTests {
 
 	@Test
-	public void mapWithDistinctKeysBuildsAsExpected() {
+	void mapWithDistinctKeysBuildsAsExpected() {
 		Map<String, String> result = new MapBuilder<String, String>()
 				.put("a", "alpha")
 				.put("b", "beta")
@@ -44,13 +44,13 @@ public class MapBuilderTests {
 	}
 
 	@Test
-	public void emptyMapIsEmpty() {
+	void emptyMapIsEmpty() {
 		Map<String, String> result = new MapBuilder<String, String>().build();
 		assertThat(result).isEmpty();
 	}
 
 	@Test
-	public void mapWithNullKeyThrowsException() {
+	void mapWithNullKeyThrowsException() {
 		MapBuilder<String, String> mb = new MapBuilder<>();
 		assertThatThrownBy(() -> mb.put(null, "nope"))
 				.isInstanceOf(IllegalArgumentException.class)
@@ -58,7 +58,7 @@ public class MapBuilderTests {
 	}
 
 	@Test
-	public void mapWithNullValueThrowsException() {
+	void mapWithNullValueThrowsException() {
 		MapBuilder<String, String> mb = new MapBuilder<>();
 		assertThatThrownBy(() -> mb.put("nope", null))
 				.isInstanceOf(IllegalArgumentException.class)
@@ -66,7 +66,7 @@ public class MapBuilderTests {
 	}
 
 	@Test
-	public void mapWithDuplicateKeysThrowsException() {
+	void mapWithDuplicateKeysThrowsException() {
 		MapBuilder<String, String> mb = new MapBuilder<>();
 		mb.put("b", "beta");
 		assertThatThrownBy(() -> mb.put("b", "vita"))


### PR DESCRIPTION
Migrated the following tests from JUnit4 to JUnit5 : 

_**Module: spring-cloud-gcp-core**_

1. MapBuilderTests.java
2. DefaultCredentialsProviderTests.java
3. UserAgentHeaderProviderTests.java
