### PR TITLE
spring cloud gcp logging tests migration(JUnit4 to JUnit5)

### DIFF
--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/LoggingAppenderTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/LoggingAppenderTests.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spring.logging;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,10 +26,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mike Eltsufin
  * @since 1.2
  */
-public class LoggingAppenderTests {
+class LoggingAppenderTests {
 
 	@Test
-	public void testGetLoggingOptions() {
+	void testGetLoggingOptions() {
 		LoggingAppender loggingAppender = new LoggingAppender();
 		loggingAppender.setCredentialsFile("src/test/resources/fake-project-key.json");
 		assertThat(loggingAppender.getLoggingOptions().getCredentials()).isNotNull();

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/StackdriverJsonLayoutLoggerTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/StackdriverJsonLayoutLoggerTests.java
@@ -31,9 +31,9 @@ import com.google.gson.Gson;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.logging.slf4j.MDCContextMap;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
@@ -49,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Stefan Dieringer
  * @author Kazuki Shimizu
  */
-public class StackdriverJsonLayoutLoggerTests {
+class StackdriverJsonLayoutLoggerTests {
 
 	private static final Gson GSON = new Gson();
 
@@ -61,8 +61,8 @@ public class StackdriverJsonLayoutLoggerTests {
 
 	private MDCContextMap mdc;
 
-	@Before
-	public void setLoggingContext() {
+	@BeforeEach
+	void setLoggingContext() {
 		logOutput = new ByteArrayOutputStream();
 		System.setOut(new java.io.PrintStream(logOutput));
 
@@ -73,15 +73,15 @@ public class StackdriverJsonLayoutLoggerTests {
 		mdc.put("foo", "bar");
 	}
 
-	@After
-	public void cleanupLoggingContext() {
+	@AfterEach
+	void cleanupLoggingContext() {
 		// Reset the System output to System.out
 		System.setOut(CONSOLE_OUTPUT);
 		mdc.clear();
 	}
 
 	@Test
-	public void testEmulatorConfig() {
+	void testEmulatorConfig() {
 		LOGGER.warn("test");
 		Map<String, String> data = getLogMetadata();
 
@@ -102,7 +102,7 @@ public class StackdriverJsonLayoutLoggerTests {
 	}
 
 	@Test
-	public void testServiceContext() {
+	void testServiceContext() {
 		Logger logger = LoggerFactory.getLogger("StackdriverJsonLayoutServiceCtxLoggerTests");
 
 		logger.warn("test");
@@ -135,7 +135,7 @@ public class StackdriverJsonLayoutLoggerTests {
 	}
 
 	@Test
-	public void testNullMessage() {
+	void testNullMessage() {
 		Logger logger = LoggerFactory.getLogger("StackdriverJsonLayoutServiceCtxLoggerTests");
 
 		try {
@@ -158,7 +158,7 @@ public class StackdriverJsonLayoutLoggerTests {
 	}
 
 	@Test
-	public void testCustomMDCFieldForTraceIdAndSpanId() {
+	void testCustomMDCFieldForTraceIdAndSpanId() {
 		Logger logger = LoggerFactory.getLogger("StackdriverJsonLayoutCustomMDCFieldTests");
 
 		mdc.remove(StackdriverTraceConstants.MDC_FIELD_TRACE_ID);
@@ -186,7 +186,7 @@ public class StackdriverJsonLayoutLoggerTests {
 	}
 
 	@Test
-	public void test64BitTraceId() {
+	void test64BitTraceId() {
 		mdc.put(StackdriverTraceConstants.MDC_FIELD_TRACE_ID, "1234567890123456");
 
 		LOGGER.warn("test");
@@ -198,7 +198,7 @@ public class StackdriverJsonLayoutLoggerTests {
 	}
 
 	@Test
-	public void testEnhancerNoMdc() {
+	void testEnhancerNoMdc() {
 		// Test if no MDC is set.
 		mdc.clear();
 		String traceId = "1234567890123456";
@@ -212,7 +212,7 @@ public class StackdriverJsonLayoutLoggerTests {
 	}
 
 	@Test
-	public void testJsonLayoutEnhancer() {
+	void testJsonLayoutEnhancer() {
 		Logger logger = LoggerFactory.getLogger("StackdriverJsonLayoutServiceCtxLoggerTests");
 
 		Marker marker = MarkerFactory.getMarker("testMarker");
@@ -223,7 +223,7 @@ public class StackdriverJsonLayoutLoggerTests {
 	}
 
 	@Test
-	public void testJsonSeverityLevelMapping() {
+	void testJsonSeverityLevelMapping() {
 		// Tests that Logback levels are mapped to correct com.google.cloud logging severities.
 		LOGGER.trace("test");
 		LOGGER.debug("test");
@@ -245,7 +245,7 @@ public class StackdriverJsonLayoutLoggerTests {
 	}
 
 	@Test
-	public void testJsonLayoutEnhancer_missing() {
+	void testJsonLayoutEnhancer_missing() {
 		LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
 		assertThat(lc.getStatusManager().getCopyOfStatusList()
 				.stream()

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/TraceIdLoggingEnhancerTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/TraceIdLoggingEnhancerTests.java
@@ -21,8 +21,8 @@ import java.util.Map;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.cloud.logging.LogEntry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,19 +34,19 @@ import static org.mockito.Mockito.when;
  *
  * @author Mike Eltsufin
  */
-public class TraceIdLoggingEnhancerTests {
+class TraceIdLoggingEnhancerTests {
 
 	TraceIdLoggingEnhancer enhancer = new TraceIdLoggingEnhancer();
 
-	@Before
-	public void before() {
+	@BeforeEach
+	void before() {
 		enhancer.setProjectIdProvider(() -> "gcp-project");
 		MDC.clear();
 		TraceIdLoggingEnhancer.setCurrentTraceId(null);
 	}
 
 	@Test
-	public void testNoTraceIdAnywhere() {
+	void testNoTraceIdAnywhere() {
 		LogEntry.Builder logEntryBuilder = LogEntry.newBuilder(null);
 
 		enhancer.enhanceLogEntry(logEntryBuilder);
@@ -58,7 +58,7 @@ public class TraceIdLoggingEnhancerTests {
 	}
 
 	@Test
-	public void testLoggingEventMDC() {
+	void testLoggingEventMDC() {
 		LogEntry.Builder logEntryBuilder = LogEntry.newBuilder(null);
 
 		ILoggingEvent mockLoggingEvent = mock(ILoggingEvent.class);
@@ -79,7 +79,7 @@ public class TraceIdLoggingEnhancerTests {
 	}
 
 	@Test
-	public void testThreadLocalMDC() {
+	void testThreadLocalMDC() {
 		LogEntry.Builder logEntryBuilder = LogEntry.newBuilder(null);
 
 		MDC.put(StackdriverTraceConstants.MDC_FIELD_TRACE_ID, "tid123");
@@ -94,7 +94,7 @@ public class TraceIdLoggingEnhancerTests {
 	}
 
 	@Test
-	public void testThreadLocalTraceId() {
+	void testThreadLocalTraceId() {
 		TraceIdLoggingEnhancer.setCurrentTraceId("tid123");
 		LogEntry.Builder logEntryBuilder = LogEntry.newBuilder(null);
 

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/TraceIdLoggingWebMvcInterceptorTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/TraceIdLoggingWebMvcInterceptorTests.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spring.logging;
 
 import com.google.cloud.spring.logging.extractors.XCloudTraceIdExtractor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mike Eltsufin
  */
 
-public class TraceIdLoggingWebMvcInterceptorTests {
+class TraceIdLoggingWebMvcInterceptorTests {
 
 	private static final String TEST_TRACE_ID = "105445aa7843bc8bf206b120001000";
 
@@ -41,7 +41,7 @@ public class TraceIdLoggingWebMvcInterceptorTests {
 			new XCloudTraceIdExtractor());
 
 	@Test
-	public void testPreHandle() throws Exception {
+	void testPreHandle() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader(TRACE_ID_HEADER, TEST_TRACE_ID_WITH_SPAN);
 
@@ -53,7 +53,7 @@ public class TraceIdLoggingWebMvcInterceptorTests {
 	}
 
 	@Test
-	public void testAfterCompletion() throws Exception {
+	void testAfterCompletion() throws Exception {
 		TraceIdLoggingEnhancer.setCurrentTraceId(TEST_TRACE_ID);
 
 		this.interceptor.afterCompletion(null, null, null, null);

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/XCloudTraceIdExtractorTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/XCloudTraceIdExtractorTests.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spring.logging;
 
 import com.google.cloud.spring.logging.extractors.XCloudTraceIdExtractor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Chengyuan Zhao
  */
 
-public class XCloudTraceIdExtractorTests {
+class XCloudTraceIdExtractorTests {
 
 	private static final String TEST_TRACE_ID = "105445aa7843bc8bf206b120001000";
 
@@ -41,7 +41,7 @@ public class XCloudTraceIdExtractorTests {
 	private XCloudTraceIdExtractor extractor = new XCloudTraceIdExtractor();
 
 	@Test
-	public void testExtractTraceIdFromRequest_valid() {
+	void testExtractTraceIdFromRequest_valid() {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader(TRACE_ID_HEADER, TEST_TRACE_ID_WITH_SPAN);
 
@@ -51,7 +51,7 @@ public class XCloudTraceIdExtractorTests {
 	}
 
 	@Test
-	public void testExtractTraceIdFromRequest_missing() {
+	void testExtractTraceIdFromRequest_missing() {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 
 		String traceId = this.extractor.extractTraceIdFromRequest(request);
@@ -60,7 +60,7 @@ public class XCloudTraceIdExtractorTests {
 	}
 
 	@Test
-	public void testExtractTraceIdFromRequest_missingSpan() {
+	void testExtractTraceIdFromRequest_missingSpan() {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader(TRACE_ID_HEADER, TEST_TRACE_ID);
 

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/extensions/LogstashLoggingEventEnhancerTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/extensions/LogstashLoggingEventEnhancerTests.java
@@ -23,8 +23,8 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Payload;
 import net.logstash.logback.marker.Markers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,14 +33,14 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for {@link LogstashLoggingEventEnhancer}.
  */
-public class LogstashLoggingEventEnhancerTests {
+class LogstashLoggingEventEnhancerTests {
 
 	private ILoggingEvent loggingEvent;
 
 	private LogstashLoggingEventEnhancer enhancer;
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		enhancer = new LogstashLoggingEventEnhancer();
 
 		loggingEvent = Mockito.mock(ILoggingEvent.class);
@@ -53,7 +53,7 @@ public class LogstashLoggingEventEnhancerTests {
 	}
 
 	@Test
-	public void testEnhanceJson() {
+	void testEnhanceJson() {
 		Map<String, Object> jsonMap = new HashMap<>();
 		enhancer.enhanceJsonLogEntry(jsonMap, loggingEvent);
 		assertThat(jsonMap)
@@ -62,7 +62,7 @@ public class LogstashLoggingEventEnhancerTests {
 	}
 
 	@Test
-	public void testEnhanceLogEntry() {
+	void testEnhanceLogEntry() {
 		LogEntry.Builder logEntryBuilder = LogEntry.newBuilder(Payload.StringPayload.of("hello world"));
 		enhancer.enhanceLogEntry(logEntryBuilder, loggingEvent);
 


### PR DESCRIPTION
Migrated the following tests from  JUnit4 to JUnit5:

module: spring-cloud-gco-logging

