### PR TITLE
Implement datastore Blob to byte[] conversion on read

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
@@ -120,7 +120,7 @@ public class TwoStepsConversions implements ReadWriteConversions {
 	public <T> T convertOnRead(Object val, EmbeddedType embeddedType, TypeInformation targetTypeInformation) {
 		TypeInformation componentTypeInformation;
 		Class collectionType = null;
-		if (targetTypeInformation.isCollectionLike()) {
+		if (ValueUtil.isCollectionLike(targetTypeInformation.getType())) {
 			componentTypeInformation = targetTypeInformation.getComponentType();
 			collectionType = targetTypeInformation.getType();
 		}
@@ -175,9 +175,6 @@ public class TwoStepsConversions implements ReadWriteConversions {
 			catch (ConversionException | DatastoreDataException ex) {
 				throw new DatastoreDataException("Unable process elements of a collection", ex);
 			}
-		} else if (val.getClass().equals(Blob.class) && targetCollectionType == byte[].class) {
-			// Special case where a single value (Blob) becomes a collection (byte[]).
-			return (T)((Blob) val).toByteArray();
 		}
 		// Convert single value.
 		return (T) readConverter.apply(val, targetComponentType);

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
@@ -152,38 +152,35 @@ public class TwoStepsConversions implements ReadWriteConversions {
 			throw new DatastoreDataException(
 					"Unexpected property embedded type: " + embeddedType);
 		}
+
 		if (ValueUtil.isCollectionLike(val.getClass())
 				&& targetCollectionType != null && targetComponentType != null) {
 			// Convert collection.
-			return convertCollectionOnRead(val, targetCollectionType, targetComponentType, readConverter);
+			try {
+				List elements;
+				if (val.getClass().isArray()) {
+					elements = Collections.singletonList(val);
+				}
+				else {
+					elements = StreamSupport
+							.stream(((Iterable<?>) val).spliterator(), false)
+							.map(v -> {
+								Object o = (v instanceof Value) ? ((Value) v).get() : v;
+								return readConverter.apply(o, targetComponentType);
+							})
+							.collect(Collectors.toList());
+				}
+				return (T) convertCollection(elements, targetCollectionType);
+			}
+			catch (ConversionException | DatastoreDataException ex) {
+				throw new DatastoreDataException("Unable process elements of a collection", ex);
+			}
 		} else if (val.getClass().equals(Blob.class) && targetCollectionType == byte[].class) {
 			// Special case where a single value (Blob) becomes a collection (byte[]).
 			return (T)((Blob) val).toByteArray();
 		}
 		// Convert single value.
 		return (T) readConverter.apply(val, targetComponentType);
-	}
-
-	private <T> T convertCollectionOnRead(Object val, Class targetCollectionType, TypeInformation targetComponentType, BiFunction<Object, TypeInformation<?>, ?> readConverter) {
-		try {
-			List elements;
-			if (val.getClass().isArray()) {
-				elements = Collections.singletonList(val);
-			}
-			else {
-				elements = StreamSupport
-						.stream(((Iterable<?>) val).spliterator(), false)
-						.map(v -> {
-							Object o = (v instanceof Value) ? ((Value) v).get() : v;
-							return readConverter.apply(o, targetComponentType);
-						})
-						.collect(Collectors.toList());
-			}
-			return (T) convertCollection(elements, targetCollectionType);
-		}
-		catch (ConversionException | DatastoreDataException ex) {
-			throw new DatastoreDataException("Unable process elements of a collection", ex);
-		}
 	}
 
 	private <T, R> Map<T, R> convertOnReadSingleEmbeddedMap(Object value,

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
@@ -152,20 +152,21 @@ public class TwoStepsConversions implements ReadWriteConversions {
 			throw new DatastoreDataException(
 					"Unexpected property embedded type: " + embeddedType);
 		}
-
 		if (ValueUtil.isCollectionLike(val.getClass())
 				&& targetCollectionType != null && targetComponentType != null) {
+			// Convert collection.
 			return convertCollectionOnRead(val, targetCollectionType, targetComponentType, readConverter);
 		} else if (val.getClass().equals(Blob.class) && targetCollectionType == byte[].class) {
+			// Special case where a single value (Blob) becomes a collection (byte[]).
 			return (T)((Blob) val).toByteArray();
 		}
+		// Convert single value.
 		return (T) readConverter.apply(val, targetComponentType);
 	}
 
 	private <T> T convertCollectionOnRead(Object val, Class targetCollectionType, TypeInformation targetComponentType, BiFunction<Object, TypeInformation<?>, ?> readConverter) {
 		try {
 			List elements;
-
 			if (val.getClass().isArray()) {
 				elements = Collections.singletonList(val);
 			}

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
@@ -103,7 +103,8 @@ public class DefaultDatastoreEntityConverterTests {
 	public void readTest() {
 		byte[] bytes = { 1, 2, 3 };
 		Key otherKey = Key.newBuilder("testproject", "test_kind", "test_name").build();
-		Entity entity = getEntityBuilder()
+		// entity as it would come back from the backend / client library.
+		Entity datastoreEntity = getEntityBuilder()
 				.set("durationField", "PT24H")
 				.set("stringField", "string value")
 				.set("boolField", true)
@@ -115,22 +116,26 @@ public class DefaultDatastoreEntityConverterTests {
 				.set("intField", 99)
 				.set("enumField", "WHITE")
 				.set("keyField", otherKey)
+				.set("byteArrayField", Blob.copyFrom(bytes))
 				.build();
-		TestDatastoreItem item = ENTITY_CONVERTER.read(TestDatastoreItem.class, entity);
+		// Plain Java Object that the user expects to operate on.
+		TestDatastoreItem userItem = ENTITY_CONVERTER.read(TestDatastoreItem.class, datastoreEntity);
 
-		assertThat(item.getDurationField()).as("validate duration field").isEqualTo(Duration.ofDays(1));
-		assertThat(item.getStringField()).as("validate string field").isEqualTo("string value");
-		assertThat(item.getBoolField()).as("validate boolean field").isTrue();
-		assertThat(item.getDoubleField()).as("validate double field").isEqualTo(3.1415D);
-		assertThat(item.getLongField()).as("validate long field").isEqualTo(123L);
-		assertThat(item.getLatLngField()).as("validate latLng field")
+		assertThat(userItem.getDurationField()).as("validate duration field").isEqualTo(Duration.ofDays(1));
+		assertThat(userItem.getStringField()).as("validate string field").isEqualTo("string value");
+		assertThat(userItem.getBoolField()).as("validate boolean field").isTrue();
+		assertThat(userItem.getDoubleField()).as("validate double field").isEqualTo(3.1415D);
+		assertThat(userItem.getLongField()).as("validate long field").isEqualTo(123L);
+		assertThat(userItem.getLatLngField()).as("validate latLng field")
 				.isEqualTo(LatLng.of(10, 20));
-		assertThat(item.getTimestampField()).as("validate timestamp field")
+		assertThat(userItem.getTimestampField()).as("validate timestamp field")
 				.isEqualTo(Timestamp.ofTimeSecondsAndNanos(30, 40));
-		assertThat(item.getBlobField()).as("validate blob field").isEqualTo(Blob.copyFrom(bytes));
-		assertThat(item.getIntField()).as("validate int field").isEqualTo(99);
-		assertThat(item.getEnumField()).as("validate enum field").isEqualTo(TestDatastoreItem.Color.WHITE);
-		assertThat(item.getKeyField()).as("validate key field").isEqualTo(otherKey);
+		assertThat(userItem.getBlobField()).as("validate blob field").isEqualTo(Blob.copyFrom(bytes));
+		assertThat(userItem.getIntField()).as("validate int field").isEqualTo(99);
+		assertThat(userItem.getEnumField()).as("validate enum field").isEqualTo(TestDatastoreItem.Color.WHITE);
+		assertThat(userItem.getKeyField()).as("validate key field").isEqualTo(otherKey);
+
+		assertThat(userItem.getByteArrayField()).as("validate byte array field").isEqualTo(bytes);
 	}
 
 	@Test

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
@@ -116,7 +116,6 @@ public class DefaultDatastoreEntityConverterTests {
 				.set("intField", 99)
 				.set("enumField", "WHITE")
 				.set("keyField", otherKey)
-				.set("byteArrayField", Blob.copyFrom(bytes))
 				.build();
 		// Plain Java Object that the user expects to operate on.
 		TestDatastoreItem userItem = ENTITY_CONVERTER.read(TestDatastoreItem.class, datastoreEntity);
@@ -134,6 +133,18 @@ public class DefaultDatastoreEntityConverterTests {
 		assertThat(userItem.getIntField()).as("validate int field").isEqualTo(99);
 		assertThat(userItem.getEnumField()).as("validate enum field").isEqualTo(TestDatastoreItem.Color.WHITE);
 		assertThat(userItem.getKeyField()).as("validate key field").isEqualTo(otherKey);
+	}
+
+	@Test
+	public void readTestByteArray() {
+		byte[] bytes = { 1, 2, 3 };
+
+		// Datastore Entity from the backend / client library.
+		Entity datastoreEntity = getEntityBuilder()
+				.set("byteArrayField", Blob.copyFrom(bytes))
+				.build();
+		// Plain Java Object that the user expects to operate on.
+		TestDatastoreItem userItem = ENTITY_CONVERTER.read(TestDatastoreItem.class, datastoreEntity);
 
 		assertThat(userItem.getByteArrayField()).as("validate byte array field").isEqualTo(bytes);
 	}

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
@@ -103,7 +103,7 @@ public class DefaultDatastoreEntityConverterTests {
 	public void readTest() {
 		byte[] bytes = { 1, 2, 3 };
 		Key otherKey = Key.newBuilder("testproject", "test_kind", "test_name").build();
-		// entity as it would come back from the backend / client library.
+		// Datastore Entity from the backend / client library.
 		Entity datastoreEntity = getEntityBuilder()
 				.set("durationField", "PT24H")
 				.set("stringField", "string value")

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/DatastoreRepositoryExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/DatastoreRepositoryExample.java
@@ -16,6 +16,7 @@
 
 package com.example;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
@@ -69,6 +70,7 @@ public class DatastoreRepositoryExample {
 							new Album("b", LocalDate.of(2018, Month.FEBRUARY, 12)))));
 			Singer richardRoe = new Singer("singer3", "Richard", "Roe",
 					new HashSet<>(Arrays.asList(new Album("c", LocalDate.of(2000, Month.AUGUST, 31)))));
+			richardRoe.setPassword("insecure".getBytes(StandardCharsets.UTF_8));
 
 			this.singerRepository.saveAll(Arrays.asList(janeDoe, richardRoe));
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/DatastoreRepositoryExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/DatastoreRepositoryExample.java
@@ -70,7 +70,7 @@ public class DatastoreRepositoryExample {
 							new Album("b", LocalDate.of(2018, Month.FEBRUARY, 12)))));
 			Singer richardRoe = new Singer("singer3", "Richard", "Roe",
 					new HashSet<>(Arrays.asList(new Album("c", LocalDate.of(2000, Month.AUGUST, 31)))));
-			richardRoe.setPassword("insecure".getBytes(StandardCharsets.UTF_8));
+			richardRoe.setMessage("Hello, dear fans!".getBytes(StandardCharsets.UTF_8));
 
 			this.singerRepository.saveAll(Arrays.asList(janeDoe, richardRoe));
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/Singer.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/Singer.java
@@ -64,6 +64,8 @@ public class Singer {
 
 	private Set<Album> albums;
 
+	private byte[] password;
+
 	public Singer() {
 	}
 
@@ -130,6 +132,14 @@ public class Singer {
 		this.albums = albums;
 	}
 
+	public byte[] getPassword() {
+		return password;
+	}
+
+	public void setPassword(byte[] password) {
+		this.password = password;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -162,6 +172,7 @@ public class Singer {
 				+ ((this.personalInstruments == null) ? ""
 						: Strings.join(this.personalInstruments.stream()
 								.map(x -> x.getType()).collect(Collectors.toList()), ','))
+				+ ((this.password == null) ? "" : ", Password (don't actually ever do this): " + new String(password) )
 				+ '}';
 	}
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/Singer.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/Singer.java
@@ -172,7 +172,7 @@ public class Singer {
 				+ ((this.personalInstruments == null) ? ""
 						: Strings.join(this.personalInstruments.stream()
 								.map(x -> x.getType()).collect(Collectors.toList()), ','))
-				+ ((this.message == null) ? "" : ", Message: " + new String(message) )
+				+ ((this.message == null) ? "" : ", Message: " + new String(message))
 				+ '}';
 	}
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/Singer.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/Singer.java
@@ -64,7 +64,7 @@ public class Singer {
 
 	private Set<Album> albums;
 
-	private byte[] password;
+	private byte[] message;
 
 	public Singer() {
 	}
@@ -132,12 +132,12 @@ public class Singer {
 		this.albums = albums;
 	}
 
-	public byte[] getPassword() {
-		return password;
+	public byte[] getMessage() {
+		return message;
 	}
 
-	public void setPassword(byte[] password) {
-		this.password = password;
+	public void setMessage(byte[] message) {
+		this.message = message;
 	}
 
 	@Override
@@ -172,7 +172,7 @@ public class Singer {
 				+ ((this.personalInstruments == null) ? ""
 						: Strings.join(this.personalInstruments.stream()
 								.map(x -> x.getType()).collect(Collectors.toList()), ','))
-				+ ((this.password == null) ? "" : ", Password (don't actually ever do this): " + new String(password) )
+				+ ((this.message == null) ? "" : ", Message: " + new String(message) )
 				+ '}';
 	}
 


### PR DESCRIPTION
Blob-to-byte[] and reverse are a special case in conversion -- it's the only exception to the general rule of "Datastore collection becomes Java collection; Datastore simple type becomes Java type". It seems to have been intended to work in original implementation, but never had a test, so either never worked right or broke over the years. The other direction, on write, works fine through `BYTE_ARRAY_TO_BLOB_CONVERTER` combined with `ValueUtil.isArrayOfItems()` exempting `byte[]` from array status. 

There were several ways of fixing this (each commit in this PR is a working solution), but at the end I went with making the standard conversion path worked. It required redefining the meaning of collection to exclude byte arrays, which is already done in the local utility `ValueUtil.isArrayOfItems()`. I replaced Spring Data's built-in `TypeDiscoverer.isCollectionLike()`, which (reasonably) assumes byte arrays are collection-like with the Spring Cloud Gcp Datastore implementation-specific  `ValueUtil.isArrayOfItems()`, which excludes `byte[]`. This exclusion is already documented in the refdoc, so no additional documentation is needed.

Fixes #661.
