### PR TITLE
Fixes for`PubSubMessageChannelBinderEmulatorIntegrationTests`

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubEmulator.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubEmulator.java
@@ -102,19 +102,19 @@ public class PubSubEmulator implements BeforeAllCallback, AfterAllCallback, Para
 	}
 
 	/**
-	 * Set up ParameterResolver to support PubSubEmulator as parameter type.
+	 * Set up ParameterResolver to support String as parameter type.
 	 */
 	@Override
 	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-		return parameterContext.getParameter().getType() == PubSubEmulator.class;
+		return parameterContext.getParameter().getType() == String.class;
 	}
 
 	/**
-	 * Set up ParameterResolver to return current instance of PubSubEmulator to test.
+	 * Set up ParameterResolver to return current emulatorHostPort to test.
 	 */
 	@Override
-	public PubSubEmulator resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-		return this;
+	public String resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+		return this.emulatorHostPort;
 	}
 
 	/**

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
@@ -45,9 +45,9 @@ class PubSubMessageChannelBinderEmulatorIntegrationTests extends
 
 	private String hostPort;
 
-	// Constructor gets PubSubEmulator instance from ParameterResolver
-	public PubSubMessageChannelBinderEmulatorIntegrationTests(PubSubEmulator pubSubEmulator) {
-		this.hostPort = pubSubEmulator.getEmulatorHostPort();
+	// Constructor gets PubSubEmulator port number from ParameterResolver
+	public PubSubMessageChannelBinderEmulatorIntegrationTests(String pubSubEmulatorPort) {
+		this.hostPort = pubSubEmulatorPort;
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
@@ -42,14 +42,16 @@ class PubSubMessageChannelBinderEmulatorIntegrationTests extends
 		AbstractBinderTests<PubSubTestBinder, ExtendedConsumerProperties<PubSubConsumerProperties>,
 				ExtendedProducerProperties<PubSubProducerProperties>> {
 
-	/**
-	 * The emulator instance, shared across tests.
-	 */
-	public static PubSubEmulator emulator = new PubSubEmulator();
+	// port set up through emulator instance
+	private String hostPort;
+
+	public void setHostPort(String hostPort) {
+		this.hostPort = hostPort;
+	}
 
 	@Override
 	protected PubSubTestBinder getBinder() {
-		return new PubSubTestBinder(emulator.getEmulatorHostPort());
+		return new PubSubTestBinder(this.hostPort);
 	}
 
 	@Override
@@ -74,14 +76,14 @@ class PubSubMessageChannelBinderEmulatorIntegrationTests extends
 		// Do nothing. Original test tests for Lifecycle logic that we don't need.
 
 		// Dummy assertion to appease SonarCloud.
-		assertThat(emulator.getEmulatorHostPort()).isNotNull();
+		assertThat(this.hostPort).isNotNull();
 	}
 
 	@Test
 	@Disabled("Looks like there is no Kryo support in SCSt")
 	void testSendPojoReceivePojoKryoWithStreamListener() {
 		// Dummy assertion to appease SonarCloud.
-		assertThat(emulator.getEmulatorHostPort()).isNotNull();
+		assertThat(this.hostPort).isNotNull();
 	}
 
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
@@ -21,6 +21,7 @@ import com.google.cloud.spring.stream.binder.pubsub.properties.PubSubProducerPro
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.cloud.stream.binder.AbstractBinderTests;
@@ -42,11 +43,11 @@ class PubSubMessageChannelBinderEmulatorIntegrationTests extends
 		AbstractBinderTests<PubSubTestBinder, ExtendedConsumerProperties<PubSubConsumerProperties>,
 				ExtendedProducerProperties<PubSubProducerProperties>> {
 
-	// port set up through emulator instance
 	private String hostPort;
 
-	public void setHostPort(String hostPort) {
-		this.hostPort = hostPort;
+	// Constructor gets PubSubEmulator instance from ParameterResolver
+	public PubSubMessageChannelBinderEmulatorIntegrationTests(PubSubEmulator pubSubEmulator) {
+		this.hostPort = pubSubEmulator.getEmulatorHostPort();
 	}
 
 	@Override

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
@@ -21,7 +21,6 @@ import com.google.cloud.spring.stream.binder.pubsub.properties.PubSubProducerPro
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.cloud.stream.binder.AbstractBinderTests;
@@ -46,7 +45,7 @@ class PubSubMessageChannelBinderEmulatorIntegrationTests extends
 	private String hostPort;
 
 	// Constructor gets PubSubEmulator port number from ParameterResolver
-	public PubSubMessageChannelBinderEmulatorIntegrationTests(String pubSubEmulatorPort) {
+	PubSubMessageChannelBinderEmulatorIntegrationTests(String pubSubEmulatorPort) {
 		this.hostPort = pubSubEmulatorPort;
 	}
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubTestBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubTestBinder.java
@@ -107,6 +107,7 @@ public class PubSubTestBinder extends AbstractTestBinder<PubSubMessageChannelBin
 				new PubSubMessageChannelBinder(null, pubSubChannelProvisioner, pubSubTemplate,
 						new PubSubExtendedBindingProperties());
 		GenericApplicationContext context = new GenericApplicationContext();
+		context.refresh();
 		binder.setApplicationContext(context);
 		this.setBinder(binder);
 	}


### PR DESCRIPTION
This is step 2 and fixes #707 

There are 2 fixes in this PR: 
1. Let `PubSubEmulator` extend `ParameterResolver` to inject the emulator port number into the instance. This is left-over from task 1 upgrading to junit5 test, solves the `java.lang.NullPointerException: target` error caused by no port number provided.
2. After above change, tests fail due to a [recent change](https://github.com/spring-cloud/spring-cloud-stream/commit/2c47c6de8977345e0595ba122adf89c2709c41d6#diff-70aeaabb8c7de9d4d4b239ba643f594bf49f111d18569056dd93a835d5e9867cR132) in spring-cloud-stream logic. 
    - when checking if context already has an ObjectMapper bean, calls `getBeansOfType(ObjectMapper.class)`, which has an internal call to `assertBeanFactoryActive()`
    - Test setup fails with error: `“org.springframework.context.support.GenericApplicationContexthas not been refreshed yet”`.
    - Fix by `refresh` the context.

Both fixes are within the test setup.