### PR TITLE
Datastore: remove unused code handling array conversion

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/ReadWriteConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/ReadWriteConversions.java
@@ -36,7 +36,7 @@ public interface ReadWriteConversions {
 
 	/**
 	 * Converts a given object to an object of a target type.
-	 * @param val the value to convert
+	 * @param val the simple type or Iterable value to convert. Arrays are not supported.
 	 * @param targetCollectionType the type of the collection to be converted into.
 	 * {@code null} if the property is a singular object.
 	 * @param targetComponentType the type of the property to convert. For collection-like
@@ -50,7 +50,7 @@ public interface ReadWriteConversions {
 	/**
 	 * Converts a given object to an object of a target type that is possibly an embedded
 	 * entity.
-	 * @param val the value to convert.
+	 * @param val the simple type or Iterable value to convert. Arrays are not supported.
 	 * @param embeddedType contains the type of embedded entity conversion should produce.
 	 * @param targetTypeInformation type metadata information for the desired type.
 	 * @param <T> the type of the object that is produced by reading

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
@@ -17,7 +17,6 @@
 package com.google.cloud.spring.data.datastore.core.convert;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -157,19 +156,14 @@ public class TwoStepsConversions implements ReadWriteConversions {
 				&& targetCollectionType != null && targetComponentType != null) {
 			// Convert collection.
 			try {
-				List elements;
-				if (val.getClass().isArray()) {
-					elements = Collections.singletonList(val);
-				}
-				else {
-					elements = StreamSupport
+				Assert.isInstanceOf(Iterable.class, val, "Value passed to convertOnRead expected to be Iterable");
+				List elements = StreamSupport
 							.stream(((Iterable<?>) val).spliterator(), false)
 							.map(v -> {
 								Object o = (v instanceof Value) ? ((Value) v).get() : v;
 								return readConverter.apply(o, targetComponentType);
 							})
 							.collect(Collectors.toList());
-				}
 				return (T) convertCollection(elements, targetCollectionType);
 			}
 			catch (ConversionException | DatastoreDataException ex) {

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversionsTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversionsTests.java
@@ -104,7 +104,7 @@ class TwoStepsConversionsTests {
 	}
 
 	@Test
-	public void convertingArrayNotSupported() {
+	void convertingArrayNotSupported() {
 		String[] arr = new String[] { "a", "b", "c"};
 
 		assertThatThrownBy(() -> {

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversionsTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversionsTests.java
@@ -103,4 +103,13 @@ public class TwoStepsConversionsTests {
 		assertThat(result).isEqualTo("three");
 	}
 
+	@Test
+	public void convertingArrayNotSupported() {
+		String[] arr = new String[] { "a", "b", "c"};
+
+		assertThatThrownBy(() -> {
+					this.twoStepsConversions.<String>convertOnRead(arr, List.class, String.class);
+				}).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Value passed to convertOnRead expected to be Iterable");
+	}
 }


### PR DESCRIPTION
**I want a second opinion on this. TLDR: code handling array-to-list conversion broke a year ago and nobody noticed. We can either (1) remove this code entirely (and document it as unsupported) or (2) fix the array-to-list conversion to the way it was before #284 and add a test.** In an ideal world, I'd prefer a type-safe conversion interface that has separate methods to convert single values and collections, but we don't have bandwidth for refactoring what's not technically broken.

When working on #729, this block in `convertOnRead(Object, EmbeddedType, TypeInformation)` was bothering me -- it did not seem right to make a List-wrapped array.
```
if (val.getClass().isArray()) {
  elements = Collections.singletonList(val);
}
```
Looking into the history of the change, this line accidentally changed behavior (old behavior: convert array to an equivalent list; new behavior: convert array into as single-element list with the array wrapped as the lone element) as part of a [routine code cleanup](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/76ddf6cc96c7cf5f4fe73fb77f41a248c123d521). I missed this behavior change in code review, but also it's a consequence of the non-type-safe nature of the original code.
Since this would be a breaking change, I suspected that this code was never used. The following is brute-force (brute tediousness?) proof that it is safe to remove this code.
	
					

TwoStepsConversions.convertOnRead(Object, EmbeddedType, Class, TypeInformation) is private and called from 2 places: convertOnRead(Object, Class, Class) and convertOnRead(Object, EmbeddedType, TypeInformation. These are both public because they want to get accessed from autoconfiguration, not because they are part of any documented API.
1. convertOnRead(Object, Class, Class) is called from 4 places: 
    - `DatastoreTemplate.fetchReferenced()`, which passes a List<T> returned from findAllById() as the first parameter
    - `DatastoreTemplate.resolveDescendantProperties()`, which passes an unparameterized List as the first parameter. 
    - `GqlDatastoreQuery.convertCollectionResult()`, which passes `DatastoreResultsIterable`, therefore not an array
    - `GqlDatastoreQuery.convertSingularResult()`. This was a bit hard to reason about, since theoretically the object passed is the first element in a collection returned from either `queryIterable()` or `queryKeysOrEntities()`. 
      - `queryIterable()` will operate on a `DatastoreResultsIterable` of objects returned from `GqlDatastoreQuery::getNonEntityObjectFromRow`, which can be either Key or a primitive Datastore type. Neither is an array.
      - `queryKeysOrEntities()` returns an interable of either Key objects or results from `DatastoreTemplate.convertEntitiesForRead()`, which is a typed List.
    So this use is safe against possibility of an array being passed.
2. convertOnRead(Object val, EmbeddedType embeddedType, TypeInformation targetTypeInformation) is called from 3 places:
    - `DefaultDatastoreEntityConverter.readAsMap()`, which always passes a `String`, so not an array.
    - `EntityPropertyValueProvider.persistentProperty()` which passes a key (extension of `IncompleteKey`).
    - `EntityPropertyValueProvider.getPropertyValue()` which passes a native Datastore type.
  
  I've further verified that this change is safe by adding an exception to the `if (val.getClass().isArray()) {` block and running all unit tests plus all datastore integration tests.
  
  