### PR TITLE
update spring-cloud-config.version for pubsub-bus-config-sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
@@ -15,7 +15,7 @@
     <name>Spring Cloud GCP Code Sample - Pub/Sub Bus Configuration Management</name>
 
     <properties>
-        <spring-cloud-config.version>3.0.4</spring-cloud-config.version>
+        <spring-cloud-config.version>3.1.0-RC1</spring-cloud-config.version>
     </properties>
 
     <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->


### PR DESCRIPTION
Update spring-cloud-config.version for pubsub-bus-config-sample compatible with Spring Boot 2.6.0-RC1.