### PR TITLE
spring cloud gcp pubsub tests migration(JUnit4 to JUnit5)

### DIFF
--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
@@ -18,14 +18,14 @@ package com.google.cloud.spring.pubsub.core;
 
 import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.rpc.StatusCode.Code;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PubSubConfigurationTests {
+class PubSubConfigurationTests {
 
 	@Test
-	public void testDefaultHealthProperties() {
+	void testDefaultHealthProperties() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Health health = pubSubConfiguration.getHealth();
 
@@ -36,7 +36,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testDefaultSubscriberProperties() {
+	void testDefaultSubscriberProperties() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = pubSubConfiguration.getSubscriber();
 		PubSubConfiguration.FlowControl flowControl = subscriber.getFlowControl();
@@ -65,7 +65,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testSubscriberProperties() {
+	void testSubscriberProperties() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = pubSubConfiguration.getSubscriber();
 
@@ -88,7 +88,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testHealthProperties() {
+	void testHealthProperties() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Health health = pubSubConfiguration.getHealth();
 
@@ -104,7 +104,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testSubscriberFlowControlSettings() {
+	void testSubscriberFlowControlSettings() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = pubSubConfiguration.getSubscriber();
 		PubSubConfiguration.FlowControl flowControl = subscriber.getFlowControl();
@@ -120,7 +120,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputeFlowControlSettings_returnCustom() {
+	void testComputeFlowControlSettings_returnCustom() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
 		PubSubConfiguration.FlowControl selectiveFlowControl = subscriber.getFlowControl();
@@ -142,7 +142,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputeFlowControlSettings_returnGlobal() {
+	void testComputeFlowControlSettings_returnGlobal() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber globalSubscriber = pubSubConfiguration.getSubscriber();
 		PubSubConfiguration.FlowControl globalFlowControl = globalSubscriber.getFlowControl();
@@ -162,7 +162,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputeParallelPullCount_returnCustom() {
+	void testComputeParallelPullCount_returnCustom() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
 		subscriber.setParallelPullCount(2);
@@ -176,7 +176,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputeParallelPullCount_returnGlobal() {
+	void testComputeParallelPullCount_returnGlobal() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber globalSubscriber = pubSubConfiguration.getSubscriber();
 		globalSubscriber.setParallelPullCount(2);
@@ -189,7 +189,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputePullEndpoint_returnCustom() {
+	void testComputePullEndpoint_returnCustom() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
 		subscriber.setPullEndpoint("endpoint");
@@ -203,7 +203,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputePullEndpoint_returnGlobal() {
+	void testComputePullEndpoint_returnGlobal() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber globalSubscriber = pubSubConfiguration.getSubscriber();
 		globalSubscriber.setPullEndpoint("endpoint");
@@ -216,7 +216,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputeMaxAckExtensionPeriod_returnCustom() {
+	void testComputeMaxAckExtensionPeriod_returnCustom() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
 		subscriber.setMaxAckExtensionPeriod(1L);
@@ -230,7 +230,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputeMaxAckExtensionPeriod_returnGlobal() {
+	void testComputeMaxAckExtensionPeriod_returnGlobal() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber globalSubscriber = pubSubConfiguration.getSubscriber();
 		globalSubscriber.setMaxAckExtensionPeriod(2L);
@@ -243,7 +243,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputeMaxAckExtensionPeriod_returnDefault() {
+	void testComputeMaxAckExtensionPeriod_returnDefault() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 
 		Long result = pubSubConfiguration.computeMaxAckExtensionPeriod(
@@ -254,7 +254,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testSubscriberRetrySettings() {
+	void testSubscriberRetrySettings() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = pubSubConfiguration.getSubscriber();
 		PubSubConfiguration.Retry retrySettings = subscriber.getRetry();
@@ -281,7 +281,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputeSubscriberRetrySettings_returnCustom() {
+	void testComputeSubscriberRetrySettings_returnCustom() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
 		PubSubConfiguration.Retry retry = subscriber.getRetry();
@@ -314,7 +314,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputeSubscriberRetrySettings_returnGlobal() {
+	void testComputeSubscriberRetrySettings_returnGlobal() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber globalSubscriber = pubSubConfiguration.getSubscriber();
 		PubSubConfiguration.Retry retry = globalSubscriber.getRetry();
@@ -344,7 +344,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputeRetryableCodes_returnsGlobal() {
+	void testComputeRetryableCodes_returnsGlobal() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber globalSubscriber = pubSubConfiguration.getSubscriber();
 
@@ -355,7 +355,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testComputeRetryableCodes_returnCustom() {
+	void testComputeRetryableCodes_returnCustom() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
 		subscriber.setRetryableCodes(new Code[] { Code.INTERNAL });
@@ -367,7 +367,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testSubscriberMapProperties_defaultOrGlobal_addToMap() {
+	void testSubscriberMapProperties_defaultOrGlobal_addToMap() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 
 		assertThat(pubSubConfiguration.getSubscription()).isEmpty();
@@ -379,7 +379,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testSubscriberMapProperties_subscriptionName_returnCustom() {
+	void testSubscriberMapProperties_subscriptionName_returnCustom() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
 		subscriber.setExecutorThreads(8);
@@ -395,7 +395,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testSubscriberMapProperties_fullNamePresentInMap_returnCustom() {
+	void testSubscriberMapProperties_fullNamePresentInMap_returnCustom() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
 		subscriber.setExecutorThreads(8);
@@ -410,7 +410,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testSubscriberMapProperties_fullNamePresentInMap_projectIdIgnored_returnCustom() {
+	void testSubscriberMapProperties_fullNamePresentInMap_projectIdIgnored_returnCustom() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
 		subscriber.setExecutorThreads(8);
@@ -427,7 +427,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testDefaultPublisherProperties() {
+	void testDefaultPublisherProperties() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Publisher publisher = pubSubConfiguration.getPublisher();
 		PubSubConfiguration.Batching batching = publisher.getBatching();
@@ -454,7 +454,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testPublisherProperties() {
+	void testPublisherProperties() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Publisher publisher = pubSubConfiguration.getPublisher();
 
@@ -468,7 +468,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testPublisherBatchingSettings() {
+	void testPublisherBatchingSettings() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Publisher publisher = pubSubConfiguration.getPublisher();
 		PubSubConfiguration.Batching batching = publisher.getBatching();
@@ -493,7 +493,7 @@ public class PubSubConfigurationTests {
 	}
 
 	@Test
-	public void testPublisherRetrySettings() {
+	void testPublisherRetrySettings() {
 		PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
 		PubSubConfiguration.Publisher publisher = pubSubConfiguration.getPublisher();
 		PubSubConfiguration.Retry retrySettings = publisher.getRetry();

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubAcknowledgmentCallbackTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubAcknowledgmentCallbackTests.java
@@ -18,8 +18,8 @@ package com.google.cloud.spring.pubsub.integration.inbound;
 
 import com.google.cloud.spring.pubsub.integration.AckMode;
 import com.google.cloud.spring.pubsub.support.AcknowledgeablePubsubMessage;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.acks.AcknowledgmentCallback;
 
@@ -35,31 +35,31 @@ import static org.mockito.Mockito.verify;
  *
  * @since 1.2
  */
-public class PubSubAcknowledgmentCallbackTests {
+ class PubSubAcknowledgmentCallbackTests {
 
 	private AcknowledgeablePubsubMessage mockMessage;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 		this.mockMessage = mock(AcknowledgeablePubsubMessage.class);
 	}
 
 	@Test
-	public void constructor_nullMessageFailsAssert() {
+	void constructor_nullMessageFailsAssert() {
 		assertThatThrownBy(() -> new PubSubAcknowledgmentCallback(null, AckMode.MANUAL))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("message to be acknowledged cannot be null");
 	}
 
 	@Test
-	public void constructor_nullAckModeFailsAssert() {
+	void constructor_nullAckModeFailsAssert() {
 		assertThatThrownBy(() -> new PubSubAcknowledgmentCallback(this.mockMessage, null))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("ackMode cannot be null");
 	}
 
 	@Test
-	public void acknowledge_acksOnAccept() {
+	void acknowledge_acksOnAccept() {
 		PubSubAcknowledgmentCallback callback = new PubSubAcknowledgmentCallback(this.mockMessage, AckMode.AUTO);
 		callback.acknowledge(AcknowledgmentCallback.Status.ACCEPT);
 		verify(this.mockMessage).ack();
@@ -67,7 +67,7 @@ public class PubSubAcknowledgmentCallbackTests {
 	}
 
 	@Test
-	public void acknowledge_nacksOnReject() {
+	void acknowledge_nacksOnReject() {
 		PubSubAcknowledgmentCallback callback = new PubSubAcknowledgmentCallback(this.mockMessage, AckMode.AUTO);
 		callback.acknowledge(AcknowledgmentCallback.Status.REJECT);
 		verify(this.mockMessage).nack();
@@ -75,7 +75,7 @@ public class PubSubAcknowledgmentCallbackTests {
 	}
 
 	@Test
-	public void acknowledge_nacksOnRequeue() {
+	void acknowledge_nacksOnRequeue() {
 		PubSubAcknowledgmentCallback callback = new PubSubAcknowledgmentCallback(this.mockMessage, AckMode.AUTO);
 		callback.acknowledge(AcknowledgmentCallback.Status.REQUEUE);
 		verify(this.mockMessage).nack();
@@ -83,38 +83,38 @@ public class PubSubAcknowledgmentCallbackTests {
 	}
 
 	@Test
-	public void isAutoAckTrueForAutoMode() {
+	void isAutoAckTrueForAutoMode() {
 		PubSubAcknowledgmentCallback callback = new PubSubAcknowledgmentCallback(this.mockMessage, AckMode.AUTO);
 		assertThat(callback.isAutoAck()).isTrue();
 	}
 
 	@Test
-	public void isAutoAckTrueForAutoAckMode() {
+	void isAutoAckTrueForAutoAckMode() {
 		PubSubAcknowledgmentCallback callback = new PubSubAcknowledgmentCallback(this.mockMessage, AckMode.AUTO_ACK);
 		assertThat(callback.isAutoAck()).isTrue();
 	}
 
 	@Test
-	public void isAutoAckFalseFroManualMode() {
+	void isAutoAckFalseFroManualMode() {
 		PubSubAcknowledgmentCallback callback = new PubSubAcknowledgmentCallback(this.mockMessage, AckMode.MANUAL);
 		assertThat(callback.isAutoAck()).isFalse();
 	}
 
 	@Test
-	public void isAcknowledgedFalseForNewCallback() {
+	void isAcknowledgedFalseForNewCallback() {
 		PubSubAcknowledgmentCallback callback = new PubSubAcknowledgmentCallback(this.mockMessage, AckMode.MANUAL);
 		assertThat(callback.isAcknowledged()).isFalse();
 	}
 
 	@Test
-	public void isAcknowledgedTrueAfterAccept() {
+	void isAcknowledgedTrueAfterAccept() {
 		PubSubAcknowledgmentCallback callback = new PubSubAcknowledgmentCallback(this.mockMessage, AckMode.MANUAL);
 		callback.acknowledge(AcknowledgmentCallback.Status.ACCEPT);
 		assertThat(callback.isAcknowledged()).isTrue();
 	}
 
 	@Test
-	public void isAcknowledgedTrueAfterReject() {
+	void isAcknowledgedTrueAfterReject() {
 		PubSubAcknowledgmentCallback callback = new PubSubAcknowledgmentCallback(this.mockMessage, AckMode.MANUAL);
 		callback.acknowledge(AcknowledgmentCallback.Status.REJECT);
 		assertThat(callback.isAcknowledged()).isTrue();

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/GcpPubSubHeadersTest.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/GcpPubSubHeadersTest.java
@@ -18,7 +18,7 @@ package com.google.cloud.spring.pubsub.support;
 
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
@@ -26,23 +26,23 @@ import org.springframework.messaging.support.GenericMessage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class GcpPubSubHeadersTest {
+class GcpPubSubHeadersTest {
 
 	@Test
-	public void getOriginalMessage_emptyHeaders() {
+	void getOriginalMessage_emptyHeaders() {
 		Message<String> m = new GenericMessage<>("batman");
 		assertThat(GcpPubSubHeaders.getOriginalMessage(m)).isEmpty();
 	}
 
 	@Test
-	public void getOriginalMessage_wrongType() {
+	void getOriginalMessage_wrongType() {
 		Message<String> m = new GenericMessage<>("batman",
 				Collections.singletonMap(GcpPubSubHeaders.ORIGINAL_MESSAGE, 101));
 		assertThat(GcpPubSubHeaders.getOriginalMessage(m)).isEmpty();
 	}
 
 	@Test
-	public void getOriginalMessage() {
+	void getOriginalMessage() {
 		Message<String> m = new GenericMessage<>("batman",
 				Collections.singletonMap(GcpPubSubHeaders.ORIGINAL_MESSAGE,
 						mock(BasicAcknowledgeablePubsubMessage.class)));

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubSubscriptionUtilsTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubSubscriptionUtilsTests.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spring.pubsub.support;
 
 import com.google.pubsub.v1.ProjectSubscriptionName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -27,10 +27,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Mike Eltsufin
  */
-public class PubSubSubscriptionUtilsTests {
+class PubSubSubscriptionUtilsTests {
 
 	@Test
-	public void testToProjectSubscriptionName_canonical() {
+	void testToProjectSubscriptionName_canonical() {
 		String project = "projectA";
 		String subscription = "subscriptionA";
 		String fqn = "projects/" + project + "/subscriptions/" + subscription;
@@ -44,21 +44,21 @@ public class PubSubSubscriptionUtilsTests {
 	}
 
 	@Test
-	public void testToProjectSubscriptionName_no_subscription() {
+	void testToProjectSubscriptionName_no_subscription() {
 		assertThatThrownBy(() -> PubSubSubscriptionUtils.toProjectSubscriptionName(null, "subscriptionA"))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("The subscription can't be null.");
 	}
 
 	@Test
-	public void testToProjectSubscriptionName_canonical_no_project() {
+	void testToProjectSubscriptionName_canonical_no_project() {
 		assertThatThrownBy(() -> PubSubSubscriptionUtils.toProjectSubscriptionName("subscriptionA", null))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("The project ID can't be null when using canonical subscription name.");
 	}
 
 	@Test
-	public void testToProjectSubscriptionName_fqn() {
+	void testToProjectSubscriptionName_fqn() {
 		String project = "projectA";
 		String subscription = "subscriptionA";
 		String fqn = "projects/" + project + "/subscriptions/" + subscription;
@@ -72,7 +72,7 @@ public class PubSubSubscriptionUtilsTests {
 	}
 
 	@Test
-	public void testToProjectSubscriptionName_fqn_no_project() {
+	void testToProjectSubscriptionName_fqn_no_project() {
 		String project = "projectA";
 		String subscription = "subscriptionA";
 		String fqn = "projects/" + project + "/subscriptions/" + subscription;

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtilsTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtilsTests.java
@@ -18,7 +18,7 @@ package com.google.cloud.spring.pubsub.support;
 
 import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.TopicName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,10 +28,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Mike Eltsufin
  */
-public class PubSubTopicUtilsTests {
+class PubSubTopicUtilsTests {
 
 	@Test
-	public void testToProjectTopicName_canonical() {
+	void testToProjectTopicName_canonical() {
 		String project = "projectA";
 		String topic = "topicA";
 		String fqn = "projects/" + project + "/topics/" + topic;
@@ -44,21 +44,21 @@ public class PubSubTopicUtilsTests {
 	}
 
 	@Test
-	public void testToProjectTopicName_no_topic() {
+	void testToProjectTopicName_no_topic() {
 		assertThatThrownBy(() -> PubSubTopicUtils.toProjectTopicName(null, "topicA"))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("The topic can't be null.");
 	}
 
 	@Test
-	public void testToProjectTopicName_canonical_no_project() {
+	void testToProjectTopicName_canonical_no_project() {
 		assertThatThrownBy(() -> PubSubTopicUtils.toProjectTopicName("topicA", null))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("The project ID can't be null when using canonical topic name.");
 	}
 
 	@Test
-	public void testToProjectTopicName_fqn() {
+	void testToProjectTopicName_fqn() {
 		String project = "projectA";
 		String topic = "topicA";
 		String fqn = "projects/" + project + "/topics/" + topic;
@@ -71,7 +71,7 @@ public class PubSubTopicUtilsTests {
 	}
 
 	@Test
-	public void testToProjectTopicName_fqn_no_project() {
+	void testToProjectTopicName_fqn_no_project() {
 		String project = "projectA";
 		String topic = "topicA";
 		String fqn = "projects/" + project + "/topics/" + topic;
@@ -84,7 +84,7 @@ public class PubSubTopicUtilsTests {
 	}
 
 	@Test
-	public void testToTopicName_canonical() {
+	void testToTopicName_canonical() {
 		String project = "projectA";
 		String topic = "topicA";
 		String fqn = "projects/" + project + "/topics/" + topic;
@@ -97,21 +97,21 @@ public class PubSubTopicUtilsTests {
 	}
 
 	@Test
-	public void testToTopicName_no_topic() {
+	void testToTopicName_no_topic() {
 		assertThatThrownBy(() -> PubSubTopicUtils.toTopicName(null, "topicA"))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("The topic can't be null.");
 	}
 
 	@Test
-	public void testToTopicName_canonical_no_project() {
+	void testToTopicName_canonical_no_project() {
 		assertThatThrownBy(() -> PubSubTopicUtils.toTopicName("topicA", null))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("The project ID can't be null when using canonical topic name.");
 	}
 
 	@Test
-	public void testToTopicName_fqn() {
+	void testToTopicName_fqn() {
 		String project = "projectA";
 		String topic = "topicA";
 		String fqn = "projects/" + project + "/topics/" + topic;
@@ -124,7 +124,7 @@ public class PubSubTopicUtilsTests {
 	}
 
 	@Test
-	public void testToTopicName_fqn_no_project() {
+	void testToTopicName_fqn_no_project() {
 		String project = "projectA";
 		String topic = "topicA";
 		String fqn = "projects/" + project + "/topics/" + topic;

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/converter/JacksonPubSubMessageConverterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/converter/JacksonPubSubMessageConverterTests.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
 import com.google.pubsub.v1.PubsubMessage;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,12 +37,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since  1.1
  */
 
-public class JacksonPubSubMessageConverterTests {
+class JacksonPubSubMessageConverterTests {
 
 	private JacksonPubSubMessageConverter converter = new JacksonPubSubMessageConverter(new ObjectMapper());
 
 	@Test
-	public void testString() throws JSONException {
+	void testString() throws JSONException {
 		String str = "test 123";
 
 		PubsubMessage pubsubMessage = this.converter.toPubSubMessage(str, null);
@@ -58,7 +58,7 @@ public class JacksonPubSubMessageConverterTests {
 	}
 
 	@Test
-	public void testPojo() throws JSONException {
+	void testPojo() throws JSONException {
 		Contact contact = new Contact("Thomas", "Edison", 8817);
 
 		PubsubMessage pubsubMessage = this.converter.toPubSubMessage(contact, null);
@@ -74,14 +74,14 @@ public class JacksonPubSubMessageConverterTests {
 	}
 
 	@Test
-	public void testToPubSubMessageWithNullPayload() throws JSONException {
+	void testToPubSubMessageWithNullPayload() throws JSONException {
 		PubsubMessage pubsubMessage = this.converter.toPubSubMessage(null, null);
 		assertThat(pubsubMessage).isNotNull();
 		assertThat(pubsubMessage.getAttributesCount()).isZero();
 	}
 
 	@Test
-	public void testToPubSubMessageWithOrderingKeyHeader() throws JSONException {
+	void testToPubSubMessageWithOrderingKeyHeader() throws JSONException {
 		PubsubMessage pubsubMessage = this.converter.toPubSubMessage(null,
 				Collections.singletonMap(GcpPubSubHeaders.ORDERING_KEY, "key1"));
 		assertThat(pubsubMessage).isNotNull();
@@ -90,7 +90,7 @@ public class JacksonPubSubMessageConverterTests {
 	}
 
 	@Test
-	public void testToPubSubMessageWitHeader() throws JSONException {
+	void testToPubSubMessageWitHeader() throws JSONException {
 		PubsubMessage pubsubMessage = this.converter.toPubSubMessage(null,
 				Collections.singletonMap("custom-header", "val1"));
 		assertThat(pubsubMessage).isNotNull();


### PR DESCRIPTION
Migrated the following modules from JUnit4 to JUnit5:


**_Module: spring-cloud-gcp-pubsub_**

1. core/PubSubConfigurationTests.java
2. integration/inbound/PubSubAcknowledgmentCallbackTests.java
3. support/converter/JacksonPubSubMessageConverterTests.java
4. support/GcpPubSubHeadersTest.java
5. support/PubSubSubscriptionUtilsTests.java
6. support/PubSubTopicUtilsTests.java
