### PR TITLE
spring cloud gcp secret manager tests migration(JUnit4 to JUnit5)

### DIFF
--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/SecretManagerPropertyUtilsTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/SecretManagerPropertyUtilsTests.java
@@ -18,17 +18,17 @@ package com.google.cloud.spring.secretmanager;
 
 import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class SecretManagerPropertyUtilsTests {
+class SecretManagerPropertyUtilsTests {
 
 	private static final GcpProjectIdProvider DEFAULT_PROJECT_ID_PROVIDER = () -> "defaultProject";
 
 	@Test
-	public void testNonSecret() {
+	void testNonSecret() {
 		String property = "spring.cloud.datasource";
 		SecretVersionName secretIdentifier =
 				SecretManagerPropertyUtils.getSecretVersionName(property, DEFAULT_PROJECT_ID_PROVIDER);
@@ -37,7 +37,7 @@ public class SecretManagerPropertyUtilsTests {
 	}
 
 	@Test
-	public void testInvalidSecretFormat_missingSecretId() {
+	void testInvalidSecretFormat_missingSecretId() {
 		String property = "sm://";
 
 		assertThatThrownBy(() ->
@@ -47,7 +47,7 @@ public class SecretManagerPropertyUtilsTests {
 	}
 
 	@Test
-	public void testShortProperty_secretId() {
+	void testShortProperty_secretId() {
 		String property = "sm://the-secret";
 		SecretVersionName secretIdentifier =
 				SecretManagerPropertyUtils.getSecretVersionName(property, DEFAULT_PROJECT_ID_PROVIDER);
@@ -58,7 +58,7 @@ public class SecretManagerPropertyUtilsTests {
 	}
 
 	@Test
-	public void testShortProperty_projectSecretId() {
+	void testShortProperty_projectSecretId() {
 		String property = "sm://the-secret/the-version";
 		SecretVersionName secretIdentifier =
 				SecretManagerPropertyUtils.getSecretVersionName(property, DEFAULT_PROJECT_ID_PROVIDER);
@@ -69,7 +69,7 @@ public class SecretManagerPropertyUtilsTests {
 	}
 
 	@Test
-	public void testShortProperty_projectSecretIdVersion() {
+	void testShortProperty_projectSecretIdVersion() {
 		String property = "sm://my-project/the-secret/2";
 		SecretVersionName secretIdentifier =
 				SecretManagerPropertyUtils.getSecretVersionName(property, DEFAULT_PROJECT_ID_PROVIDER);
@@ -80,7 +80,7 @@ public class SecretManagerPropertyUtilsTests {
 	}
 
 	@Test
-	public void testLongProperty_projectSecret() {
+	void testLongProperty_projectSecret() {
 		String property = "sm://projects/my-project/secrets/the-secret";
 		SecretVersionName secretIdentifier =
 				SecretManagerPropertyUtils.getSecretVersionName(property, DEFAULT_PROJECT_ID_PROVIDER);
@@ -91,7 +91,7 @@ public class SecretManagerPropertyUtilsTests {
 	}
 
 	@Test
-	public void testLongProperty_projectSecretVersion() {
+	void testLongProperty_projectSecretVersion() {
 		String property = "sm://projects/my-project/secrets/the-secret/versions/3";
 		SecretVersionName secretIdentifier =
 				SecretManagerPropertyUtils.getSecretVersionName(property, DEFAULT_PROJECT_ID_PROVIDER);

--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/SecretManagerTemplateTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/SecretManagerTemplateTests.java
@@ -28,8 +28,8 @@ import com.google.cloud.secretmanager.v1.SecretName;
 import com.google.cloud.secretmanager.v1.SecretPayload;
 import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.protobuf.ByteString;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,14 +38,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class SecretManagerTemplateTests {
+class SecretManagerTemplateTests {
 
 	private SecretManagerServiceClient client;
 
 	private SecretManagerTemplate secretManagerTemplate;
 
-	@Before
-	public void setupMocks() {
+	@BeforeEach
+	void setupMocks() {
 		this.client = mock(SecretManagerServiceClient.class);
 		when(this.client.accessSecretVersion(any(SecretVersionName.class)))
 				.thenReturn(
@@ -58,7 +58,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testCreateSecretIfMissing() {
+	void testCreateSecretIfMissing() {
 		// This means that no previous secrets exist.
 		when(this.client.getSecret(any(SecretName.class))).thenThrow(NotFoundException.class);
 
@@ -72,7 +72,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testCreateSecretIfMissing_withProject() {
+	void testCreateSecretIfMissing_withProject() {
 		when(this.client.getSecret(any(SecretName.class))).thenThrow(NotFoundException.class);
 
 		this.secretManagerTemplate.createSecret(
@@ -83,7 +83,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testCreateSecretIfAlreadyPresent() {
+	void testCreateSecretIfAlreadyPresent() {
 		// The secret 'my-secret' already exists.
 		when(this.client.getSecret(SecretName.of("my-project", "my-secret")))
 				.thenReturn(Secret.getDefaultInstance());
@@ -96,7 +96,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testCreateSecretIfAlreadyPresent_withProject() {
+	void testCreateSecretIfAlreadyPresent_withProject() {
 		when(this.client.getSecret(SecretName.of("custom-project", "my-secret")))
 				.thenReturn(Secret.getDefaultInstance());
 
@@ -108,7 +108,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testCreateByteSecretIfMissing() {
+	void testCreateByteSecretIfMissing() {
 		// This means that no previous secrets exist.
 		when(this.client.getSecret(any(SecretName.class))).thenThrow(NotFoundException.class);
 
@@ -119,7 +119,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testCreateByteSecretIfMissing_withProject() {
+	void testCreateByteSecretIfMissing_withProject() {
 		// This means that no previous secrets exist.
 		when(this.client.getSecret(any(SecretName.class))).thenThrow(NotFoundException.class);
 
@@ -130,7 +130,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testCreateByteSecretIfAlreadyPresent() {
+	void testCreateByteSecretIfAlreadyPresent() {
 		// The secret 'my-secret' already exists.
 		when(this.client.getSecret(SecretName.of("my-project", "my-secret")))
 				.thenReturn(Secret.getDefaultInstance());
@@ -143,7 +143,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testCreateByteSecretIfAlreadyPresent_withProject() {
+	void testCreateByteSecretIfAlreadyPresent_withProject() {
 		// The secret 'my-secret' already exists.
 		when(this.client.getSecret(SecretName.of("custom-project", "my-secret")))
 				.thenReturn(Secret.getDefaultInstance());
@@ -156,7 +156,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testAccessSecretBytes() {
+	void testAccessSecretBytes() {
 		byte[] result = this.secretManagerTemplate.getSecretBytes("my-secret");
 		verify(this.client).accessSecretVersion(
 				SecretVersionName.of("my-project", "my-secret", "latest"));
@@ -169,7 +169,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testAccessSecretString() {
+	void testAccessSecretString() {
 		String result = this.secretManagerTemplate.getSecretString("my-secret");
 		verify(this.client).accessSecretVersion(
 				SecretVersionName.of("my-project", "my-secret", "latest"));
@@ -182,7 +182,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testEnableSecretVersion() {
+	void testEnableSecretVersion() {
 		this.secretManagerTemplate.enableSecretVersion("my-secret", "1");
 		verifyEnableSecretVersionRequest("my-secret", "1", "my-project");
 
@@ -191,7 +191,7 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testDeleteSecret() {
+	void testDeleteSecret() {
 		this.secretManagerTemplate.deleteSecret("my-secret");
 		verifyDeleteSecretRequest("my-secret", "my-project");
 
@@ -200,13 +200,13 @@ public class SecretManagerTemplateTests {
 	}
 
 	@Test
-	public void testDeleteSecretVersion() {
+	void testDeleteSecretVersion() {
 		this.secretManagerTemplate.deleteSecretVersion("my-secret", "10", "custom-project");
 		verifyDeleteSecretVersionRequest("my-secret", "10", "custom-project");
 	}
 
 	@Test
-	public void testDisableSecretVersion() {
+	void testDisableSecretVersion() {
 		this.secretManagerTemplate.disableSecretVersion("my-secret", "1");
 		verifyDisableSecretVersionRequest("my-secret", "1", "my-project");
 


### PR DESCRIPTION
Migrated the following tests from JUnit4 to JUnit5

**_Module : spring-cloud-gcp-secretmanager_**

SecretManagerPropertyUtilsTests.java
SecretManagerTemplateTests.java
