### PR TITLE
spring cloud gcp storage tests migration(JUnit4 to JUnit5)

### DIFF
--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageLocationTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageLocationTests.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spring.storage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -24,31 +24,31 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Daniel Zou
  */
-public class GoogleStorageLocationTests {
+class GoogleStorageLocationTests {
 
 	@Test
-	public void testBadInputsToConstructor() {
+	void testBadInputsToConstructor() {
 		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new GoogleStorageLocation(null));
 		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new GoogleStorageLocation(""));
 		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new GoogleStorageLocation(" "));
 	}
 
 	@Test
-	public void testCorrectLocationForBucket() {
+	void testCorrectLocationForBucket() {
 		GoogleStorageLocation location = GoogleStorageLocation.forBucket("bucketName");
 		assertThat(location.uriString()).isEqualTo("gs://bucketName/");
 		assertThat(location.isBucket()).isTrue();
 	}
 
 	@Test
-	public void testCorrectLocationForFolder() {
+	void testCorrectLocationForFolder() {
 		GoogleStorageLocation location = GoogleStorageLocation.forFolder("bucketName", "folderName");
 		assertThat(location.uriString()).isEqualTo("gs://bucketName/folderName/");
 		assertThat(location.isFolder()).isTrue();
 	}
 
 	@Test
-	public void testCorrectLocationForFile() {
+	void testCorrectLocationForFile() {
 		GoogleStorageLocation location = GoogleStorageLocation.forFile("bucketName", "fileName");
 		assertThat(location.uriString()).isEqualTo("gs://bucketName/fileName");
 		assertThat(location.isFile()).isTrue();

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageResourceTest.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/GoogleStorageResourceTest.java
@@ -22,17 +22,17 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class GoogleStorageResourceTest {
+class GoogleStorageResourceTest {
 
 	@Test
-	public void testConstructorValidation() {
+	void testConstructorValidation() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 				.isThrownBy(() -> new GoogleStorageResource(null, "gs://foo", false))
 				.withMessageContaining("Storage object can not be null");
@@ -50,7 +50,7 @@ public class GoogleStorageResourceTest {
 	}
 
 	@Test
-	public void getURL_Bucket() throws IOException {
+	void getURL_Bucket() throws IOException {
 		Storage mockStorage = mock(Storage.class);
 		Bucket mockBucket = mock(Bucket.class);
 
@@ -62,7 +62,7 @@ public class GoogleStorageResourceTest {
 	}
 
 	@Test
-	public void getURL_Object() throws IOException {
+	void getURL_Object() throws IOException {
 		Storage mockStorage = mock(Storage.class);
 		Blob mockBlob = mock(Blob.class);
 

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/filters/GcsDiscardRecentModifiedFileListFilterTest.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/filters/GcsDiscardRecentModifiedFileListFilterTest.java
@@ -23,16 +23,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.cloud.storage.BlobInfo;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class GcsDiscardRecentModifiedFileListFilterTest {
+class GcsDiscardRecentModifiedFileListFilterTest {
 
 	@Test
-	public void testFileLessThanMinimumAgeIsFilteredOut() {
+	void testFileLessThanMinimumAgeIsFilteredOut() {
 		GcsDiscardRecentModifiedFileListFilter filter = new GcsDiscardRecentModifiedFileListFilter(Duration.ofSeconds(60));
 		AtomicBoolean callbackTriggered = new AtomicBoolean(false);
 		filter.addDiscardCallback(blobInfo -> callbackTriggered.set(true));
@@ -48,7 +48,7 @@ public class GcsDiscardRecentModifiedFileListFilterTest {
 	}
 
 	@Test
-	public void testFileOlderThanMinimumAgeIsReturned() {
+	void testFileOlderThanMinimumAgeIsReturned() {
 		GcsDiscardRecentModifiedFileListFilter filter = new GcsDiscardRecentModifiedFileListFilter(Duration.ofSeconds(60));
 		filter.addDiscardCallback(blobInfo -> Assert.fail("Not expected"));
 

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/filters/GcsPersistentAcceptOnceFileListFilterTest.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/integration/filters/GcsPersistentAcceptOnceFileListFilterTest.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spring.storage.integration.filters;
 
 import com.google.cloud.storage.BlobInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.metadata.ConcurrentMetadataStore;
 
@@ -30,16 +30,16 @@ import static org.mockito.Mockito.when;
  *
  * @author Lukas Gemela
  */
-public class GcsPersistentAcceptOnceFileListFilterTest {
+class GcsPersistentAcceptOnceFileListFilterTest {
 
 	@Test
-	public void modified_blobInfoIsNull_shouldReturnMinusOne() {
+	void modified_blobInfoIsNull_shouldReturnMinusOne() {
 		assertThat(new GcsPersistentAcceptOnceFileListFilter(mock(ConcurrentMetadataStore.class), "").modified(null))
 				.isEqualTo(-1);
 	}
 
 	@Test
-	public void modified_updateTimeIsNull_shouldReturnMinusOne() {
+	void modified_updateTimeIsNull_shouldReturnMinusOne() {
 		BlobInfo blobInfo = mock(BlobInfo.class);
 		when(blobInfo.getUpdateTime()).thenReturn(null);
 


### PR DESCRIPTION
Migrated the following modules from JUnit4 to JUnit5:

**_Module: spring-cloud-gcp-storage_**
	
1. GcsDiscardRecentModifiedFileListFilterTest.java
2. GcsPersistentAcceptOnceFileListFilterTest.java
3. GoogleStorageLocationTests.java
4. GoogleStorageResourceTest.java