### PR TITLE
Datastore array conversion: turn array into a list with same elements

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spring.data.datastore.core.convert;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -159,7 +159,7 @@ public class TwoStepsConversions implements ReadWriteConversions {
 			try {
 				List elements;
 				if (val.getClass().isArray()) {
-					elements = Collections.singletonList(val);
+					elements = Arrays.asList((Object[]) val);
 				}
 				else {
 					elements = StreamSupport

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversionsTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversionsTests.java
@@ -103,4 +103,12 @@ class TwoStepsConversionsTests {
 		assertThat(result).isEqualTo("three");
 	}
 
+	@Test
+	void convertingArraysTranslatesToList() {
+		String[] arr = new String[] { "a", "b", "c"};
+
+		List<String> result = this.twoStepsConversions.convertOnRead(arr, List.class, String.class);
+		assertThat(result).containsExactly("a", "b", "c");
+	}
+
 }


### PR DESCRIPTION
Pick your poison -- this PR fixes the logic, and #733 rips it out.