### PR TITLE
Remove wording for foreign keys being unsupported

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -328,7 +328,6 @@ These relationships can be up to 7 levels deep.
 Cloud Spanner also provides automatic cascading delete or enforces the deletion of child entities before parents.
 
 While one-to-one and many-to-many relationships can be implemented in Cloud Spanner and Spring Data Cloud Spanner using constructs of interleaved parent-child tables, only the parent-child relationship is natively supported.
-Cloud Spanner does not support the foreign key constraint, though the parent-child key constraint enforces a similar requirement when used with interleaved tables.
 
 For example, the following Java entities:
 


### PR DESCRIPTION
This PR removes outdated wording from our documentation.

Cloud Spanner supports foreign keys [since March 2020](https://cloud.google.com/spanner/docs/release-notes).

Addresses a small part of #737.