### PR TITLE
Cleanup todo tags: no need to support 2.4 and verified tests.

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepository.java
@@ -212,7 +212,7 @@ public class SimpleDatastoreRepository<T, I> implements DatastoreRepository<T, I
 		return pageable instanceof DatastorePageable ? ((DatastorePageable) pageable).getTotalCount() : countCall.getAsLong();
 	}
 
-	// TODO: Restore @Override when not supporting Spring Boot 2.4 anymore
+	@Override
 	public void deleteAllById(Iterable<? extends I> iterable) {
 		this.datastoreTemplate.deleteAllById(iterable, entityType);
 	}

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepository.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepository.java
@@ -121,8 +121,7 @@ public class SimpleFirestoreReactiveRepository<T> implements FirestoreReactiveRe
 		return this.firestoreTemplate.deleteAll(this.type);
 	}
 
-	// TODO: Restore @Override when not supporting Spring Boot 2.4 anymore
-	// @Override
+	@Override
 	public Mono<Void> deleteAllById(Iterable<? extends String> ids) {
 		return this.firestoreTemplate.deleteById(Flux.fromIterable(ids), this.type);
 	}

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
@@ -164,8 +164,7 @@ public class SimpleSpannerRepository<T, I> implements SpannerRepository<T, I> {
 				pageable, this.spannerTemplate.count(this.entityType));
 	}
 
-	// TODO: Restore @Override when not supporting Spring Boot 2.4 anymore
-	//@Override
+	@Override
 	public void deleteAllById(Iterable<? extends I> ids) {
 		KeySet.Builder builder = KeySet.newBuilder();
 		for (Object id : ids) {

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderEmulatorIntegrationTests.java
@@ -61,7 +61,6 @@ class PubSubMessageChannelBinderEmulatorIntegrationTests extends
 
 	@Override
 	protected ExtendedProducerProperties<PubSubProducerProperties> createProducerProperties(TestInfo testInfo) {
-		// TODO: signature change, need to validate test behavior.
 		return new ExtendedProducerProperties<>(new PubSubProducerProperties());
 	}
 
@@ -72,7 +71,6 @@ class PubSubMessageChannelBinderEmulatorIntegrationTests extends
 
 	@Override
 	public void testClean(TestInfo testInfo) throws Exception {
-		// TODO: signature change, need to validate test behavior.
 		// Do nothing. Original test tests for Lifecycle logic that we don't need.
 
 		// Dummy assertion to appease SonarCloud.


### PR DESCRIPTION
Cleanup todo tags: 
- no need to support 2.4 on 3.x, so restore `@Override` for `deleteAllById()`
- `PubSubMessageChannelBinderEmulatorIntegrationTests` tests already verified in #730 .