### PR TITLE
Remove python version override

### DIFF
--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -5,9 +5,6 @@ if [[ -z "${CREDENTIALS}" ]]; then
   CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
 fi
 
-# Set the version of python to 3.6
-pyenv global 3.7.2
-
 # Get into the spring-cloud-gcp repo directory
 dir=$(dirname "$0")
 pushd $dir/../


### PR DESCRIPTION
It's an experiment to fix our javadoc publishing. The error seems to be caused by a mismatch in python versions vs code.