### PR TITLE
Switch unit tests from Java 16 to 17

### DIFF
--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 16]
+        java: [8, 11, 17]
     steps:
     - name: Get current date
       id: date

--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
 								<!-- illegal-access=permit is needed to make GCLIB proxying work, used in Datastore -->
-								<argLine>-Xms512m -Xmx512m --illegal-access=permit --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+								<argLine>-Xms512m -Xmx512m --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
 								<skip>${skip.surefire.tests}</skip>
 								<excludes>
 									<exclude>${integration-test.pattern}</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
 								<!-- illegal-access=permit is needed to make GCLIB proxying work, used in Datastore -->
-								<argLine>-Xms512m -Xmx512m --illegal-access=permit</argLine>
+								<argLine>-Xms512m -Xmx512m --illegal-access=permit --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
 								<skip>${skip.surefire.tests}</skip>
 								<excludes>
 									<exclude>${integration-test.pattern}</exclude>


### PR DESCRIPTION
With Java 17, the old way to override illegal module access switched to `--add-opens java.base/java.lang=ALL-UNNAMED`. 
This is all to make one test using a concrete implementation of a collection --  `DatastoreTemplateTests.saveTestNotInterfaceLazy` -- work. 

[This discussion in Spring](https://github.com/spring-projects/spring-boot/issues/26578#issuecomment-842305746) was helpful for understanding why this was an issue in the first place -- JUnit has a different classloader from the one Spring is using to create context.

The original error when running tests with Java17 was
```
[INFO] Running com.google.cloud.spring.data.datastore.core.DatastoreTemplateTests
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.953 s <<< FAILURE! - in com.google.cloud.spring.data.datastore.core.DatastoreTemplateTests
[ERROR] saveTestNotInterfaceLazy  Time elapsed: 0.949 s  <<< ERROR!
org.springframework.cglib.core.CodeGenerationException: java.lang.IllegalAccessException-->module java.base does not open java.util to unnamed module @3bf44630
	at com.google.cloud.spring.data.datastore.core.DatastoreTemplateTests.saveTestNotInterfaceLazy(DatastoreTemplateTests.java:574)
Caused by: java.lang.IllegalAccessException: module java.base does not open java.util to unnamed module @3bf44630
	at com.google.cloud.spring.data.datastore.core.DatastoreTemplateTests.saveTestNotInterfaceLazy(DatastoreTemplateTests.java:574)
```

As a side rabbit hole, I don't understand why exporting `java.lang` works but exporting `java.util` does not. With `--add-opens java.base/java.lang=ALL-UNNAMED`, the following error shows up instead:

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.951 s <<< FAILURE! - in com.google.cloud.spring.data.datastore.core.DatastoreTemplateTests
[ERROR] saveTestNotInterfaceLazy  Time elapsed: 0.949 s  <<< ERROR!
org.springframework.cglib.core.CodeGenerationException: java.lang.IllegalArgumentException-->$java.util.ArrayList$$EnhancerByCGLIB$$3c595c98 not in same package as lookup class
	at com.google.cloud.spring.data.datastore.core.DatastoreTemplateTests.saveTestNotInterfaceLazy(DatastoreTemplateTests.java:571)
Caused by: java.lang.IllegalArgumentException: $java.util.ArrayList$$EnhancerByCGLIB$$3c595c98 not in same package as lookup class
	at com.google.cloud.spring.data.datastore.core.DatastoreTemplateTests.saveTestNotInterfaceLazy(DatastoreTemplateTests.java:571)
```