### PR TITLE
change to index.yaml to match integration test setup.

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/EmbeddedEntity.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/EmbeddedEntity.java
@@ -24,19 +24,19 @@ import com.google.cloud.spring.data.datastore.core.mapping.Entity;
  * @author Dmitry Solomakha
  */
 @Entity
-public class EmbeddedEntity {
+class EmbeddedEntity {
 
 	private String stringField;
 
-	public EmbeddedEntity(String stringField) {
+	EmbeddedEntity(String stringField) {
 		this.stringField = stringField;
 	}
 
-	public String getStringField() {
+	String getStringField() {
 		return stringField;
 	}
 
-	public void setStringField(String stringField) {
+	void setStringField(String stringField) {
 		this.stringField = stringField;
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntity.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntity.java
@@ -30,7 +30,7 @@ import org.springframework.data.annotation.Id;
  * @author Chengyuan Zhao
  */
 @Entity(name = "test_entities_#{\"ci\"}")
-public class TestEntity {
+class TestEntity {
 
 	@Id
 	private Long id;
@@ -47,10 +47,10 @@ public class TestEntity {
 
 	EmbeddedEntity embeddedEntity;
 
-	public TestEntity() {
+	TestEntity() {
 	}
 
-	public TestEntity(Long id, String color, Long size, Shape shape, Blob blobField) {
+	TestEntity(Long id, String color, Long size, Shape shape, Blob blobField) {
 		this.id = id;
 		this.color = color;
 		this.size = size;
@@ -58,7 +58,7 @@ public class TestEntity {
 		this.blobField = blobField;
 	}
 
-	public TestEntity(Long id, String color, Long size, Shape shape, Blob blobField, EmbeddedEntity embeddedEntity) {
+	TestEntity(Long id, String color, Long size, Shape shape, Blob blobField, EmbeddedEntity embeddedEntity) {
 		this.id = id;
 		this.color = color;
 		this.size = size;
@@ -67,58 +67,58 @@ public class TestEntity {
 		this.embeddedEntity = embeddedEntity;
 	}
 
-	public TestEntity(Long id, String color, Long size, Timestamp datetime) {
+	TestEntity(Long id, String color, Long size, Timestamp datetime) {
 		this.id = id;
 		this.color = color;
 		this.size = size;
 		this.datetime = datetime;
 	}
 
-	public Shape getShape() {
+	Shape getShape() {
 		return this.shape;
 	}
 
-	public void setShape(Shape shape) {
+	void setShape(Shape shape) {
 		this.shape = shape;
 	}
 
-	public Long getId() {
+	Long getId() {
 		return this.id;
 	}
 
-	public void setId(Long id) {
+	void setId(Long id) {
 		this.id = id;
 	}
 
-	public Blob getBlobField() {
+	Blob getBlobField() {
 		return this.blobField;
 	}
 
-	public void setBlobField(Blob blobField) {
+	void setBlobField(Blob blobField) {
 		this.blobField = blobField;
 	}
 
-	public String getColor() {
+	String getColor() {
 		return this.color;
 	}
 
-	public void setColor(String color) {
+	void setColor(String color) {
 		this.color = color;
 	}
 
-	public Long getSize() {
+	Long getSize() {
 		return this.size;
 	}
 
-	public void setSize(Long size) {
+	void setSize(Long size) {
 		this.size = size;
 	}
 
-	public Timestamp getDatetime() {
+	Timestamp getDatetime() {
 		return datetime;
 	}
 
-	public void setDatetime(Timestamp datetime) {
+	void setDatetime(Timestamp datetime) {
 		this.datetime = datetime;
 	}
 

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntityRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/TestEntityRepository.java
@@ -45,7 +45,7 @@ import org.springframework.lang.Nullable;
  * @author Dmitry Solomakha
  */
 @Nonnull
-public interface TestEntityRepository extends DatastoreRepository<TestEntity, Long> {
+interface TestEntityRepository extends DatastoreRepository<TestEntity, Long> {
 
 	@Query("select * from  test_entities_ci where size = @size ")
 	LinkedList<TestEntity> findEntitiesWithCustomQuery(@Param("size") long size);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.spring.data.datastore.repository.query;
 
-import com.google.cloud.Timestamp;
-import com.google.cloud.datastore.Blob;
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
@@ -30,6 +28,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import com.google.cloud.Timestamp;
+import com.google.cloud.datastore.Blob;
 import com.google.cloud.datastore.Cursor;
 import com.google.cloud.datastore.EntityQuery;
 import com.google.cloud.datastore.Key;
@@ -1002,10 +1002,10 @@ public class PartTreeDatastoreQueryTests {
 
 		EmbeddedEntity embeddedEntity;
 
-		public TestEntity() {
+		TestEntity() {
 		}
 
-		public TestEntity(Long id, String color, Long size, Shape shape, Blob blobField) {
+		TestEntity(Long id, String color, Long size, Shape shape, Blob blobField) {
 			this.id = id;
 			this.color = color;
 			this.size = size;
@@ -1013,7 +1013,7 @@ public class PartTreeDatastoreQueryTests {
 			this.blobField = blobField;
 		}
 
-		public TestEntity(Long id, String color, Long size, Shape shape, Blob blobField, EmbeddedEntity embeddedEntity) {
+		TestEntity(Long id, String color, Long size, Shape shape, Blob blobField, EmbeddedEntity embeddedEntity) {
 			this.id = id;
 			this.color = color;
 			this.size = size;
@@ -1022,7 +1022,7 @@ public class PartTreeDatastoreQueryTests {
 			this.embeddedEntity = embeddedEntity;
 		}
 
-		public TestEntity(Long id, String color, Long size, Timestamp datetime) {
+		TestEntity(Long id, String color, Long size, Timestamp datetime) {
 			this.id = id;
 			this.color = color;
 			this.size = size;

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
@@ -23,13 +23,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import com.google.cloud.Timestamp;
-import com.google.cloud.datastore.Blob;
 import com.google.cloud.datastore.Cursor;
 import com.google.cloud.datastore.EntityQuery;
 import com.google.cloud.datastore.Key;
@@ -121,7 +118,7 @@ public class PartTreeDatastoreQueryTests {
 	@Before
 	public void initMocks() {
 		this.queryMethod = mock(DatastoreQueryMethod.class);
-		when(this.queryMethod.getReturnedObjectType()).thenReturn((Class) TestEntity.class);
+		when(this.queryMethod.getReturnedObjectType()).thenReturn((Class) Trade.class);
 		this.datastoreTemplate = mock(DatastoreTemplate.class);
 		this.datastoreMappingContext = new DatastoreMappingContext();
 		this.datastoreEntityConverter = mock(DatastoreEntityConverter.class);
@@ -190,7 +187,7 @@ public class PartTreeDatastoreQueryTests {
 		when(this.queryMethod.getCollectionReturnType()).thenReturn(List.class);
 
 		this.partTreeDatastoreQuery.execute(params);
-		verify(this.datastoreTemplate, times(1))
+		verify(this.datastoreTemplate)
 				.queryKeysOrEntities(any(), any());
 	}
 
@@ -238,7 +235,7 @@ public class PartTreeDatastoreQueryTests {
 		when(this.queryMethod.getCollectionReturnType()).thenReturn(List.class);
 
 		this.partTreeDatastoreQuery.execute(params);
-		verify(this.datastoreTemplate, times(1))
+		verify(this.datastoreTemplate)
 				.queryKeysOrEntities(any(), any());
 	}
 
@@ -977,165 +974,8 @@ public class PartTreeDatastoreQueryTests {
 		String getSymbol();
 	}
 
-	/**
-	 * An enum that tests conversion and storage.
-	 */
-	enum Shape {
-		CIRCLE, SQUARE;
-	}
-
-	@Entity(name = "test_entities_#{\"ci\"}")
-	private class TestEntity {
-
-		@Id
-		private Long id;
-
-		private String color;
-
-		private Long size;
-
-		private Shape shape;
-
-		private Blob blobField;
-
-		private Timestamp datetime;
-
-		EmbeddedEntity embeddedEntity;
-
-		TestEntity() {
-		}
-
-		TestEntity(Long id, String color, Long size, Shape shape, Blob blobField) {
-			this.id = id;
-			this.color = color;
-			this.size = size;
-			this.shape = shape;
-			this.blobField = blobField;
-		}
-
-		TestEntity(Long id, String color, Long size, Shape shape, Blob blobField, EmbeddedEntity embeddedEntity) {
-			this.id = id;
-			this.color = color;
-			this.size = size;
-			this.shape = shape;
-			this.blobField = blobField;
-			this.embeddedEntity = embeddedEntity;
-		}
-
-		TestEntity(Long id, String color, Long size, Timestamp datetime) {
-			this.id = id;
-			this.color = color;
-			this.size = size;
-			this.datetime = datetime;
-		}
-
-		public Shape getShape() {
-			return this.shape;
-		}
-
-		public void setShape(Shape shape) {
-			this.shape = shape;
-		}
-
-		public Long getId() {
-			return this.id;
-		}
-
-		public void setId(Long id) {
-			this.id = id;
-		}
-
-		public Blob getBlobField() {
-			return this.blobField;
-		}
-
-		public void setBlobField(Blob blobField) {
-			this.blobField = blobField;
-		}
-
-		public String getColor() {
-			return this.color;
-		}
-
-		public void setColor(String color) {
-			this.color = color;
-		}
-
-		public Long getSize() {
-			return this.size;
-		}
-
-		public void setSize(Long size) {
-			this.size = size;
-		}
-
-		public Timestamp getDatetime() {
-			return datetime;
-		}
-
-		public void setDatetime(Timestamp datetime) {
-			this.datetime = datetime;
-		}
-
-
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) {
-				return true;
-			}
-			if (o == null || getClass() != o.getClass()) {
-				return false;
-			}
-			TestEntity that = (TestEntity) o;
-			return Objects.equals(getId(), that.getId()) &&
-					Objects.equals(getColor(), that.getColor()) &&
-					Objects.equals(getSize(), that.getSize()) &&
-					getShape() == that.getShape() &&
-					Objects.equals(getBlobField(), that.getBlobField());
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(getId(), getColor(), getSize(), getShape(), getBlobField());
-		}
-
-		@Override
-		public String toString() {
-			return "TestEntity{" +
-					"id=" + id +
-					", color='" + color + '\'' +
-					", size=" + size +
-					", shape=" + shape +
-					", blobField=" + blobField +
-					", embeddedEntity=" + embeddedEntity +
-					", datetime=" + datetime +
-					'}';
-		}
-	}
-
 	@Entity
 	public class EmbeddedEntity {
-
 		private String stringField;
-
-		public EmbeddedEntity(String stringField) {
-			this.stringField = stringField;
-		}
-
-		public String getStringField() {
-			return stringField;
-		}
-
-		public void setStringField(String stringField) {
-			this.stringField = stringField;
-		}
-
-		@Override
-		public String toString() {
-			return "EmbeddedEntity{" +
-					"stringField='" + stringField + '\'' +
-					'}';
-		}
 	}
 }

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spring.data.datastore.repository.query;
 
+import com.google.cloud.Timestamp;
+import com.google.cloud.datastore.Blob;
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
@@ -23,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -45,8 +48,6 @@ import com.google.cloud.spring.data.datastore.core.convert.TwoStepsConversions;
 import com.google.cloud.spring.data.datastore.core.mapping.DatastoreMappingContext;
 import com.google.cloud.spring.data.datastore.core.mapping.Entity;
 import com.google.cloud.spring.data.datastore.core.mapping.Field;
-import com.google.cloud.spring.data.datastore.it.EmbeddedEntity;
-import com.google.cloud.spring.data.datastore.it.TestEntity;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -974,5 +975,167 @@ public class PartTreeDatastoreQueryTests {
 		String getId();
 
 		String getSymbol();
+	}
+
+	/**
+	 * An enum that tests conversion and storage.
+	 */
+	enum Shape {
+		CIRCLE, SQUARE;
+	}
+
+	@Entity(name = "test_entities_#{\"ci\"}")
+	private class TestEntity {
+
+		@Id
+		private Long id;
+
+		private String color;
+
+		private Long size;
+
+		private Shape shape;
+
+		private Blob blobField;
+
+		private Timestamp datetime;
+
+		EmbeddedEntity embeddedEntity;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Long id, String color, Long size, Shape shape, Blob blobField) {
+			this.id = id;
+			this.color = color;
+			this.size = size;
+			this.shape = shape;
+			this.blobField = blobField;
+		}
+
+		public TestEntity(Long id, String color, Long size, Shape shape, Blob blobField, EmbeddedEntity embeddedEntity) {
+			this.id = id;
+			this.color = color;
+			this.size = size;
+			this.shape = shape;
+			this.blobField = blobField;
+			this.embeddedEntity = embeddedEntity;
+		}
+
+		public TestEntity(Long id, String color, Long size, Timestamp datetime) {
+			this.id = id;
+			this.color = color;
+			this.size = size;
+			this.datetime = datetime;
+		}
+
+		public Shape getShape() {
+			return this.shape;
+		}
+
+		public void setShape(Shape shape) {
+			this.shape = shape;
+		}
+
+		public Long getId() {
+			return this.id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Blob getBlobField() {
+			return this.blobField;
+		}
+
+		public void setBlobField(Blob blobField) {
+			this.blobField = blobField;
+		}
+
+		public String getColor() {
+			return this.color;
+		}
+
+		public void setColor(String color) {
+			this.color = color;
+		}
+
+		public Long getSize() {
+			return this.size;
+		}
+
+		public void setSize(Long size) {
+			this.size = size;
+		}
+
+		public Timestamp getDatetime() {
+			return datetime;
+		}
+
+		public void setDatetime(Timestamp datetime) {
+			this.datetime = datetime;
+		}
+
+
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			TestEntity that = (TestEntity) o;
+			return Objects.equals(getId(), that.getId()) &&
+					Objects.equals(getColor(), that.getColor()) &&
+					Objects.equals(getSize(), that.getSize()) &&
+					getShape() == that.getShape() &&
+					Objects.equals(getBlobField(), that.getBlobField());
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(getId(), getColor(), getSize(), getShape(), getBlobField());
+		}
+
+		@Override
+		public String toString() {
+			return "TestEntity{" +
+					"id=" + id +
+					", color='" + color + '\'' +
+					", size=" + size +
+					", shape=" + shape +
+					", blobField=" + blobField +
+					", embeddedEntity=" + embeddedEntity +
+					", datetime=" + datetime +
+					'}';
+		}
+	}
+
+	@Entity
+	public class EmbeddedEntity {
+
+		private String stringField;
+
+		public EmbeddedEntity(String stringField) {
+			this.stringField = stringField;
+		}
+
+		public String getStringField() {
+			return stringField;
+		}
+
+		public void setStringField(String stringField) {
+			this.stringField = stringField;
+		}
+
+		@Override
+		public String toString() {
+			return "EmbeddedEntity{" +
+					"stringField='" + stringField + '\'' +
+					'}';
+		}
 	}
 }

--- a/spring-cloud-gcp-data-datastore/src/test/resources/index.yaml
+++ b/spring-cloud-gcp-data-datastore/src/test/resources/index.yaml
@@ -2,8 +2,5 @@ indexes:
 
 - kind: test_entities_ci
   properties:
-  - name: embeddedEntity.stringField
-  - name: blobField
-  - name: color
-  - name: shape
   - name: size
+  - name: color


### PR DESCRIPTION
`index.yaml` is only used for integration test setup once per GCP project. It affects 3 test in `DatastoreIntegrationTests.java`: `testSlicedEntityProjections`, `testSliceString`, `projectionTest` due to the query method used in tests.
Proposing change aligns with current CI project setting and tested with new GCP project. 