### PR TITLE
Overriding autoconfiguration of DefaultCredentialsProvider to make the test run faster

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationTests.java
@@ -20,6 +20,7 @@ import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.auth.Credentials;
+import com.google.cloud.NoCredentials;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
@@ -46,11 +47,15 @@ class GcpFirestoreEmulatorAutoConfigurationTests {
 
 	@Test
 	void testEmulatorEnabledConfig() {
+
+		CredentialsProvider mockedCredentialsProvider = () -> mock(NoCredentials.class);
+
 		this.contextRunner.withPropertyValues(
 				"spring.cloud.gcp.firestore.projectId=test-project",
 				"spring.cloud.gcp.firestore.emulator.enabled=true",
 				"spring.cloud.gcp.firestore.host-port=localhost:8080"
-		).run(context -> {
+			).withBean("mockedCredentialsProvider", CredentialsProvider.class, () -> mockedCredentialsProvider)
+		.run(context -> {
 			CredentialsProvider defaultCredentialsProvider = context.getBean(CredentialsProvider.class);
 			assertThat(defaultCredentialsProvider).isNotInstanceOf(NoCredentialsProvider.class);
 


### PR DESCRIPTION
Making **spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationTests.java** run faster.