### PR TITLE
Set graal to 21.2

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -27,6 +27,7 @@
 		<app-engine-maven-plugin.version>2.4.1</app-engine-maven-plugin.version>
 		<spring-native.version>0.10.4</spring-native.version>
 		<google-cloud-graalvm-support.version>0.7.0</google-cloud-graalvm-support.version>
+		<java-native-image.version>5.5.0</java-native-image.version>
 		<testcontainers.version>1.16.2</testcontainers.version>
 		<skip.surefire.tests>false</skip.surefire.tests>
 		<skip.failsafe.tests>false</skip.failsafe.tests>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/pom.xml
@@ -176,6 +176,9 @@
                   <BP_NATIVE_IMAGE_BUILD_ARGUMENTS>${native.build.args}</BP_NATIVE_IMAGE_BUILD_ARGUMENTS>
                 </env>
                 <pullPolicy>IF_NOT_PRESENT</pullPolicy>
+                <buildpacks>
+                    <buildpack>gcr.io/paketo-buildpacks/java-native-image:5.5.0</buildpack>
+                </buildpacks>
               </image>
             </configuration>
             <executions>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/pom.xml
@@ -177,7 +177,7 @@
                 </env>
                 <pullPolicy>IF_NOT_PRESENT</pullPolicy>
                 <buildpacks>
-                    <buildpack>gcr.io/paketo-buildpacks/java-native-image:5.5.0</buildpack>
+                    <buildpack>gcr.io/paketo-buildpacks/java-native-image:${java-native-image.version}</buildpack>
                 </buildpacks>
               </image>
             </configuration>


### PR DESCRIPTION
Java8 is [not supported](https://github.com/paketo-buildpacks/graalvm/commit/276cf8880ed8f81573db0f3577e5679bd71734b7) by the latest graal buildpack.

In any case, we should keep the version of graal in buildpack consistent with the rest of the dependencies.