### PR TITLE
Port fixes that worked for javadoc publishing back to main

### DIFF
--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -5,6 +5,8 @@ if [[ -z "${CREDENTIALS}" ]]; then
   CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
 fi
 
+pyenv global 3.7.2
+
 # Get into the spring-cloud-gcp repo directory
 dir=$(dirname "$0")
 pushd $dir/../
@@ -17,6 +19,7 @@ PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceSt
 
 # Install docuploader package
 python3 -m pip install --upgrade six
+python3 -m pip install --upgrade protobuf
 python3 -m pip install gcp-docuploader
 
 # Build the javadocs


### PR DESCRIPTION
I published javadoc from `2.0.6-javadoc` branch because `main` was already tagged at a point in time that had the bad version of the script.

Porting it, so it's correct for future releases.