### PR TITLE
Roll back spring-cloud-dependencies from 2020.0.5 to 2020.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
 		<skipTests>false</skipTests>
 		<spring-cloud-build.version>3.0.4</spring-cloud-build.version>
-		<spring-cloud-dependencies.version>2020.0.5</spring-cloud-dependencies.version>
+		<spring-cloud-dependencies.version>2020.0.4</spring-cloud-dependencies.version>
 		<spring-boot-dependencies.version>2.5.7</spring-boot-dependencies.version>
 		<spring-javaformat-checkstyle.version>0.0.29</spring-javaformat-checkstyle.version>
 		<zipkin-gcp.version>1.0.2</zipkin-gcp.version>


### PR DESCRIPTION
roll back dependabot bump of spring-cloud-dependencies (#807) due to failing integration tests.