### PR TITLE
upgrade to spring-boot 2.6.2 for 3.x

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.1</version>
+		<version>2.6.2</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
[Spring Boot 2.6.2](https://github.com/spring-projects/spring-boot/releases/tag/v2.6.2) just released today. 
Including upgrade to Log4j2 2.17.0 
