### PR TITLE
Update Spring Boot in samples to 2.5.8

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.3</version>
+		<version>2.5.8</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
I think dependabot ignored updates for a bit because we asked to not do "minor updates" when it tried to go from 2.5.3 to 2.6.0.