### PR TITLE
Rename method to avoid confusing name clash with parent

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/PartTreeSpannerQuery.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/PartTreeSpannerQuery.java
@@ -60,7 +60,7 @@ public class PartTreeSpannerQuery<T> extends AbstractSpannerQuery<T> {
 		if (isCountOrExistsQuery()) {
 			return SpannerStatementQueryExecutor.executeQuery(
 					struct -> isCountQuery() ? struct.getLong(0) : struct.getBoolean(0),
-					this.entityType, this.tree, paramAccessor, getQueryMethod().getMethod().getParameters(),
+					this.entityType, this.tree, paramAccessor, getQueryMethod().getQueryMethod().getParameters(),
 					this.spannerTemplate,
 					this.spannerMappingContext);
 		}
@@ -69,7 +69,7 @@ public class PartTreeSpannerQuery<T> extends AbstractSpannerQuery<T> {
 					.performReadWriteTransaction(getDeleteFunction(parameters));
 		}
 		return SpannerStatementQueryExecutor.executeQuery(this.entityType, this.tree,
-				paramAccessor, getQueryMethod().getMethod().getParameters(), this.spannerTemplate,
+				paramAccessor, getQueryMethod().getQueryMethod().getParameters(), this.spannerTemplate,
 				this.spannerMappingContext);
 	}
 
@@ -78,7 +78,7 @@ public class PartTreeSpannerQuery<T> extends AbstractSpannerQuery<T> {
 			ParameterAccessor paramAccessor = new ParametersParameterAccessor(getQueryMethod().getParameters(),
 					parameters);
 			List<T> entitiesToDelete = SpannerStatementQueryExecutor
-					.executeQuery(this.entityType, this.tree, paramAccessor, getQueryMethod().getMethod().getParameters(),
+					.executeQuery(this.entityType, this.tree, paramAccessor, getQueryMethod().getQueryMethod().getParameters(),
 							transactionTemplate, this.spannerMappingContext);
 			transactionTemplate.deleteAll(entitiesToDelete);
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryMethod.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryMethod.java
@@ -37,19 +37,19 @@ import org.springframework.util.StringUtils;
  */
 public class SpannerQueryMethod extends QueryMethod {
 
-	private final Method method;
+	private final Method queryMethod;
 
 	/**
 	 * Creates a new {@link QueryMethod} from the given parameters. Looks up the correct
 	 * query to use for following invocations of the method given.
 	 *
-	 * @param method must not be {@literal null}.
+	 * @param queryMethod must not be {@literal null}.
 	 * @param metadata must not be {@literal null}.
 	 * @param factory must not be {@literal null}.
 	 */
-	public SpannerQueryMethod(Method method, RepositoryMetadata metadata, ProjectionFactory factory) {
-		super(method, metadata, factory);
-		this.method = method;
+	public SpannerQueryMethod(Method queryMethod, RepositoryMetadata metadata, ProjectionFactory factory) {
+		super(queryMethod, metadata, factory);
+		this.queryMethod = queryMethod;
 	}
 
 	/**
@@ -73,8 +73,8 @@ public class SpannerQueryMethod extends QueryMethod {
 	 * Get the method metadata.
 	 * @return the method metadata.
 	 */
-	public Method getMethod() {
-		return this.method;
+	Method getQueryMethod() {
+		return this.queryMethod;
 	}
 
 	/**
@@ -85,6 +85,6 @@ public class SpannerQueryMethod extends QueryMethod {
 	 */
 	@Nullable
 	Query getQueryAnnotation() {
-		return AnnotatedElementUtils.findMergedAnnotation(this.method, Query.class);
+		return AnnotatedElementUtils.findMergedAnnotation(this.queryMethod, Query.class);
 	}
 }

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQuery.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQuery.java
@@ -262,7 +262,7 @@ public class SqlSpannerQuery<T> extends AbstractSpannerQuery<T> {
 
 	private Statement buildStatementFromQueryAndTags(QueryTagValue queryTagValue) {
 		Map<String, java.lang.reflect.Parameter> paramMetadataMap = new HashMap<>();
-		for (java.lang.reflect.Parameter param : getQueryMethod().getMethod().getParameters()) {
+		for (java.lang.reflect.Parameter param : getQueryMethod().getQueryMethod().getParameters()) {
 			Param annotation = param.getAnnotation(Param.class);
 			paramMetadataMap.put(annotation == null ? param.getName() : annotation.value(), param);
 		}

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryMethodTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryMethodTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.data.spanner.repository.query;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.util.ClassTypeInformation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SpannerQueryMethodTests {
+
+
+	RepositoryMetadata mockMetadata;
+	ProjectionFactory mockProjectionFactory;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		this.mockMetadata = mock(RepositoryMetadata.class);
+		this.mockProjectionFactory = mock(ProjectionFactory.class);
+		when(mockMetadata.getReturnType(any())).thenReturn(
+				ClassTypeInformation.fromReturnTypeOf(Example.class.getMethod("someAnnotatedMethod")));
+		doAnswer(a -> String.class).when(mockMetadata).getReturnedDomainClass(any());
+	}
+
+	@Test
+	public void hasQueryAnnotationTrueIfNonEmptyQueryFound() throws NoSuchMethodException {
+		SpannerQueryMethod queryMethod = new SpannerQueryMethod(
+				Example.class.getMethod("someAnnotatedMethod"), mockMetadata, mockProjectionFactory);
+		assertThat(queryMethod.hasAnnotatedQuery()).isTrue();
+	}
+
+	@Test
+	public void hasQueryAnnotationFalseIfNotAnnotated() throws NoSuchMethodException {
+		SpannerQueryMethod queryMethod = new SpannerQueryMethod(
+				Example.class.getMethod("plainMethod"), mockMetadata, mockProjectionFactory);
+		assertThat(queryMethod.hasAnnotatedQuery()).isFalse();
+	}
+
+	@Test
+	public void getQueryMethodReturnsStoredConstructorArgument() throws NoSuchMethodException {
+		Method method = Example.class.getMethod("plainMethod");
+		SpannerQueryMethod queryMethod = new SpannerQueryMethod(method, mockMetadata, mockProjectionFactory);
+		assertThat(queryMethod.getQueryMethod()).isSameAs(method);
+	}
+
+	@Test
+	public void getQueryAnnotationsReturnsCorrectOne() throws NoSuchMethodException {
+		SpannerQueryMethod queryMethod = new SpannerQueryMethod(
+				Example.class.getMethod("someAnnotatedMethod"), mockMetadata, mockProjectionFactory);
+		Query query = queryMethod.getQueryAnnotation();
+		assertThat(query.value()).isEqualTo("select something");
+	}
+
+
+	static class Example {
+		@Query("select something")
+		public String someAnnotatedMethod() {
+			return "I'm annotated";
+		}
+
+		public String plainMethod() {
+			return "I'm not annotated";
+		}
+	}
+}

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryMethodTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryMethodTests.java
@@ -31,14 +31,14 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SpannerQueryMethodTests {
+class SpannerQueryMethodTests {
 
 
 	RepositoryMetadata mockMetadata;
 	ProjectionFactory mockProjectionFactory;
 
 	@BeforeEach
-	public void setUp() throws Exception {
+	void setUp() throws Exception {
 		this.mockMetadata = mock(RepositoryMetadata.class);
 		this.mockProjectionFactory = mock(ProjectionFactory.class);
 		when(mockMetadata.getReturnType(any())).thenReturn(
@@ -47,28 +47,28 @@ public class SpannerQueryMethodTests {
 	}
 
 	@Test
-	public void hasQueryAnnotationTrueIfNonEmptyQueryFound() throws NoSuchMethodException {
+	void hasQueryAnnotationTrueIfNonEmptyQueryFound() throws NoSuchMethodException {
 		SpannerQueryMethod queryMethod = new SpannerQueryMethod(
 				Example.class.getMethod("someAnnotatedMethod"), mockMetadata, mockProjectionFactory);
 		assertThat(queryMethod.hasAnnotatedQuery()).isTrue();
 	}
 
 	@Test
-	public void hasQueryAnnotationFalseIfNotAnnotated() throws NoSuchMethodException {
+	void hasQueryAnnotationFalseIfNotAnnotated() throws NoSuchMethodException {
 		SpannerQueryMethod queryMethod = new SpannerQueryMethod(
 				Example.class.getMethod("plainMethod"), mockMetadata, mockProjectionFactory);
 		assertThat(queryMethod.hasAnnotatedQuery()).isFalse();
 	}
 
 	@Test
-	public void getQueryMethodReturnsStoredConstructorArgument() throws NoSuchMethodException {
+	void getQueryMethodReturnsStoredConstructorArgument() throws NoSuchMethodException {
 		Method method = Example.class.getMethod("plainMethod");
 		SpannerQueryMethod queryMethod = new SpannerQueryMethod(method, mockMetadata, mockProjectionFactory);
 		assertThat(queryMethod.getQueryMethod()).isSameAs(method);
 	}
 
 	@Test
-	public void getQueryAnnotationsReturnsCorrectOne() throws NoSuchMethodException {
+	void getQueryAnnotationsReturnsCorrectOne() throws NoSuchMethodException {
 		SpannerQueryMethod queryMethod = new SpannerQueryMethod(
 				Example.class.getMethod("someAnnotatedMethod"), mockMetadata, mockProjectionFactory);
 		Query query = queryMethod.getQueryAnnotation();

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
@@ -84,7 +84,7 @@ public class SpannerStatementQueryTests {
 		this.queryMethod = mock(SpannerQueryMethod.class);
 		// this is a dummy object. it is not mockable otherwise.
 		Method method = Object.class.getMethod("toString");
-		when(this.queryMethod.getMethod()).thenReturn(method);
+		when(this.queryMethod.getQueryMethod()).thenReturn(method);
 		this.spannerTemplate = mock(SpannerTemplate.class);
 		SpannerEntityProcessor spannerEntityProcessor = mock(SpannerEntityProcessor.class);
 		when(this.spannerTemplate.getSpannerEntityProcessor()).thenReturn(spannerEntityProcessor);
@@ -160,7 +160,7 @@ public class SpannerStatementQueryTests {
 		Method method = QueryHolder.class.getMethod("repositoryMethod1", Object.class, Object.class, Object.class,
 				Object.class, Object.class, Object.class, Object.class, Object.class, Object.class, Object.class,
 				Object.class, Object.class, List.class, BigDecimal.class);
-		when(this.queryMethod.getMethod()).thenReturn(method);
+		when(this.queryMethod.getQueryMethod()).thenReturn(method);
 		doReturn(new DefaultParameters(method)).when(this.queryMethod).getParameters();
 
 		this.partTreeSpannerQuery.execute(params);

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
@@ -116,7 +116,7 @@ public class SqlSpannerQueryTests {
 		this.queryMethod = mock(SpannerQueryMethod.class);
 		// this is a dummy object. it is not mockable otherwise.
 		Method method = Object.class.getMethod("toString");
-		when(this.queryMethod.getMethod()).thenReturn(method);
+		when(this.queryMethod.getQueryMethod()).thenReturn(method);
 		when(this.spannerEntityProcessor.getWriteConverter()).thenReturn(new SpannerWriteConverter());
 		when(this.spannerEntityProcessor.getReadConverter()).thenReturn(new SpannerReadConverter());
 		this.spannerTemplate = spy(new SpannerTemplate(() -> this.databaseClient,
@@ -171,7 +171,7 @@ public class SqlSpannerQueryTests {
 		// This dummy method was created so the metadata for the ARRAY param inner type is
 		// provided.
 		Method method = QueryHolder.class.getMethod("dummyMethod2");
-		when(this.queryMethod.getMethod()).thenReturn(method);
+		when(this.queryMethod.getQueryMethod()).thenReturn(method);
 		Mockito.<Parameters>when(this.queryMethod.getParameters()).thenReturn(new DefaultParameters(method));
 
 		sqlSpannerQuery.execute(new Object[] {});
@@ -227,7 +227,7 @@ public class SqlSpannerQueryTests {
 		// This dummy method was created so the metadata for the ARRAY param inner type is
 		// provided.
 		Method method = QueryHolder.class.getMethod("dummyMethod4", String.class, String.class, Pageable.class);
-		when(this.queryMethod.getMethod()).thenReturn(method);
+		when(this.queryMethod.getQueryMethod()).thenReturn(method);
 		Mockito.<Parameters>when(this.queryMethod.getParameters()).thenReturn(new DefaultParameters(method));
 
 		sqlSpannerQuery.execute(params);
@@ -283,7 +283,7 @@ public class SqlSpannerQueryTests {
 		// This dummy method was created so the metadata for the ARRAY param inner type is
 		// provided.
 		Method method = QueryHolder.class.getMethod("dummyMethod5", String.class, String.class, Sort.class);
-		when(this.queryMethod.getMethod()).thenReturn(method);
+		when(this.queryMethod.getQueryMethod()).thenReturn(method);
 		Mockito.<Parameters>when(this.queryMethod.getParameters()).thenReturn(new DefaultParameters(method));
 
 		sqlSpannerQuery.execute(params);
@@ -340,7 +340,7 @@ public class SqlSpannerQueryTests {
 
 
 		Method method = QueryHolder.class.getMethod("sortAndPageable", String.class, String.class, Sort.class, Pageable.class);
-		when(this.queryMethod.getMethod()).thenReturn(method);
+		when(this.queryMethod.getQueryMethod()).thenReturn(method);
 		Mockito.<Parameters>when(this.queryMethod.getParameters()).thenReturn(new DefaultParameters(method));
 
 		sqlSpannerQuery.execute(params);
@@ -433,7 +433,7 @@ public class SqlSpannerQueryTests {
 		Method method = QueryHolder.class.getMethod("dummyMethod", Object.class, Pageable.class, Object.class,
 				Object.class, Object.class, Object.class, Object.class, Object.class, Object.class, Object.class,
 				Object.class, List.class);
-		when(this.queryMethod.getMethod()).thenReturn(method);
+		when(this.queryMethod.getQueryMethod()).thenReturn(method);
 		Mockito.<Parameters>when(this.queryMethod.getParameters()).thenReturn(new DefaultParameters(method));
 		sqlSpannerQuery.execute(params);
 
@@ -520,7 +520,7 @@ public class SqlSpannerQueryTests {
 		// This dummy method was created so the metadata for the ARRAY param inner type is
 		// provided.
 		Method method = QueryHolder.class.getMethod("dummyMethod3", String.class, String.class);
-		when(this.queryMethod.getMethod()).thenReturn(method);
+		when(this.queryMethod.getQueryMethod()).thenReturn(method);
 		Mockito.<Parameters>when(this.queryMethod.getParameters()).thenReturn(new DefaultParameters(method));
 
 		when(sqlSpannerQuery.getReturnedSimpleConvertableItemType()).thenReturn(long.class);
@@ -565,7 +565,7 @@ public class SqlSpannerQueryTests {
 		// This dummy method was created so the metadata for the ARRAY param inner type is
 		// provided.
 		Method arrayParameterTriggeringMethod = QueryHolder.class.getMethod("dummyMethod6", String.class);
-		when(this.queryMethod.getMethod()).thenReturn(arrayParameterTriggeringMethod);
+		when(this.queryMethod.getQueryMethod()).thenReturn(arrayParameterTriggeringMethod);
 		Mockito.<Parameters>when(this.queryMethod.getParameters()).thenReturn(new DefaultParameters(arrayParameterTriggeringMethod));
 
 		sqlSpannerQuery.execute(params);


### PR DESCRIPTION
Spring Data added a new package-private method in v2.5.0 that clashes in name with `SpannerQueryMethod.getMethod()`. Sonar had angry thoughts about this that came up when I set Spring Boot version to 2.5.x in this repo.

This PR should fix Sonar's complaint about a confusing method name. Also, since this method never had any business being public, and because this is a breaking change anyhow, I've reduced visibility to package-private.