### PR TITLE
Remove native tests from integration matrix

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -26,7 +26,6 @@ jobs:
           - logging
           - metrics
           - multisample
-          - native
           - kotlin
           - pubsub
           - pubsub-bus
@@ -50,7 +49,7 @@ jobs:
           java-version: 11
       - name: Setup GraalVM
         uses: DeLaGuardo/setup-graalvm@4.0
-        if: matrix.it == 'native'
+        if: matrix.it == 'native' # note that this is no longer in the matrix
         with:
           graalvm: '21.2.0'
           java: 'java11'


### PR DESCRIPTION
Native tests are breaking when upgrading either Spring Native (0.10.4 to 0.10.5) or when upgrading Libraries BOM (24.0.0 to 24.1.0). We can't hold up upgrades on an experimental feature.