### PR TITLE
Added scheduled CI workflows for 2.x

### DIFF
--- a/.github/workflows/integrationTests-2.x.yaml
+++ b/.github/workflows/integrationTests-2.x.yaml
@@ -1,0 +1,131 @@
+name: Scheduled Integration Tests for 2.x
+
+on:
+  # push to 2.x branch is handled by default integrationTests.yaml
+  workflow_dispatch:
+  schedule:
+    - cron: '05 5 * * *' # 05:00 UTC every day
+
+
+jobs:
+  integrationTests:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        it:
+          - bigquery
+          - cloudsql
+          - config
+          - datastore
+          - firestore
+          - kms
+          - logging
+          - metrics
+          - multisample
+          - kotlin
+          - pubsub
+          - pubsub-bus
+          - pubsub-docs
+          - pubsub-emulator
+          - pubsub-integration
+          - secretmanager
+          - spanner
+          - storage
+          - trace
+          - vision
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+      - uses: actions/checkout@v2
+        - ref: '2.x'
+      - name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v2
+        id: mvn-cache
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: latest
+          project_id: spring-cloud-gcp-ci
+          service_account_key: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY }}
+          export_default_credentials: true
+      - name: Install pubsub-emulator
+        if: ${{ matrix.it == 'pubsub-emulator' }}
+        run: |
+          gcloud components install pubsub-emulator beta && \
+            gcloud components update
+      - name: Maven go offline
+        id: mvn-offline
+        if: steps.mvn-cache.outputs.cache-hit != 'true'
+        run: ./mvnw compile dependency:go-offline
+      - name: Mvn install # Need this when the directory/pom structure changes
+        id: install1
+        continue-on-error: true
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --threads 1.5C \
+            --define maven.test.skip=true \
+            --define maven.javadoc.skip=true \
+            install
+      - name: Retry install on failure
+        id: install2
+        if: steps.install1.outcome == 'failure'
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --threads 1.5C \
+            --define maven.test.skip=true \
+            --define maven.javadoc.skip=true \
+            install
+      - name: Wait our turn for running integration tests
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          continue-after-seconds: 1200 # 30 min
+          same-branch-only: false
+      - name: Integration Tests
+        id: intTest1
+        continue-on-error: true
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --activate-profiles spring-cloud-gcp-ci-it \
+            --define maven.javadoc.skip=true \
+            --define skip.surefire.tests=true \
+            --define it.${{ matrix.it }}=true \
+            verify
+      - name: Retry on Failure
+        id: intTest2
+        if: steps.intTest1.outcome == 'failure'
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --activate-profiles spring-cloud-gcp-ci-it \
+            --define maven.javadoc.skip=true \
+            --define skip.surefire.tests=true \
+            --define it.${{ matrix.it }}=true \
+            verify
+      - name: Aggregate Report
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --define aggregate=true \
+            surefire-report:failsafe-report-only
+      - name: Archive logs
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: Integration Test Logs - ${{ matrix.it}}
+          path: |
+            **/target/failsafe-reports/*
+            **/target/site

--- a/.github/workflows/integrationTests-2.x.yaml
+++ b/.github/workflows/integrationTests-2.x.yaml
@@ -40,7 +40,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
       - uses: actions/checkout@v2
         with:
-          ref: '2.x'
+          ref: 2.x
       - name: Setup Java 11
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/integrationTests-2.x.yaml
+++ b/.github/workflows/integrationTests-2.x.yaml
@@ -39,7 +39,8 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
       - uses: actions/checkout@v2
-        - ref: '2.x'
+        with:
+          ref: '2.x'
       - name: Setup Java 11
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 2.x
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/unitTests-2.x.yaml
+++ b/.github/workflows/unitTests-2.x.yaml
@@ -20,7 +20,8 @@ jobs:
       run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
 
     - uses: actions/checkout@v2
-      - ref: '2.x'
+      with:
+        ref: '2.x'
 
     - uses: actions/setup-java@v1
       with:
@@ -97,7 +98,8 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
 
       - uses: actions/checkout@v2
-        - ref: '2.x'
+        with:
+          ref: '2.x'
 
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/unitTests-2.x.yaml
+++ b/.github/workflows/unitTests-2.x.yaml
@@ -21,7 +21,7 @@ jobs:
 
     - uses: actions/checkout@v2
       with:
-        ref: '2.x'
+        ref: 2.x
 
     - uses: actions/setup-java@v1
       with:
@@ -99,7 +99,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          ref: '2.x'
+          ref: 2.x
 
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/unitTests-2.x.yaml
+++ b/.github/workflows/unitTests-2.x.yaml
@@ -1,14 +1,10 @@
-name: Unit Tests
+name: Scheduled Unit Tests for 2.x
 
 on:
-  push:
-    branches:
-      - main
-      - 2.x
-  pull_request:
+  # push to 2.x branch is handled by default unitTests.yaml
   workflow_dispatch:
   schedule:
-    - cron: '05 7 * * *' # 07:00 UTC every day
+    - cron: '05 5 * * *' # 05:00 UTC every day
 
 
 jobs:
@@ -24,6 +20,7 @@ jobs:
       run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
 
     - uses: actions/checkout@v2
+      - ref: '2.x'
 
     - uses: actions/setup-java@v1
       with:
@@ -100,6 +97,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
 
       - uses: actions/checkout@v2
+        - ref: '2.x'
 
       - uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
GHA "schedule" task does not allow you to set custom branches; it always runs on the last commit of the main branch. So I added two new actions to handle the scheduled unit/integration tests for the 2.x branch.

Pull requests and pushes to the branch will continue being handled by the existing yaml configuration files.

I also removed all native IT setup from the 2.x integration configuration. No reason to maintain it for the 2.x branch, as those are not released artifacts.