### PR TITLE
Add dependabot config to also work on 2.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,14 @@ updates:
     versions: ["[3.0.0,)"]
   - dependency-name: "org.springframework.cloud:spring-cloud-config-dependencies"
     versions: ["[3.0.0,)"]
-  - dependency-name: "org.springframework.experimental:*"
+    # Spring Native dependencies
+  - dependency-name: "org.springframework.experimental:spring-native-configuration"
+    versions: ["[0.11.0,)"]
+  - dependency-name: "org.springframework.experimental:spring-aot"
+    versions: ["[0.11.0,)"]
+  - dependency-name: "org.springframework.experimental:spring-native"
+    versions: ["[0.11.0,)"]
+  - dependency-name: "org.springframework.experimental:spring-aot-maven-plugin"
     versions: ["[0.11.0,)"]
   - dependency-name: "*"
     update-types: [ "version-update:semver-major" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,21 @@ updates:
     interval: daily
   target-branch: "2.x"
   ignore:
-    - dependency-name: "*"
-      update-types: [ "version-update:semver-major" ]
+  # Ignore Spring dependencies based on Spring Boot 2.6 and later
+  - dependency-name: "org.springframework.boot:spring-boot*"
+    versions: ["[2.6.0,)"]
+  - dependency-name: "org.springframework.cloud:spring-cloud-build*"
+    versions: ["[3.0.0,)"]
+  - dependency-name: "org.springframework.cloud:spring-cloud-dependencies"
+    versions: ["[2021.0.0,)"]
+  - dependency-name: "org.springframework.cloud:spring-cloud-dependencies-parent"
+    versions: ["[3.0.0,)"]
+  - dependency-name: "org.springframework.cloud:spring-cloud-config-dependencies"
+    versions: ["[3.0.0,)"]
+  - dependency-name: "org.springframework.experimental:*"
+    versions: ["[0.11.0,)"]
+  - dependency-name: "*"
+    update-types: [ "version-update:semver-major" ]
   labels:
-    - "2.x dependencies"
+  - "2.x dependencies"
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,17 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  labels:
+  - "dependencies"
+
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+  target-branch: "2.x"
+  ignore:
+  - dependency-name: "*"
+    update-types: [ "version-update:semver-major" ]
+  labels:
+  - "2.x dependencies"
+  open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   labels:
-  - "dependencies"
+    - "dependencies"
 
 - package-ecosystem: maven
   directory: "/"
@@ -14,8 +14,8 @@ updates:
     interval: daily
   target-branch: "2.x"
   ignore:
-  - dependency-name: "*"
-    update-types: [ "version-update:semver-major" ]
+    - dependency-name: "*"
+      update-types: [ "version-update:semver-major" ]
   labels:
-  - "2.x dependencies"
+    - "2.x dependencies"
   open-pull-requests-limit: 10


### PR DESCRIPTION
Add dependabot config for targeting 2.x branch, ignoring all major version upgrades.
[guide for setting up ignore.](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#creating-ignore-conditions-from-dependabot-ignore)

