### PR TITLE
fix doc link to javadoc page PatternMatchUtils.class

### DIFF
--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -321,7 +321,7 @@ NOTE: The order in which the patterns are declared in `PubSubHeaderMapper.setOut
 The first patterns have precedence over the following ones.
 
 In the previous example, the `"*"` pattern means every header is mapped.
-However, because it comes last in the list, https://docs.spring.io/spring-integration/api/org/springframework/integration/util/PatternMatchUtils.html#smartMatch-java.lang.String-java.lang.String...-[the previous patterns take precedence].
+However, because it comes last in the list, https://docs.spring.io/spring-integration/api/org/springframework/integration/support/utils/PatternMatchUtils.html[the previous patterns take precedence].
 
 ==== Samples
 


### PR DESCRIPTION
fix doc link to javadoc page PatternMatchUtils.class