### PR TITLE
Google checkstyle breaking changes only

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -132,8 +132,8 @@ a| This is used to generate fully qualified Cloud Trace ID format: `projects/[PR
 This format is required to correlate trace between Cloud Trace and Cloud Logging.
 
 If `projectId` is not set and cannot be determined, then it'll log `traceId` without the fully qualified format.
-| `traceIdMDCField` | `traceId` | The MDC field name for retrieving a trace id
-| `spanIdMDCField` | `spanId` | the MDC field name for retrieving a span id
+| `traceIdMdcField` | `traceId` | The MDC field name for retrieving a trace id
+| `spanIdMdcField` | `spanId` | the MDC field name for retrieving a span id
 | `includeTraceId` | `true` | Should the trace id be included
 | `includeSpanId` | `true` | Should the span id be included
 | `includeLevel` | `true` | Should the severity be included
@@ -170,8 +170,8 @@ This is an example of such an Logback configuration:
       <layout class="com.google.cloud.spring.logging.StackdriverJsonLayout">
         <projectId>${projectId}</projectId>
 
-        <!--<traceIdMDCField>traceId</traceIdMDCField>-->
-        <!--<spanIdMDCField>spanId</spanIdMDCField>-->
+        <!--<traceIdMdcField>traceId</traceIdMdcField>-->
+        <!--<spanIdMdcField>spanId</spanIdMdcField>-->
         <!--<includeTraceId>true</includeTraceId>-->
         <!--<includeSpanId>true</includeSpanId>-->
         <!--<includeLevel>true</includeLevel>-->

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
@@ -35,12 +35,12 @@ import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
- * This class configures a Web MVC interceptor to capture trace IDs for log correlation. This
- * configuration is turned on only if Trace support is not used and Web MVC is used. Otherwise, the
- * MDC context will be used by the Logback appenders.
+ * This class configures a Web MVC interceptor to capture trace IDs for log correlation.
+ * This configuration is turned on only if Trace support is not used and Web MVC is used.
+ * Otherwise, the MDC context will be used by the Logback appenders.
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass({HandlerInterceptor.class, LoggingAppender.class, TraceIdExtractor.class})
+@ConditionalOnClass({ HandlerInterceptor.class, LoggingAppender.class, TraceIdExtractor.class })
 @ConditionalOnMissingBean(name = "stackdriverTracingCustomizer")
 @AutoConfigureAfter(StackdriverTraceAutoConfiguration.class)
 @ConditionalOnWebApplication(type = Type.SERVLET)

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/logging/StackdriverLoggingAutoConfiguration.java
@@ -20,8 +20,8 @@ import com.google.cloud.logging.logback.LoggingAppender;
 import com.google.cloud.spring.autoconfigure.trace.StackdriverTraceAutoConfiguration;
 import com.google.cloud.spring.logging.LoggingWebMvcConfigurer;
 import com.google.cloud.spring.logging.TraceIdLoggingWebMvcInterceptor;
+import com.google.cloud.spring.logging.extractors.CloudTraceIdExtractor;
 import com.google.cloud.spring.logging.extractors.TraceIdExtractor;
-import com.google.cloud.spring.logging.extractors.XCloudTraceIdExtractor;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -35,12 +35,12 @@ import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
- * This class configures a Web MVC interceptor to capture trace IDs for log correlation.
- * This configuration is turned on only if Trace support is not used and Web MVC is used.
- * Otherwise, the MDC context will be used by the Logback appenders.
+ * This class configures a Web MVC interceptor to capture trace IDs for log correlation. This
+ * configuration is turned on only if Trace support is not used and Web MVC is used. Otherwise, the
+ * MDC context will be used by the Logback appenders.
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass({ HandlerInterceptor.class, LoggingAppender.class, TraceIdExtractor.class })
+@ConditionalOnClass({HandlerInterceptor.class, LoggingAppender.class, TraceIdExtractor.class})
 @ConditionalOnMissingBean(name = "stackdriverTracingCustomizer")
 @AutoConfigureAfter(StackdriverTraceAutoConfiguration.class)
 @ConditionalOnWebApplication(type = Type.SERVLET)
@@ -58,7 +58,7 @@ public class StackdriverLoggingAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public TraceIdExtractor traceIdExtractor() {
-		return new XCloudTraceIdExtractor();
+		return new CloudTraceIdExtractor();
 	}
 
 }

--- a/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/LoggingWebMvcConfigurer.java
+++ b/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/LoggingWebMvcConfigurer.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spring.logging;
 
 import com.google.cloud.spring.core.GcpProjectIdProvider;
-import com.google.cloud.spring.logging.extractors.XCloudTraceIdExtractor;
+import com.google.cloud.spring.logging.extractors.CloudTraceIdExtractor;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
@@ -34,10 +34,11 @@ public class LoggingWebMvcConfigurer implements WebMvcConfigurer {
 
 	/**
 	 * Constructor that accepts an {@link TraceIdLoggingWebMvcInterceptor}. If the given
-	 * interceptor is null, then a default {@link XCloudTraceIdExtractor} is used.
+	 * interceptor is null, then a default {@link CloudTraceIdExtractor} is used.
+	 *
 	 * @param interceptor the interceptor to use with this configurer. If not provided a
-	 * {@link TraceIdLoggingWebMvcInterceptor} is used with the trace ID extractor
-	 * described above.
+	 *     {@link TraceIdLoggingWebMvcInterceptor} is used with the trace ID extractor
+	 *     described above.
 	 * @param projectIdProvider the project ID provider to use
 	 */
 	public LoggingWebMvcConfigurer(
@@ -47,8 +48,7 @@ public class LoggingWebMvcConfigurer implements WebMvcConfigurer {
 			this.interceptor = interceptor;
 		}
 		else {
-			this.interceptor = new TraceIdLoggingWebMvcInterceptor(
-					new XCloudTraceIdExtractor());
+			this.interceptor = new TraceIdLoggingWebMvcInterceptor(new CloudTraceIdExtractor());
 		}
 	}
 

--- a/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/LoggingWebMvcConfigurer.java
+++ b/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/LoggingWebMvcConfigurer.java
@@ -35,10 +35,9 @@ public class LoggingWebMvcConfigurer implements WebMvcConfigurer {
 	/**
 	 * Constructor that accepts an {@link TraceIdLoggingWebMvcInterceptor}. If the given
 	 * interceptor is null, then a default {@link CloudTraceIdExtractor} is used.
-	 *
 	 * @param interceptor the interceptor to use with this configurer. If not provided a
-	 *     {@link TraceIdLoggingWebMvcInterceptor} is used with the trace ID extractor
-	 *     described above.
+	 * {@link TraceIdLoggingWebMvcInterceptor} is used with the trace ID extractor
+	 * described above.
 	 * @param projectIdProvider the project ID provider to use
 	 */
 	public LoggingWebMvcConfigurer(
@@ -48,7 +47,9 @@ public class LoggingWebMvcConfigurer implements WebMvcConfigurer {
 			this.interceptor = interceptor;
 		}
 		else {
-			this.interceptor = new TraceIdLoggingWebMvcInterceptor(new CloudTraceIdExtractor());
+			this.interceptor = new TraceIdLoggingWebMvcInterceptor(
+					new CloudTraceIdExtractor()
+			);
 		}
 	}
 

--- a/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/StackdriverJsonLayout.java
+++ b/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/StackdriverJsonLayout.java
@@ -76,7 +76,9 @@ public class StackdriverJsonLayout extends JsonLayout {
 
 	private final List<JsonLoggingEventEnhancer> loggingEventEnhancers = new ArrayList<>();
 
-	/** creates a layout for a Logback appender compatible to the Stackdriver log format. */
+	/**
+	 * creates a layout for a Logback appender compatible to the Stackdriver log format.
+	 */
 	public StackdriverJsonLayout() {
 		this.traceIdMdcField = StackdriverTraceConstants.MDC_FIELD_TRACE_ID;
 		this.spanIdMdcField = StackdriverTraceConstants.MDC_FIELD_SPAN_ID;
@@ -107,7 +109,6 @@ public class StackdriverJsonLayout extends JsonLayout {
 
 	/**
 	 * Get the MDC filed name for trace id.
-	 *
 	 * @return the MDC field name for retrieving a trace id
 	 * @since 2.0.5
 	 */
@@ -117,7 +118,6 @@ public class StackdriverJsonLayout extends JsonLayout {
 
 	/**
 	 * Set the MDC filed name for trace id.
-	 *
 	 * @param traceIdMdcField the MDC field name for retrieving a trace id
 	 * @since 2.0.5
 	 */
@@ -127,7 +127,6 @@ public class StackdriverJsonLayout extends JsonLayout {
 
 	/**
 	 * Get the MDC field name for span id.
-	 *
 	 * @return the MDC field name for retrieving a span id
 	 * @since 2.0.5
 	 */
@@ -137,7 +136,6 @@ public class StackdriverJsonLayout extends JsonLayout {
 
 	/**
 	 * Set the MDC field name for span id.
-	 *
 	 * @param spanIdMdcField the MDC field name for retrieving a span id
 	 * @since 2.0.5
 	 */
@@ -237,9 +235,9 @@ public class StackdriverJsonLayout extends JsonLayout {
 			this.projectId = projectIdProvider.getProjectId();
 		}
 
-		this.filteredMdcFields = new HashSet<>(
-				Arrays.asList(
-						traceIdMdcField, spanIdMdcField, StackdriverTraceConstants.MDC_FIELD_SPAN_EXPORT));
+		this.filteredMdcFields =
+				new HashSet<>(Arrays.asList(traceIdMdcField, spanIdMdcField,
+						StackdriverTraceConstants.MDC_FIELD_SPAN_EXPORT));
 	}
 
 	/**
@@ -276,18 +274,11 @@ public class StackdriverJsonLayout extends JsonLayout {
 			map.put(JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, formatMessage(event));
 		}
 		add(JsonLayout.MESSAGE_ATTR_NAME, this.includeMessage, event.getMessage(), map);
-		add(
-				JsonLayout.CONTEXT_ATTR_NAME,
-				this.includeContextName,
-				event.getLoggerContextVO().getName(),
-				map);
+		add(JsonLayout.CONTEXT_ATTR_NAME, this.includeContextName, event.getLoggerContextVO().getName(), map);
 		addThrowableInfo(JsonLayout.EXCEPTION_ATTR_NAME, this.includeException, event, map);
 		addTraceId(event, map);
-		add(
-				StackdriverTraceConstants.SPAN_ID_ATTRIBUTE,
-				this.includeSpanId,
-				event.getMDCPropertyMap().get(spanIdMdcField),
-				map);
+		add(StackdriverTraceConstants.SPAN_ID_ATTRIBUTE, this.includeSpanId,
+				event.getMDCPropertyMap().get(spanIdMdcField), map);
 		if (this.serviceContext != null) {
 			map.put(StackdriverTraceConstants.SERVICE_CONTEXT_ATTRIBUTE, this.serviceContext);
 		}
@@ -306,8 +297,7 @@ public class StackdriverJsonLayout extends JsonLayout {
 	}
 
 	private String formatMessage(ILoggingEvent event) {
-		// the formatted message might be null, don't initialize StringBuilder with it, but append
-		// it afterwards
+		//the formatted message might be null, don't initialize StringBuilder with it, but append it afterwards
 		StringBuilder message = new StringBuilder();
 		message.append(event.getFormattedMessage());
 		if (!this.includeExceptionInMessage) {
@@ -327,8 +317,7 @@ public class StackdriverJsonLayout extends JsonLayout {
 
 	protected String formatTraceId(final String traceId) {
 		// Trace IDs are either 64-bit or 128-bit, which is 16-digit hex, or 32-digit hex.
-		// If traceId is 64-bit (16-digit hex), then we need to prepend 0's to make a 32-digit
-		// hex.
+		// If traceId is 64-bit (16-digit hex), then we need to prepend 0's to make a 32-digit hex.
 		if (traceId != null && traceId.length() == 16) {
 			return "0000000000000000" + traceId;
 		}
@@ -347,7 +336,8 @@ public class StackdriverJsonLayout extends JsonLayout {
 		if (StringUtils.hasText(traceId)
 				&& StringUtils.hasText(this.projectId)
 				&& !this.projectId.endsWith("_IS_UNDEFINED")) {
-			traceId = StackdriverTraceConstants.composeFullTraceName(this.projectId, formatTraceId(traceId));
+			traceId = StackdriverTraceConstants.composeFullTraceName(
+					this.projectId, formatTraceId(traceId));
 		}
 
 		add(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE, this.includeTraceId, traceId, map);

--- a/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/StackdriverJsonLayout.java
+++ b/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/StackdriverJsonLayout.java
@@ -58,9 +58,9 @@ public class StackdriverJsonLayout extends JsonLayout {
 
 	private String projectId;
 
-	private String traceIdMDCField;
+	private String traceIdMdcField;
 
-	private String spanIdMDCField;
+	private String spanIdMdcField;
 
 	private boolean includeTraceId;
 
@@ -76,12 +76,10 @@ public class StackdriverJsonLayout extends JsonLayout {
 
 	private final List<JsonLoggingEventEnhancer> loggingEventEnhancers = new ArrayList<>();
 
-	/**
-	 * creates a layout for a Logback appender compatible to the Stackdriver log format.
-	 */
+	/** creates a layout for a Logback appender compatible to the Stackdriver log format. */
 	public StackdriverJsonLayout() {
-		this.traceIdMDCField = StackdriverTraceConstants.MDC_FIELD_TRACE_ID;
-		this.spanIdMDCField = StackdriverTraceConstants.MDC_FIELD_SPAN_ID;
+		this.traceIdMdcField = StackdriverTraceConstants.MDC_FIELD_TRACE_ID;
+		this.spanIdMdcField = StackdriverTraceConstants.MDC_FIELD_SPAN_ID;
 		this.appendLineSeparator = true;
 		this.includeExceptionInMessage = true;
 		this.includeException = false;
@@ -109,38 +107,42 @@ public class StackdriverJsonLayout extends JsonLayout {
 
 	/**
 	 * Get the MDC filed name for trace id.
+	 *
 	 * @return the MDC field name for retrieving a trace id
 	 * @since 2.0.5
 	 */
-	public String getTraceIdMDCField() {
-		return traceIdMDCField;
+	public String getTraceIdMdcField() {
+		return traceIdMdcField;
 	}
 
 	/**
 	 * Set the MDC filed name for trace id.
-	 * @param traceIdMDCField the MDC field name for retrieving a trace id
+	 *
+	 * @param traceIdMdcField the MDC field name for retrieving a trace id
 	 * @since 2.0.5
 	 */
-	public void setTraceIdMDCField(String traceIdMDCField) {
-		this.traceIdMDCField = traceIdMDCField;
+	public void setTraceIdMdcField(String traceIdMdcField) {
+		this.traceIdMdcField = traceIdMdcField;
 	}
 
 	/**
 	 * Get the MDC field name for span id.
+	 *
 	 * @return the MDC field name for retrieving a span id
 	 * @since 2.0.5
 	 */
-	public String getSpanIdMDCField() {
-		return spanIdMDCField;
+	public String getSpanIdMdcField() {
+		return spanIdMdcField;
 	}
 
 	/**
 	 * Set the MDC field name for span id.
-	 * @param spanIdMDCField the MDC field name for retrieving a span id
+	 *
+	 * @param spanIdMdcField the MDC field name for retrieving a span id
 	 * @since 2.0.5
 	 */
-	public void setSpanIdMDCField(String spanIdMDCField) {
-		this.spanIdMDCField = spanIdMDCField;
+	public void setSpanIdMdcField(String spanIdMdcField) {
+		this.spanIdMdcField = spanIdMdcField;
 	}
 
 	/**
@@ -235,9 +237,9 @@ public class StackdriverJsonLayout extends JsonLayout {
 			this.projectId = projectIdProvider.getProjectId();
 		}
 
-		this.filteredMdcFields =
-				new HashSet<>(Arrays.asList(traceIdMDCField, spanIdMDCField,
-						StackdriverTraceConstants.MDC_FIELD_SPAN_EXPORT));
+		this.filteredMdcFields = new HashSet<>(
+				Arrays.asList(
+						traceIdMdcField, spanIdMdcField, StackdriverTraceConstants.MDC_FIELD_SPAN_EXPORT));
 	}
 
 	/**
@@ -274,11 +276,18 @@ public class StackdriverJsonLayout extends JsonLayout {
 			map.put(JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, formatMessage(event));
 		}
 		add(JsonLayout.MESSAGE_ATTR_NAME, this.includeMessage, event.getMessage(), map);
-		add(JsonLayout.CONTEXT_ATTR_NAME, this.includeContextName, event.getLoggerContextVO().getName(), map);
+		add(
+				JsonLayout.CONTEXT_ATTR_NAME,
+				this.includeContextName,
+				event.getLoggerContextVO().getName(),
+				map);
 		addThrowableInfo(JsonLayout.EXCEPTION_ATTR_NAME, this.includeException, event, map);
 		addTraceId(event, map);
-		add(StackdriverTraceConstants.SPAN_ID_ATTRIBUTE, this.includeSpanId,
-				event.getMDCPropertyMap().get(spanIdMDCField), map);
+		add(
+				StackdriverTraceConstants.SPAN_ID_ATTRIBUTE,
+				this.includeSpanId,
+				event.getMDCPropertyMap().get(spanIdMdcField),
+				map);
 		if (this.serviceContext != null) {
 			map.put(StackdriverTraceConstants.SERVICE_CONTEXT_ATTRIBUTE, this.serviceContext);
 		}
@@ -297,7 +306,8 @@ public class StackdriverJsonLayout extends JsonLayout {
 	}
 
 	private String formatMessage(ILoggingEvent event) {
-		//the formatted message might be null, don't initialize StringBuilder with it, but append it afterwards
+		// the formatted message might be null, don't initialize StringBuilder with it, but append
+		// it afterwards
 		StringBuilder message = new StringBuilder();
 		message.append(event.getFormattedMessage());
 		if (!this.includeExceptionInMessage) {
@@ -317,7 +327,8 @@ public class StackdriverJsonLayout extends JsonLayout {
 
 	protected String formatTraceId(final String traceId) {
 		// Trace IDs are either 64-bit or 128-bit, which is 16-digit hex, or 32-digit hex.
-		// If traceId is 64-bit (16-digit hex), then we need to prepend 0's to make a 32-digit hex.
+		// If traceId is 64-bit (16-digit hex), then we need to prepend 0's to make a 32-digit
+		// hex.
 		if (traceId != null && traceId.length() == 16) {
 			return "0000000000000000" + traceId;
 		}
@@ -329,15 +340,14 @@ public class StackdriverJsonLayout extends JsonLayout {
 			return;
 		}
 
-		String traceId = event.getMDCPropertyMap().get(traceIdMDCField);
+		String traceId = event.getMDCPropertyMap().get(traceIdMdcField);
 		if (traceId == null) {
 			traceId = TraceIdLoggingEnhancer.getCurrentTraceId();
 		}
 		if (StringUtils.hasText(traceId)
 				&& StringUtils.hasText(this.projectId)
 				&& !this.projectId.endsWith("_IS_UNDEFINED")) {
-			traceId = StackdriverTraceConstants.composeFullTraceName(
-					this.projectId, formatTraceId(traceId));
+			traceId = StackdriverTraceConstants.composeFullTraceName(this.projectId, formatTraceId(traceId));
 		}
 
 		add(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE, this.includeTraceId, traceId, map);

--- a/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/extractors/CloudTraceIdExtractor.java
+++ b/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/extractors/CloudTraceIdExtractor.java
@@ -21,7 +21,7 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * Extracts trace IDs from HTTP requests using the x-cloud-trace-context header.
  */
-public class XCloudTraceIdExtractor implements TraceIdExtractor {
+public class CloudTraceIdExtractor implements TraceIdExtractor {
 
 	/**
 	 * The name of the header that contains the trace id.

--- a/spring-cloud-gcp-logging/src/main/resources/com/google/cloud/spring/logging/logback-json-appender.xml
+++ b/spring-cloud-gcp-logging/src/main/resources/com/google/cloud/spring/logging/logback-json-appender.xml
@@ -10,8 +10,8 @@ Stackdriver json-log format provided for import.
             <layout class="com.google.cloud.spring.logging.StackdriverJsonLayout">
                 <projectId>${projectId}</projectId>
 
-                <!--<traceIdMDCField>traceId</traceIdMDCField>-->
-                <!--<spanIdMDCField>spanId</spanIdMDCField>-->
+                <!--<traceIdMdcField>traceId</traceIdMdcField>-->
+                <!--<spanIdMdcField>spanId</spanIdMdcField>-->
                 <!--<includeTraceId>true</includeTraceId>-->
                 <!--<includeSpanId>true</includeSpanId>-->
                 <!--<includeLevel>true</includeLevel>-->

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/CloudTraceIdExtractorTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/CloudTraceIdExtractorTests.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spring.logging;
 
-import com.google.cloud.spring.logging.extractors.XCloudTraceIdExtractor;
+import com.google.cloud.spring.logging.extractors.CloudTraceIdExtractor;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -26,8 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for the x-cloud trace ID extractor.
  */
-
-class XCloudTraceIdExtractorTests {
+class CloudTraceIdExtractorTests {
 
 	private static final String TEST_TRACE_ID = "105445aa7843bc8bf206b120001000";
 
@@ -35,7 +34,7 @@ class XCloudTraceIdExtractorTests {
 
 	private static final String TRACE_ID_HEADER = "X-CLOUD-TRACE-CONTEXT";
 
-	private XCloudTraceIdExtractor extractor = new XCloudTraceIdExtractor();
+	private CloudTraceIdExtractor extractor = new CloudTraceIdExtractor();
 
 	@Test
 	void testExtractTraceIdFromRequest_valid() {

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/StackdriverJsonLayoutLoggerTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/StackdriverJsonLayoutLoggerTests.java
@@ -86,8 +86,7 @@ class StackdriverJsonLayoutLoggerTests {
 				.containsEntry(JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, "test")
 				.containsEntry(StackdriverTraceConstants.SEVERITY_ATTRIBUTE, "WARNING")
 				.containsEntry(StackdriverJsonLayout.LOGGER_ATTR_NAME, "StackdriverJsonLayoutLoggerTests")
-				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE,
-						"projects/test-project/traces/12345678901234561234567890123456")
+				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE, "projects/test-project/traces/12345678901234561234567890123456")
 				.containsEntry(StackdriverTraceConstants.SPAN_ID_ATTRIBUTE, "span123")
 				.containsKey(StackdriverTraceConstants.TIMESTAMP_SECONDS_ATTRIBUTE)
 				.containsKey(StackdriverTraceConstants.TIMESTAMP_NANOS_ATTRIBUTE)
@@ -108,10 +107,8 @@ class StackdriverJsonLayoutLoggerTests {
 				.isNotNull()
 				.containsEntry(JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, "test")
 				.containsEntry(StackdriverTraceConstants.SEVERITY_ATTRIBUTE, "WARNING")
-				.containsEntry(StackdriverJsonLayout.LOGGER_ATTR_NAME,
-						"StackdriverJsonLayoutServiceCtxLoggerTests")
-				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE,
-						"projects/test-project/traces/12345678901234561234567890123456")
+				.containsEntry(StackdriverJsonLayout.LOGGER_ATTR_NAME, "StackdriverJsonLayoutServiceCtxLoggerTests")
+				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE, "projects/test-project/traces/12345678901234561234567890123456")
 				.containsEntry(StackdriverTraceConstants.SPAN_ID_ATTRIBUTE, "span123")
 				.containsEntry("foo", "bar")
 				.containsEntry("custom-key", "custom-value")
@@ -173,10 +170,8 @@ class StackdriverJsonLayoutLoggerTests {
 				.containsEntry("foo", "bar")
 				.containsEntry(JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, "test")
 				.containsEntry(StackdriverTraceConstants.SEVERITY_ATTRIBUTE, "WARNING")
-				.containsEntry(StackdriverJsonLayout.LOGGER_ATTR_NAME,
-						"StackdriverJsonLayoutCustomMDCFieldTests")
-				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE,
-						"projects/test-project/traces/12345678901234561234567890123456")
+				.containsEntry(StackdriverJsonLayout.LOGGER_ATTR_NAME, "StackdriverJsonLayoutCustomMDCFieldTests")
+				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE, "projects/test-project/traces/12345678901234561234567890123456")
 				.containsEntry(StackdriverTraceConstants.SPAN_ID_ATTRIBUTE, "span123")
 				.containsKey(StackdriverTraceConstants.TIMESTAMP_SECONDS_ATTRIBUTE)
 				.containsKey(StackdriverTraceConstants.TIMESTAMP_NANOS_ATTRIBUTE)
@@ -235,10 +230,11 @@ class StackdriverJsonLayoutLoggerTests {
 
 		List<String> jsonLogRecords = Arrays.asList(new String(logOutput.toByteArray()).split("\n"));
 
-		List<String> logSeverities = jsonLogRecords.stream()
-				.map(record -> GSON.fromJson(record, Map.class))
-				.map(data -> (String) data.get(StackdriverTraceConstants.SEVERITY_ATTRIBUTE))
-				.collect(Collectors.toList());
+		List<String> logSeverities =
+				jsonLogRecords.stream()
+						.map(record -> GSON.fromJson(record, Map.class))
+						.map(data -> (String) data.get(StackdriverTraceConstants.SEVERITY_ATTRIBUTE))
+						.collect(Collectors.toList());
 
 		assertThat(logSeverities)
 				.containsExactly("DEBUG", "DEBUG", "INFO", "WARNING", "ERROR", "ERROR");
@@ -252,7 +248,8 @@ class StackdriverJsonLayoutLoggerTests {
 				.filter(s -> s.getLevel() == Status.ERROR)
 				.map(s -> s.getThrowable().getCause())
 				.filter(t -> t instanceof IllegalArgumentException)
-				.findFirst()).isPresent();
+				.findFirst()
+		).isPresent();
 
 	}
 

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/StackdriverJsonLayoutLoggerTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/StackdriverJsonLayoutLoggerTests.java
@@ -86,7 +86,8 @@ class StackdriverJsonLayoutLoggerTests {
 				.containsEntry(JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, "test")
 				.containsEntry(StackdriverTraceConstants.SEVERITY_ATTRIBUTE, "WARNING")
 				.containsEntry(StackdriverJsonLayout.LOGGER_ATTR_NAME, "StackdriverJsonLayoutLoggerTests")
-				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE, "projects/test-project/traces/12345678901234561234567890123456")
+				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE,
+						"projects/test-project/traces/12345678901234561234567890123456")
 				.containsEntry(StackdriverTraceConstants.SPAN_ID_ATTRIBUTE, "span123")
 				.containsKey(StackdriverTraceConstants.TIMESTAMP_SECONDS_ATTRIBUTE)
 				.containsKey(StackdriverTraceConstants.TIMESTAMP_NANOS_ATTRIBUTE)
@@ -107,8 +108,10 @@ class StackdriverJsonLayoutLoggerTests {
 				.isNotNull()
 				.containsEntry(JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, "test")
 				.containsEntry(StackdriverTraceConstants.SEVERITY_ATTRIBUTE, "WARNING")
-				.containsEntry(StackdriverJsonLayout.LOGGER_ATTR_NAME, "StackdriverJsonLayoutServiceCtxLoggerTests")
-				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE, "projects/test-project/traces/12345678901234561234567890123456")
+				.containsEntry(StackdriverJsonLayout.LOGGER_ATTR_NAME,
+						"StackdriverJsonLayoutServiceCtxLoggerTests")
+				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE,
+						"projects/test-project/traces/12345678901234561234567890123456")
 				.containsEntry(StackdriverTraceConstants.SPAN_ID_ATTRIBUTE, "span123")
 				.containsEntry("foo", "bar")
 				.containsEntry("custom-key", "custom-value")
@@ -153,7 +156,8 @@ class StackdriverJsonLayoutLoggerTests {
 	}
 
 	@Test
-	void testCustomMDCFieldForTraceIdAndSpanId() {
+	void testCustomMdcFieldForTraceIdAndSpanId() {
+
 		Logger logger = LoggerFactory.getLogger("StackdriverJsonLayoutCustomMDCFieldTests");
 
 		mdc.remove(StackdriverTraceConstants.MDC_FIELD_TRACE_ID);
@@ -169,8 +173,10 @@ class StackdriverJsonLayoutLoggerTests {
 				.containsEntry("foo", "bar")
 				.containsEntry(JsonLayout.FORMATTED_MESSAGE_ATTR_NAME, "test")
 				.containsEntry(StackdriverTraceConstants.SEVERITY_ATTRIBUTE, "WARNING")
-				.containsEntry(StackdriverJsonLayout.LOGGER_ATTR_NAME, "StackdriverJsonLayoutCustomMDCFieldTests")
-				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE, "projects/test-project/traces/12345678901234561234567890123456")
+				.containsEntry(StackdriverJsonLayout.LOGGER_ATTR_NAME,
+						"StackdriverJsonLayoutCustomMDCFieldTests")
+				.containsEntry(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE,
+						"projects/test-project/traces/12345678901234561234567890123456")
 				.containsEntry(StackdriverTraceConstants.SPAN_ID_ATTRIBUTE, "span123")
 				.containsKey(StackdriverTraceConstants.TIMESTAMP_SECONDS_ATTRIBUTE)
 				.containsKey(StackdriverTraceConstants.TIMESTAMP_NANOS_ATTRIBUTE)
@@ -229,11 +235,10 @@ class StackdriverJsonLayoutLoggerTests {
 
 		List<String> jsonLogRecords = Arrays.asList(new String(logOutput.toByteArray()).split("\n"));
 
-		List<String> logSeverities =
-				jsonLogRecords.stream()
-						.map(record -> GSON.fromJson(record, Map.class))
-						.map(data -> (String) data.get(StackdriverTraceConstants.SEVERITY_ATTRIBUTE))
-						.collect(Collectors.toList());
+		List<String> logSeverities = jsonLogRecords.stream()
+				.map(record -> GSON.fromJson(record, Map.class))
+				.map(data -> (String) data.get(StackdriverTraceConstants.SEVERITY_ATTRIBUTE))
+				.collect(Collectors.toList());
 
 		assertThat(logSeverities)
 				.containsExactly("DEBUG", "DEBUG", "INFO", "WARNING", "ERROR", "ERROR");
@@ -247,8 +252,7 @@ class StackdriverJsonLayoutLoggerTests {
 				.filter(s -> s.getLevel() == Status.ERROR)
 				.map(s -> s.getThrowable().getCause())
 				.filter(t -> t instanceof IllegalArgumentException)
-				.findFirst()
-		).isPresent();
+				.findFirst()).isPresent();
 
 	}
 

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/TraceIdLoggingWebMvcInterceptorTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/TraceIdLoggingWebMvcInterceptorTests.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spring.logging;
 
-import com.google.cloud.spring.logging.extractors.XCloudTraceIdExtractor;
+import com.google.cloud.spring.logging.extractors.CloudTraceIdExtractor;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -35,8 +35,8 @@ class TraceIdLoggingWebMvcInterceptorTests {
 
 	private static final String TRACE_ID_HEADER = "X-CLOUD-TRACE-CONTEXT";
 
-	private TraceIdLoggingWebMvcInterceptor interceptor = new TraceIdLoggingWebMvcInterceptor(
-			new XCloudTraceIdExtractor());
+	private TraceIdLoggingWebMvcInterceptor interceptor =
+			new TraceIdLoggingWebMvcInterceptor(new CloudTraceIdExtractor());
 
 	@Test
 	void testPreHandle() throws Exception {

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/TraceIdLoggingWebMvcInterceptorTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/TraceIdLoggingWebMvcInterceptorTests.java
@@ -35,8 +35,8 @@ class TraceIdLoggingWebMvcInterceptorTests {
 
 	private static final String TRACE_ID_HEADER = "X-CLOUD-TRACE-CONTEXT";
 
-	private TraceIdLoggingWebMvcInterceptor interceptor =
-			new TraceIdLoggingWebMvcInterceptor(new CloudTraceIdExtractor());
+	private TraceIdLoggingWebMvcInterceptor interceptor = new TraceIdLoggingWebMvcInterceptor(
+			new CloudTraceIdExtractor());
 
 	@Test
 	void testPreHandle() throws Exception {

--- a/spring-cloud-gcp-logging/src/test/resources/logback-test.xml
+++ b/spring-cloud-gcp-logging/src/test/resources/logback-test.xml
@@ -48,8 +48,8 @@
 		<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
 			<layout class="com.google.cloud.spring.logging.StackdriverJsonLayout">
 				<projectId>${projectId}</projectId>
-				<traceIdMDCField>trace_id</traceIdMDCField>
-				<spanIdMDCField>span_id</spanIdMDCField>
+				<traceIdMdcField>trace_id</traceIdMdcField>
+				<spanIdMdcField>span_id</spanIdMdcField>
 			</layout>
 		</encoder>
 	</appender>


### PR DESCRIPTION
In preparation for switching from Spring to Google checkstyle, several breaking changes are needed. These will not be backported to 2.x.

### Breaking changes:
- Renamed XCloudTraceIdExtractor to CloudTraceIdExtractor
- Renamed methods in StackdriverJsonLayout (users will have to update `traceIdMDCField` and `spanIdMDCField` in custom layouts to `traceIdMdcField` and `spanIdMdcField` respectively.)
  - getTraceIdMDCField -> getTraceIdMdcField
  - setTraceIdMDCField -> setTraceIdMdcField
  - getSpanIdMDCField -> getSpanIdMdcField
  - setSpanIdMDCField -> setSpanIdMdcField. 