### PR TITLE
Fix outdated link to spring-security in documentation.

### DIFF
--- a/docs/src/main/asciidoc/security-iap.adoc
+++ b/docs/src/main/asciidoc/security-iap.adoc
@@ -1,4 +1,4 @@
-:spring-security-ref: https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/
+:spring-security-ref: https://docs.spring.io/spring-security/reference/
 :spring-security-javadoc: https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/
 
 [#cloud-iap]
@@ -6,7 +6,7 @@
 
 https://cloud.google.com/iap/[Cloud Identity-Aware Proxy (IAP)] provides a security layer over applications deployed to Google Cloud.
 
-The IAP starter uses {spring-security-ref}#oauth2resourceserver[Spring Security OAuth 2.0 Resource Server] functionality to automatically extract user identity from the proxy-injected `x-goog-iap-jwt-assertion` HTTP header.
+The IAP starter uses {spring-security-ref}servlet/oauth2/resource-server/index.html[Spring Security OAuth 2.0 Resource Server] functionality to automatically extract user identity from the proxy-injected `x-goog-iap-jwt-assertion` HTTP header.
 
 The following claims are validated automatically:
 


### PR DESCRIPTION
Update link to [Spring Security OAuth 2.0 Resource Server](https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/index.html) mentioned in Cloud-IAP documentation.