### PR TITLE
Close Spanner health check ResultSet to prevent session leak

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/health/SpannerHealthIndicator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/health/SpannerHealthIndicator.java
@@ -52,10 +52,10 @@ public class SpannerHealthIndicator extends AbstractHealthIndicator {
 
   @Override
   protected void doHealthCheck(Builder builder) throws Exception {
-    ResultSet resultSet = spannerTemplate.executeQuery(validationStatement, null);
-    // Touch the record
-    resultSet.next();
-    resultSet.close();
+    try (ResultSet resultSet = spannerTemplate.executeQuery(validationStatement, null)) {
+      // Touch the record
+      resultSet.next();
+    }
 
     builder.up();
   }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/health/SpannerHealthIndicator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/health/SpannerHealthIndicator.java
@@ -55,6 +55,8 @@ public class SpannerHealthIndicator extends AbstractHealthIndicator {
     ResultSet resultSet = spannerTemplate.executeQuery(validationStatement, null);
     // Touch the record
     resultSet.next();
+    resultSet.close();
+
     builder.up();
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/health/SpannerHealthIndicatorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/health/SpannerHealthIndicatorTests.java
@@ -79,6 +79,8 @@ class SpannerHealthIndicatorTests {
     assertThatThrownBy(() -> spannerHealthIndicator.doHealthCheck(builder))
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Cloud Spanner is down!!!");
+
+    verify(resultSet, never()).close();
   }
 
   @Test
@@ -94,6 +96,7 @@ class SpannerHealthIndicatorTests {
     assertThatThrownBy(() -> spannerHealthIndicator.doHealthCheck(builder))
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Cloud Spanner is down!!!");
+    verify(resultSet).close();
   }
 
   @Test
@@ -107,6 +110,7 @@ class SpannerHealthIndicatorTests {
     assertThat(spannerHealthIndicator.health().getStatus()).isSameAs(Status.UP);
     verify(spannerTemplate).executeQuery(Statement.of(QUERY), null);
     verify(resultSet).next();
+    verify(resultSet).close();
   }
 
   @Test
@@ -134,5 +138,6 @@ class SpannerHealthIndicatorTests {
     assertThat(spannerHealthIndicator.health().getStatus()).isEqualTo(Status.DOWN);
     verify(spannerTemplate).executeQuery(Statement.of(QUERY), null);
     verify(resultSet).next();
+    verify(resultSet).close();
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/health/SpannerHealthIndicatorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/health/SpannerHealthIndicatorTests.java
@@ -39,7 +39,7 @@ import org.springframework.boot.actuate.health.Status;
  * @since 2.0.6
  */
 @ExtendWith(MockitoExtension.class)
-public class SpannerHealthIndicatorTests {
+class SpannerHealthIndicatorTests {
 
   @Mock private SpannerTemplate spannerTemplate;
 
@@ -48,7 +48,7 @@ public class SpannerHealthIndicatorTests {
   private static final String QUERY = "SELECT 2";
 
   @Test
-  public void testdoHealthCheckUp() throws Exception {
+  void testdoHealthCheckUp() throws Exception {
     SpannerHealthIndicator spannerHealthIndicator =
         new SpannerHealthIndicator(spannerTemplate, QUERY);
 
@@ -67,7 +67,7 @@ public class SpannerHealthIndicatorTests {
   }
 
   @Test
-  public void testdoHealthCheckDownSpannerTemplate() throws Exception {
+  void testdoHealthCheckDownSpannerTemplate() throws Exception {
     SpannerHealthIndicator spannerHealthIndicator =
         new SpannerHealthIndicator(spannerTemplate, QUERY);
 
@@ -82,7 +82,7 @@ public class SpannerHealthIndicatorTests {
   }
 
   @Test
-  public void testdoHealthCheckDownResultSet() throws Exception {
+  void testdoHealthCheckDownResultSet() throws Exception {
     SpannerHealthIndicator spannerHealthIndicator =
         new SpannerHealthIndicator(spannerTemplate, QUERY);
 
@@ -97,7 +97,7 @@ public class SpannerHealthIndicatorTests {
   }
 
   @Test
-  public void testHealthy() {
+  void testHealthy() {
     SpannerHealthIndicator spannerHealthIndicator =
         new SpannerHealthIndicator(spannerTemplate, QUERY);
 
@@ -110,7 +110,7 @@ public class SpannerHealthIndicatorTests {
   }
 
   @Test
-  public void testUnhealthySpannerTemplate() {
+  void testUnhealthySpannerTemplate() {
     SpannerHealthIndicator spannerHealthIndicator =
         new SpannerHealthIndicator(spannerTemplate, QUERY);
 
@@ -124,7 +124,7 @@ public class SpannerHealthIndicatorTests {
   }
 
   @Test
-  public void testUnhealthyResultSet() {
+  void testUnhealthyResultSet() {
     SpannerHealthIndicator spannerHealthIndicator =
         new SpannerHealthIndicator(spannerTemplate, QUERY);
 


### PR DESCRIPTION
Verified that the session pool stays stable after the fix using one of the Spanner samples, plus actuator dependency.

Fixes #891.