### PR TITLE
Differentiate scheduled 2.x job cache from main cache

### DIFF
--- a/.github/workflows/integrationTests-2.x.yaml
+++ b/.github/workflows/integrationTests-2.x.yaml
@@ -49,7 +49,7 @@ jobs:
         id: mvn-cache
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
+          key: ${{ runner.os }}-maven-unified-2.x-${{ steps.date.outputs.date }}
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/unitTests-2.x.yaml
+++ b/.github/workflows/unitTests-2.x.yaml
@@ -31,7 +31,7 @@ jobs:
       id: mvn-cache
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
+        key: ${{ runner.os }}-maven-unified-2.x-${{ steps.date.outputs.date }}
 
     - name: Maven go offline
       id: mvn-offline


### PR DESCRIPTION
I think one of the reasons the flakes got more frequent is that the 2.x unit/integration tests run first, and set up the older set of artifacts. Then all the new code (`main` branch and PRs off of it) has to re-download Spring Boot 2.6-related artifacts on the fly.

This PR makes 2.x unit and integration tests use different caches.

After this if, once we start backporting changes to 2.x, we notice that 2.x flakes more than `main`, it will be confirmation of this hypothesis.