### PR TITLE
Add documentation for R2DBC and simplify samples

### DIFF
--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -8,7 +8,9 @@ The Cloud SQL support is provided by Spring Cloud GCP in the form of two Spring 
 The role of the starters is to read configuration from properties and assume default settings so that user experience connecting to MySQL and PostgreSQL is as simple as possible.
 
 === JDBC Support
-Maven coordinates, using <<getting-started.adoc#bill-of-materials, Spring Cloud GCP BOM>>:
+Maven and Gradle coordinates, using <<getting-started.adoc#bill-of-materials, Spring Cloud GCP BOM>>:
+
+To use MySQL:
 
 [source,xml]
 ----
@@ -16,18 +18,28 @@ Maven coordinates, using <<getting-started.adoc#bill-of-materials, Spring Cloud 
     <groupId>com.google.cloud</groupId>
     <artifactId>spring-cloud-gcp-starter-sql-mysql</artifactId>
 </dependency>
-<dependency>
-    <groupId>com.google.cloud</groupId>
-    <artifactId>spring-cloud-gcp-starter-sql-postgresql</artifactId>
-</dependency>
 ----
-
-Gradle coordinates:
 
 [source,subs="normal"]
 ----
 dependencies {
-    implementation("com.google.cloud:spring-cloud-gcp-starter-sql-mysql")
+implementation("com.google.cloud:spring-cloud-gcp-starter-sql-mysql")
+}
+----
+
+To use PostgreSQL:
+
+[source,xml]
+----
+<dependency>
+<groupId>com.google.cloud</groupId>
+<artifactId>spring-cloud-gcp-starter-sql-postgresql</artifactId>
+</dependency>
+----
+
+[source,subs="normal"]
+----
+dependencies {
     implementation("com.google.cloud:spring-cloud-gcp-starter-sql-postgresql")
 }
 ----
@@ -36,10 +48,8 @@ dependencies {
 
 In order to use the Spring Boot Starters for Google Cloud SQL, the Google Cloud SQL API must be enabled in your GCP project.
 
-To do that, go to the https://console.cloud.google.com/apis/library[API library page] of the Google Cloud Console, search for "Cloud SQL API", click the first result and enable the API.
+To do that, go to the https://console.cloud.google.com/apis/library[API library page] of the Google Cloud Console, search for "Cloud SQL API" and enable the option that is called "Cloud SQL" .
 
-NOTE: There are several similar "Cloud SQL" results.
-You must access the "Google Cloud SQL API" one and enable the API from there.
 
 === Spring Boot Starter for Google Cloud SQL
 
@@ -82,27 +92,40 @@ You can connect to your database with as little as a database and instance names
 
 == R2DBC Support
 
-Maven coordinates, using <<getting-started.adoc#bill-of-materials, Spring Cloud GCP BOM>>:
+Maven and Gradle coordinates, using <<getting-started.adoc#bill-of-materials, Spring Cloud GCP BOM>>:
+
+To use MySQL:
 
 [source,xml]
 ----
 <dependency>
     <groupId>com.google.cloud</groupId>
-    <artifactId>spring-cloud-gcp-starter-sql-r2dbc-mysql</artifactId>
+    <artifactId>spring-cloud-gcp-starter-sql-mysql-r2dbc</artifactId>
 </dependency>
-<dependency>
-    <groupId>com.google.cloud</groupId>
-    <artifactId>spring-cloud-gcp-starter-sql-r2dbc-postgresql</artifactId>
-</dependency>
-----
 
-Gradle coordinates:
+----
 
 [source,subs="normal"]
 ----
 dependencies {
-    implementation("com.google.cloud:spring-cloud-gcp-starter-sql-r2dbc-mysql")
-    implementation("com.google.cloud:spring-cloud-gcp-starter-sql-r2dbc-postgresql")
+    implementation("com.google.cloud:spring-cloud-gcp-starter-sql-mysql-r2dbc")
+}
+----
+
+To use PostgreSQL:
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter-sql-postgres-r2dbc</artifactId>
+</dependency>
+----
+
+[source,subs="normal"]
+----
+dependencies {
+    implementation("com.google.cloud:spring-cloud-gcp-starter-sql-postgres-r2dbc")
 }
 ----
 
@@ -110,26 +133,25 @@ dependencies {
 
 In order to use the Spring Boot Starters for Google Cloud SQL, the Google Cloud SQL API must be enabled in your GCP project.
 
-To do that, go to the https://console.cloud.google.com/apis/library[API library page] of the Google Cloud Console, search for "Cloud SQL API", click the first result and enable the API.
-
-NOTE: There are several similar "Cloud SQL" results.
-You must access the "Google Cloud SQL API" one and enable the API from there.
+To do that, go to the https://console.cloud.google.com/apis/library[API library page] of the Google Cloud Console, search for "Cloud SQL API" and enable the option that is called "Cloud SQL".
 
 === Spring Boot Starter for Google Cloud SQL
 
-The Cloud SQL R2DBC starter provides a customized io.r2dbc.spi.ConnectionFactory[`ConnectionFactory`] bean for connecting to Cloud SQL with the help of the [Cloud SQL Socket Factory](https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory).
+The Cloud SQL R2DBC starter provides a customized `io.r2dbc.spi.ConnectionFactory` bean for connecting to Cloud SQL with the help of the https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory[Cloud SQL Socket Factory].
+Similar to the JDBC support, you can connect to your database with as little as a database and instance names.
+
 A higher level convenience object
 https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#r2dbc.core[`R2dbcEntityTemplate`] is also provided for operations such as querying and modifying a database.
 
 [source,java]
 ----
+@Autowired R2dbcEntityTemplate template;
+
 public Flux<String> listUsers() {
   return template.select(User.class).all().map(user -> user.toString());
 }
 ----
 
-You can rely on
-https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-connect-to-production-database[Spring Boot data source auto-configuration] to configure a `ConnectionFactory` bean.
 Standard R2DBC properties like the SQL username, `spring.r2dbc.username`, and password, `spring.r2dbc.password` can be used.
 There is also some configuration specific to Google Cloud SQL (see "Cloud SQL Configuration Properties" section below).
 
@@ -147,10 +169,9 @@ Spring Cloud GCP starter for Google Cloud SQL registers a `R2dbcCloudSqlEnvironm
 It also provides a default value for `spring.r2dbc.username`, which can be overridden.
 The starter also configures credentials for the R2DBC connection based on the properties below.
 
-The user properties and the properties provided by the `R2dbcCloudSqlEnvironmentPostProcessor` are then used by https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html[Spring Boot] to create the `ConnectionFactory`.
+The user properties and the properties provided by the `R2dbcCloudSqlEnvironmentPostProcessor` are then used by Spring Boot to create the `ConnectionFactory`.
 
 The customized `ConnectionFactory` is then ready to connect to Cloud SQL. The rest of Spring Data R2DBC objects built on it ( `R2dbcEntityTemplate`,  `DatabaseClient`) are automatically configured and operational, ready to interact with your SQL database.
-Similar to the JDBC support, you can connect to your database with as little as a database and instance names.
 
 == Cloud SQL IAM database authentication
 

--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -130,7 +130,7 @@ public Flux<String> listUsers() {
 
 You can rely on
 https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-connect-to-production-database[Spring Boot data source auto-configuration] to configure a `ConnectionFactory` bean.
-In other words, properties like the SQL username, `spring.r2dbc.username`, and password, `spring.r2dbc.password` can be used.
+Standard R2DBC properties like the SQL username, `spring.r2dbc.username`, and password, `spring.r2dbc.password` can be used.
 There is also some configuration specific to Google Cloud SQL (see "Cloud SQL Configuration Properties" section below).
 
 |===

--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -117,7 +117,7 @@ You must access the "Google Cloud SQL API" one and enable the API from there.
 
 === Spring Boot Starter for Google Cloud SQL
 
-The Spring Boot Starters for Google Cloud SQL provide an auto-configured https://docs.oracle.com/javaee/7/api/javax/jms/ConnectionFactory.html[`ConnectionFactory`] bean.
+The Cloud SQL R2DBC starter provides a customized io.r2dbc.spi.ConnectionFactory[`ConnectionFactory`] bean for connecting to Cloud SQL with the help of the [Cloud SQL Socket Factory](https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory).
 Coupled with Spring R2DBC it produces a
 https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#r2dbc.core[`R2dbcEntityTemplate`] object bean that allows for operations such as querying and modifying a database.
 

--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -2,7 +2,7 @@
 == Cloud SQL
 
 Spring Cloud GCP adds integrations with
-https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html[Spring JDBC] and https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#r2dbc.core[Spring R2DBC]  so you can run your MySQL or PostgreSQL databases in https://cloud.google.com/sql[Google Cloud SQL] using Spring JDBC and other libraries that depend on it like Spring Data JPA or Spring R2DBC.
+https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html[Spring JDBC] and https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#r2dbc.core[Spring R2DBC]  so you can run your MySQL or PostgreSQL databases in https://cloud.google.com/sql[Google Cloud SQL] using Spring JDBC and other libraries that depend on it like Spring Data JPA or Spring Data R2DBC.
 
 The Cloud SQL support is provided by Spring Cloud GCP in the form of two Spring Boot starters, one for MySQL and another one for PostgreSQL.
 The role of the starters is to read configuration from properties and assume default settings so that user experience connecting to MySQL and PostgreSQL is as simple as possible.

--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -149,7 +149,7 @@ The starter also configures credentials for the R2DBC connection based on the pr
 
 The user properties and the properties provided by the `R2dbcCloudSqlEnvironmentPostProcessor` are then used by https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html[Spring Boot] to create the `ConnectionFactory`.
 
-Using the created `ConnectionFactory` in conjunction with Spring R2DBC provides you with a fully configured and operational `R2dbcEntityTemplate` object that you can use to interact with your SQL database.
+The customized `ConnectionFactory` is then ready to connect to Cloud SQL. The rest of Spring Data R2DBC objects built on it ( `R2dbcEntityTemplate`,  `DatabaseClient`) are automatically configured and operational, ready to interact with your SQL database.
 Similar to the JDBC support, you can connect to your database with as little as a database and instance names.
 
 == Cloud SQL IAM database authentication

--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -143,7 +143,7 @@ NOTE: If you provide your own `spring.r2dbc.url`, it will be ignored, unless you
 
 ==== `ConnectionFactory` creation flow
 
-Spring Boot starter for Google Cloud SQL registers a `R2dbcCloudSqlEnvironmentPostProcessor` that provides a correctly formatted `spring.r2dbc.url` property to the environment based on the properties mentioned above.
+Spring Cloud GCP starter for Google Cloud SQL registers a `R2dbcCloudSqlEnvironmentPostProcessor` that provides a correctly formatted `spring.r2dbc.url` property to the environment based on the properties mentioned above.
 It also provides a default value for `spring.r2dbc.username`, which can be overridden.
 The starter also configures credentials for the R2DBC connection based on the properties below.
 

--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -119,7 +119,7 @@ You must access the "Google Cloud SQL API" one and enable the API from there.
 
 The Cloud SQL R2DBC starter provides a customized io.r2dbc.spi.ConnectionFactory[`ConnectionFactory`] bean for connecting to Cloud SQL with the help of the [Cloud SQL Socket Factory](https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory).
 A higher level convenience object
-https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#r2dbc.core[`R2dbcEntityTemplate`] object bean that allows for operations such as querying and modifying a database.
+https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#r2dbc.core[`R2dbcEntityTemplate`] is also provided for operations such as querying and modifying a database.
 
 [source,java]
 ----

--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -2,11 +2,12 @@
 == Cloud SQL
 
 Spring Cloud GCP adds integrations with
-https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html[Spring JDBC] so you can run your MySQL or PostgreSQL databases in https://cloud.google.com/sql[Google Cloud SQL] using Spring JDBC, or other libraries that depend on it like Spring Data JPA.
+https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html[Spring JDBC] and https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#r2dbc.core[Spring R2DBC]  so you can run your MySQL or PostgreSQL databases in https://cloud.google.com/sql[Google Cloud SQL] using Spring JDBC and other libraries that depend on it like Spring Data JPA or Spring R2DBC.
 
 The Cloud SQL support is provided by Spring Cloud GCP in the form of two Spring Boot starters, one for MySQL and another one for PostgreSQL.
 The role of the starters is to read configuration from properties and assume default settings so that user experience connecting to MySQL and PostgreSQL is as simple as possible.
 
+=== JDBC Support
 Maven coordinates, using <<getting-started.adoc#bill-of-materials, Spring Cloud GCP BOM>>:
 
 [source,xml]
@@ -30,7 +31,6 @@ dependencies {
     implementation("com.google.cloud:spring-cloud-gcp-starter-sql-postgresql")
 }
 ----
-
 
 === Prerequisites
 
@@ -57,22 +57,10 @@ public List<Map<String, Object>> listUsers() {
 You can rely on
 https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-connect-to-production-database[Spring Boot data source auto-configuration] to configure a `DataSource` bean.
 In other words, properties like the SQL username, `spring.datasource.username`, and password, `spring.datasource.password` can be used.
-There is also some configuration specific to Google Cloud SQL:
+There is also some configuration specific to Google Cloud SQL (see "Cloud SQL Configuration Properties" section below).
 
 |===
 | Property name | Description | Required | Default value
-| `spring.cloud.gcp.sql.enabled` | Enables or disables Cloud SQL auto configuration | No | `true`
-| `spring.cloud.gcp.sql.database-name` | Name of the database to connect to. | Yes |
-| `spring.cloud.gcp.sql.instance-connection-name` | A string containing a Google Cloud SQL instance's project ID, region and name, each separated by a colon. | Yes |
-For example, `my-project-id:my-region:my-instance-name`.
-| `spring.cloud.gcp.sql.ip-types` | Allows you to specify a comma delimited list of preferred IP types for connecting to a Cloud SQL instance. Left unconfigured Cloud SQL Socket Factory will default it to `PUBLIC,PRIVATE`. See https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory#specifying-ip-types[Cloud SQL Socket Factory - Specifying IP Types] | No | `PUBLIC,PRIVATE`
-| `spring.cloud.gcp.sql.credentials.location` | File system path to the Google OAuth2 credentials private key file.
-Used to authenticate and authorize new connections to a Google Cloud SQL instance. | No
-| Default credentials provided by the Spring GCP Boot starter
-| `spring.cloud.gcp.sql.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key in JSON format.
-Used to authenticate and authorize new connections to a Google Cloud SQL instance. | No
-| Default credentials provided by the Spring GCP Boot starter
-| `spring.cloud.gcp.sql.enableIamAuth` | Specifies whether to enable IAM database authentication (PostgreSQL only). | No | `False`
 | `spring.datasource.username` | Database username | No | MySQL: `root`; PostgreSQL: `postgres`
 | `spring.datasource.password` | Database password | No | `null`
 | `spring.datasource.driver-class-name` | JDBC driver to use. | No | MySQL: `com.mysql.cj.jdbc.Driver`; PostgreSQL: `org.postgresql.Driver`
@@ -82,9 +70,9 @@ NOTE: If you provide your own `spring.datasource.url`, it will be ignored, unles
 
 ==== `DataSource` creation flow
 
-Spring Boot starter for Google Cloud SQL registers a `CloudSqlEnvironmentPostProcessor` that provides a correctly formatted `spring.datasource.url` property to the environment based on the properties defined above.
+Spring Boot starter for Google Cloud SQL registers a `CloudSqlEnvironmentPostProcessor` that provides a correctly formatted `spring.datasource.url` property to the environment based on the properties mentioned above.
 It also provides defaults for `spring.datasource.username` and `spring.datasource.driver-class-name`, which can be overridden.
-The starter also configures credentials for the JDBC connection based on the properties above.
+The starter also configures credentials for the JDBC connection based on the properties below.
 
 The user properties and the properties provided by the `CloudSqlEnvironmentPostProcessor` are then used by https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html[Spring Boot] to create the `DataSource`.
 You can select the type of connection pool (e.g., Tomcat, HikariCP, etc.) by https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-connect-to-production-database[adding their dependency to the classpath].
@@ -92,7 +80,79 @@ You can select the type of connection pool (e.g., Tomcat, HikariCP, etc.) by htt
 Using the created `DataSource` in conjunction with Spring JDBC provides you with a fully configured and operational `JdbcTemplate` object that you can use to interact with your SQL database.
 You can connect to your database with as little as a database and instance names.
 
-==== Cloud SQL IAM database authentication
+== R2DBC Support
+
+Maven coordinates, using <<getting-started.adoc#bill-of-materials, Spring Cloud GCP BOM>>:
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter-sql-r2dbc-mysql</artifactId>
+</dependency>
+<dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>spring-cloud-gcp-starter-sql-r2dbc-postgresql</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+[source,subs="normal"]
+----
+dependencies {
+    implementation("com.google.cloud:spring-cloud-gcp-starter-sql-r2dbc-mysql")
+    implementation("com.google.cloud:spring-cloud-gcp-starter-sql-r2dbc-postgresql")
+}
+----
+
+=== Prerequisites
+
+In order to use the Spring Boot Starters for Google Cloud SQL, the Google Cloud SQL API must be enabled in your GCP project.
+
+To do that, go to the https://console.cloud.google.com/apis/library[API library page] of the Google Cloud Console, search for "Cloud SQL API", click the first result and enable the API.
+
+NOTE: There are several similar "Cloud SQL" results.
+You must access the "Google Cloud SQL API" one and enable the API from there.
+
+=== Spring Boot Starter for Google Cloud SQL
+
+The Spring Boot Starters for Google Cloud SQL provide an auto-configured https://docs.oracle.com/javaee/7/api/javax/jms/ConnectionFactory.html[`ConnectionFactory`] bean.
+Coupled with Spring R2DBC it produces a
+https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#r2dbc.core[`R2dbcEntityTemplate`] object bean that allows for operations such as querying and modifying a database.
+
+[source,java]
+----
+public Flux<String> listUsers() {
+  return template.select(User.class).all().map(user -> user.toString());
+}
+----
+
+You can rely on
+https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-connect-to-production-database[Spring Boot data source auto-configuration] to configure a `ConnectionFactory` bean.
+In other words, properties like the SQL username, `spring.r2dbc.username`, and password, `spring.r2dbc.password` can be used.
+There is also some configuration specific to Google Cloud SQL (see "Cloud SQL Configuration Properties" section below).
+
+|===
+| Property name | Description | Required | Default value
+| `spring.r2dbc.username` | Database username | No | MySQL: `root`; PostgreSQL: `postgres`
+| `spring.r2dbc.password` | Database password | No | `null`
+|===
+
+NOTE: If you provide your own `spring.r2dbc.url`, it will be ignored, unless you disable Cloud SQL auto-configuration for R2DBC with `spring.cloud.gcp.sql.enabled=false` or `spring.cloud.gcp.sql.r2dbc.enabled=false` .
+
+==== `ConnectionFactory` creation flow
+
+Spring Boot starter for Google Cloud SQL registers a `R2dbcCloudSqlEnvironmentPostProcessor` that provides a correctly formatted `spring.r2dbc.url` property to the environment based on the properties mentioned above.
+It also provides a default value for `spring.r2dbc.username`, which can be overridden.
+The starter also configures credentials for the R2DBC connection based on the properties below.
+
+The user properties and the properties provided by the `R2dbcCloudSqlEnvironmentPostProcessor` are then used by https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html[Spring Boot] to create the `ConnectionFactory`.
+
+Using the created `ConnectionFactory` in conjunction with Spring R2DBC provides you with a fully configured and operational `R2dbcEntityTemplate` object that you can use to interact with your SQL database.
+Similar to the JDBC support, you can connect to your database with as little as a database and instance names.
+
+== Cloud SQL IAM database authentication
 
 Currently, Cloud SQL only supports https://cloud.google.com/sql/docs/postgres/authentication:[IAM database authentication for PostgreSQL].
 It allows you to connect to the database using an IAM account, rather than a predefined database username and password.
@@ -104,7 +164,27 @@ You will need to do the following to enable it:
 (Note that this will also set the database protocol `sslmode` to `disabled`, as it's required for IAM authentication to work.
 However, it doesn't compromise the security of the communication because the connection is always encrypted.)
 
-==== Troubleshooting tips
+== Cloud SQL Configuration Properties
+
+|===
+| Property name | Description | Required | Default value
+| `spring.cloud.gcp.sql.enabled` | Enables or disables Cloud SQL auto configuration | No | `true`
+| `spring.cloud.gcp.sql.jdbc.enabled` | Enables or disables Cloud SQL auto-configuration for JDBC | No | `true`
+| `spring.cloud.gcp.sql.r2dbc.enabled` | Enables or disables Cloud SQL auto-configuration for R2DBC | No | `true`
+| `spring.cloud.gcp.sql.database-name` | Name of the database to connect to. | Yes |
+| `spring.cloud.gcp.sql.instance-connection-name` | A string containing a Google Cloud SQL instance's project ID, region and name, each separated by a colon. | Yes |
+For example, `my-project-id:my-region:my-instance-name`.
+| `spring.cloud.gcp.sql.ip-types` | Allows you to specify a comma delimited list of preferred IP types for connecting to a Cloud SQL instance. Left unconfigured Cloud SQL Socket Factory will default it to `PUBLIC,PRIVATE`. See https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory#specifying-ip-types[Cloud SQL Socket Factory - Specifying IP Types] | No | `PUBLIC,PRIVATE`
+| `spring.cloud.gcp.sql.credentials.location` | File system path to the Google OAuth2 credentials private key file.
+Used to authenticate and authorize new connections to a Google Cloud SQL instance. | No
+| Default credentials provided by the Spring GCP Boot starter
+| `spring.cloud.gcp.sql.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key in JSON format.
+Used to authenticate and authorize new connections to a Google Cloud SQL instance. | No
+| Default credentials provided by the Spring GCP Boot starter
+| `spring.cloud.gcp.sql.enableIamAuth` | Specifies whether to enable IAM database authentication (PostgreSQL only). | No | `False`
+|===
+
+== Troubleshooting tips
 
 [#connection-issues]
 ===== Connection issues
@@ -146,7 +226,7 @@ For example, in Maven:
 ----
 
 
-=== Samples
+== Samples
 
 Available sample applications and codelabs:
 
@@ -154,3 +234,5 @@ Available sample applications and codelabs:
 - https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample[Spring Cloud GCP PostgreSQL]
 - https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample[Spring Data JPA with Spring Cloud GCP SQL]
 - Codelab: https://codelabs.developers.google.com/codelabs/cloud-spring-petclinic-cloudsql/index.html[Spring Pet Clinic using Cloud SQL]
+- https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-r2dbc-sample[R2DBC: Spring Cloud GCP MySQL]
+- https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-r2dbc-sample[R2DBC: Spring Cloud GCP PostgreSQL]

--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -118,7 +118,7 @@ You must access the "Google Cloud SQL API" one and enable the API from there.
 === Spring Boot Starter for Google Cloud SQL
 
 The Cloud SQL R2DBC starter provides a customized io.r2dbc.spi.ConnectionFactory[`ConnectionFactory`] bean for connecting to Cloud SQL with the help of the [Cloud SQL Socket Factory](https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory).
-Coupled with Spring R2DBC it produces a
+A higher level convenience object
 https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#r2dbc.core[`R2dbcEntityTemplate`] object bean that allows for operations such as querying and modifying a database.
 
 [source,java]

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -85,6 +85,12 @@
       "defaultValue": true
     },
     {
+      "name": "spring.cloud.gcp.sql.r2dbc.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enables auto-configuration for R2DBC support in Google Cloud SQL.",
+      "defaultValue": true
+    },
+    {
       "name": "spring.cloud.gcp.secretmanager.enabled",
       "type": "java.lang.Boolean",
       "description": "Auto-configure GCP Secret Manager support components.",

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-r2dbc-sample/src/main/java/com/example/User.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-r2dbc-sample/src/main/java/com/example/User.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("users")
+public class User {
+
+  private String email;
+  private String firstName;
+  private String lastName;
+
+  public User(String email, String firstName, String lastName) {
+    this.email = email;
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  @Override
+  public String toString() {
+    return "[" + email + ", " + firstName + ", " + lastName + "]";
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-r2dbc-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-r2dbc-sample/src/main/java/com/example/WebController.java
@@ -16,11 +16,10 @@
 
 package com.example;
 
-import io.r2dbc.spi.ConnectionFactory;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 /**
  * Web app controller class for sample application. Contains a function that runs a query and
@@ -29,24 +28,14 @@ import reactor.core.publisher.Mono;
 @RestController
 public class WebController {
 
-  private final ConnectionFactory connectionFactory;
+  private final R2dbcEntityTemplate template;
 
-  public WebController(ConnectionFactory connectionFactory) {
-    this.connectionFactory = connectionFactory;
+  public WebController(R2dbcEntityTemplate template) {
+    this.template = template;
   }
 
   @GetMapping("/getTuples")
   public Flux<String> getTuples() {
-    return Mono.from(connectionFactory.create())
-        .flatMapMany(connection -> connection.createStatement("SELECT * FROM users").execute())
-        .flatMap(
-            result ->
-                result.map(
-                    (row, metadata) ->
-                        String.format(
-                            "[%s, %s, %s]",
-                            row.get("EMAIL", String.class),
-                            row.get("FIRST_NAME", String.class),
-                            row.get("LAST_NAME", String.class))));
+    return template.select(User.class).all().map(user -> user.toString());
   }
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-r2dbc-sample/src/main/java/com/example/User.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-r2dbc-sample/src/main/java/com/example/User.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("users")
+public class User {
+
+  private String email;
+  private String firstName;
+  private String lastName;
+
+  public User(String email, String firstName, String lastName) {
+    this.email = email;
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  @Override
+  public String toString() {
+    return "[" + email + ", " + firstName + ", " + lastName + "]";
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-r2dbc-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-r2dbc-sample/src/main/java/com/example/WebController.java
@@ -16,11 +16,10 @@
 
 package com.example;
 
-import io.r2dbc.spi.ConnectionFactory;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 /**
  * Web app controller class for sample application. Contains a function that runs a query and
@@ -29,24 +28,14 @@ import reactor.core.publisher.Mono;
 @RestController
 public class WebController {
 
-  private final ConnectionFactory connectionFactory;
+  private final R2dbcEntityTemplate template;
 
-  public WebController(ConnectionFactory connectionFactory) {
-    this.connectionFactory = connectionFactory;
+  public WebController(R2dbcEntityTemplate template) {
+    this.template = template;
   }
 
   @GetMapping("/getTuples")
   public Flux<String> getTuples() {
-    return Mono.from(connectionFactory.create())
-        .flatMapMany(connection -> connection.createStatement("SELECT * FROM users").execute())
-        .flatMap(
-            result ->
-                result.map(
-                    (row, metadata) ->
-                        String.format(
-                            "[%s, %s, %s]",
-                            row.get("EMAIL", String.class),
-                            row.get("FIRST_NAME", String.class),
-                            row.get("LAST_NAME", String.class))));
+    return template.select(User.class).all().map(user -> user.toString());
   }
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-r2dbc-sample/src/test/java/com/example/SqlR2dbcPostgresSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-r2dbc-sample/src/test/java/com/example/SqlR2dbcPostgresSampleApplicationIntegrationTests.java
@@ -28,25 +28,29 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 
-/** Simple integration test to verify the SQL sample application with Postgres. */
+/**
+ * Simple integration test to verify the SQL sample application with Postgres.
+ */
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
     classes = {SqlApplication.class},
     properties = {
-      "spring.cloud.gcp.sql.databaseName=code_samples_test_r2dbc_db",
-      "spring.cloud.gcp.sql.instanceConnectionName=spring-cloud-gcp-ci:us-central1:testpostgres",
-      "spring.r2dbc.password=test"
+        "spring.cloud.gcp.sql.databaseName=code_samples_test_r2dbc_db",
+        "spring.cloud.gcp.sql.instanceConnectionName=spring-cloud-gcp-ci:us-central1:testpostgres",
+        "spring.r2dbc.password=test"
     })
 @EnabledIfSystemProperty(named = "it.cloudsql", matches = "true")
 public class SqlR2dbcPostgresSampleApplicationIntegrationTests {
 
-  @Autowired private TestRestTemplate testRestTemplate;
+  @Autowired
+  private TestRestTemplate testRestTemplate;
 
   @Test
   void testSqlRowsAccess() {
     ResponseEntity<String> result =
         this.testRestTemplate.exchange(
-            "/getTuples", HttpMethod.GET, null, new ParameterizedTypeReference<String>() {});
+            "/getTuples", HttpMethod.GET, null, new ParameterizedTypeReference<String>() {
+            });
 
     assertThat(result.getBody())
         .isEqualTo(

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-r2dbc-sample/src/test/java/com/example/SqlR2dbcPostgresSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-r2dbc-sample/src/test/java/com/example/SqlR2dbcPostgresSampleApplicationIntegrationTests.java
@@ -28,29 +28,25 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 
-/**
- * Simple integration test to verify the SQL sample application with Postgres.
- */
+/** Simple integration test to verify the SQL sample application with Postgres. */
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
     classes = {SqlApplication.class},
     properties = {
-        "spring.cloud.gcp.sql.databaseName=code_samples_test_r2dbc_db",
-        "spring.cloud.gcp.sql.instanceConnectionName=spring-cloud-gcp-ci:us-central1:testpostgres",
-        "spring.r2dbc.password=test"
+      "spring.cloud.gcp.sql.databaseName=code_samples_test_r2dbc_db",
+      "spring.cloud.gcp.sql.instanceConnectionName=spring-cloud-gcp-ci:us-central1:testpostgres",
+      "spring.r2dbc.password=test"
     })
 @EnabledIfSystemProperty(named = "it.cloudsql", matches = "true")
 public class SqlR2dbcPostgresSampleApplicationIntegrationTests {
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
   @Test
   void testSqlRowsAccess() {
     ResponseEntity<String> result =
         this.testRestTemplate.exchange(
-            "/getTuples", HttpMethod.GET, null, new ParameterizedTypeReference<String>() {
-            });
+            "/getTuples", HttpMethod.GET, null, new ParameterizedTypeReference<String>() {});
 
     assertThat(result.getBody())
         .isEqualTo(


### PR DESCRIPTION
This PR also modifies the samples to use `R2dbcEntityTemplate` to query databases instead of using `ConnectionFactory` directly. 

Fixes #904