### PR TITLE
Remove Spring Milestones/Snapshots repositories

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
--P spring

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -25,14 +25,6 @@
 
 	<repositories>
 		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
 			<id>spring-releases</id>
 			<name>Spring Releases</name>
 			<url>https://repo.spring.io/release</url>
@@ -42,14 +34,6 @@
 		</repository>
 	</repositories>
 	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
 		<pluginRepository>
 			<id>spring-releases</id>
 			<name>Spring Releases</name>

--- a/pom.xml
+++ b/pom.xml
@@ -338,14 +338,6 @@
 			<id>spring</id>
 			<repositories>
 				<repository>
-					<id>spring-milestones</id>
-					<name>Spring Milestones</name>
-					<url>https://repo.spring.io/milestone</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
-				<repository>
 					<id>spring-releases</id>
 					<name>Spring Releases</name>
 					<url>https://repo.spring.io/release</url>
@@ -366,14 +358,6 @@
 				</repository>
 			</repositories>
 			<pluginRepositories>
-				<pluginRepository>
-					<id>spring-milestones</id>
-					<name>Spring Milestones</name>
-					<url>https://repo.spring.io/milestone</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</pluginRepository>
 				<pluginRepository>
 					<id>spring-releases</id>
 					<name>Spring Releases</name>

--- a/pom.xml
+++ b/pom.xml
@@ -334,51 +334,6 @@
 			</modules>
 		</profile>
 
-		<profile>
-			<id>spring</id>
-			<repositories>
-				<repository>
-					<id>spring-releases</id>
-					<name>Spring Releases</name>
-					<url>https://repo.spring.io/release</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
-				<repository>
-					<id>gcs-mirror</id>
-					<name>GCS Maven Mirror</name>
-					<url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-					<releases>
-						<enabled>true</enabled>
-					</releases>
-				</repository>
-			</repositories>
-			<pluginRepositories>
-				<pluginRepository>
-					<id>spring-releases</id>
-					<name>Spring Releases</name>
-					<url>https://repo.spring.io/release</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</pluginRepository>
-				<pluginRepository>
-					<id>gcs-mirror</id>
-					<name>GCS Maven Mirror</name>
-					<url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-					<releases>
-						<enabled>true</enabled>
-					</releases>
-				</pluginRepository>
-			</pluginRepositories>
-		</profile>
 		<!-- Code Coverage -->
 		<profile>
 			<id>codecov</id>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -284,19 +284,6 @@
 	</dependencyManagement>
 
 	<profiles>
-		<profile>
-			<id>spring</id>
-			<repositories>
-				<repository>
-					<id>spring-releases</id>
-					<name>Spring Releases</name>
-					<url>https://repo.spring.io/release</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
-			</repositories>
-		</profile>
 
     <!--
     		Release profile must be defined here as well since spring-cloud-gcp-dependencies

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -288,25 +288,6 @@
 			<id>spring</id>
 			<repositories>
 				<repository>
-					<id>spring-snapshots</id>
-					<name>Spring Snapshots</name>
-					<url>https://repo.spring.io/snapshot</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-					<releases>
-						<enabled>false</enabled>
-					</releases>
-				</repository>
-				<repository>
-					<id>spring-milestones</id>
-					<name>Spring Milestones</name>
-					<url>https://repo.spring.io/milestone</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
-				<repository>
 					<id>spring-releases</id>
 					<name>Spring Releases</name>
 					<url>https://repo.spring.io/release</url>
@@ -315,27 +296,6 @@
 					</snapshots>
 				</repository>
 			</repositories>
-			<pluginRepositories>
-				<pluginRepository>
-					<id>spring-snapshots</id>
-					<name>Spring Snapshots</name>
-					<url>https://repo.spring.io/snapshot</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-					<releases>
-						<enabled>false</enabled>
-					</releases>
-				</pluginRepository>
-				<pluginRepository>
-					<id>spring-milestones</id>
-					<name>Spring Milestones</name>
-					<url>https://repo.spring.io/milestone</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</pluginRepository>
-			</pluginRepositories>
 		</profile>
 
     <!--

--- a/spring-cloud-gcp-native-support/pom.xml
+++ b/spring-cloud-gcp-native-support/pom.xml
@@ -37,4 +37,15 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>spring-releases</id>
+            <name>Spring Releases</name>
+            <url>https://repo.spring.io/release</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/pom.xml
@@ -190,6 +190,27 @@
           </plugin>
         </plugins>
       </build>
+      <repositories>
+        <repository>
+          <id>spring-releases</id>
+          <name>Spring Releases</name>
+          <url>https://repo.spring.io/release</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>spring-releases</id>
+          <name>Spring Releases</name>
+          <url>https://repo.spring.io/release</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
     </profile>
+
   </profiles>
 </project>


### PR DESCRIPTION
We don't rely on snapshots/milestones in the releasable branches.

This may help with the flakes -- I suspect that maven's multi-threading tries to fetch jars from Maven Central and from Spring Milestones at the same time, but milestones don't actually have the artifacts that cause issues.