### PR TITLE
Exclude `goog_` prefixed attributes from outbound Pub/Sub messages (backport)

### DIFF
--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/PubSubHeaderMapper.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/PubSubHeaderMapper.java
@@ -46,6 +46,7 @@ public class PubSubHeaderMapper implements HeaderMapper<Map<String, String>> {
     "!" + MessageHeaders.ID,
     "!" + MessageHeaders.TIMESTAMP,
     "!" + GcpPubSubHeaders.ORIGINAL_MESSAGE,
+    "!" + GcpPubSubHeaders.CLIENT,
     "!" + NativeMessageHeaderAccessor.NATIVE_HEADERS,
     "!" + MessageHistory.HEADER_NAME,
     "*"

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/GcpPubSubHeaders.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/GcpPubSubHeaders.java
@@ -28,6 +28,9 @@ public abstract class GcpPubSubHeaders {
 
   private static final String PREFIX = "gcp_pubsub_";
 
+  /** The client header text. */
+  public static final String CLIENT = "googclient_*";
+
   /** The topic header text. */
   public static final String TOPIC = PREFIX + "topic";
 
@@ -42,7 +45,7 @@ public abstract class GcpPubSubHeaders {
    * Message}.
    *
    * @param message The Spring Message that was converted by a {@link
-   *     com.google.cloud.spring.pubsub.integration.inbound.PubSubInboundChannelAdapter}.
+   * com.google.cloud.spring.pubsub.integration.inbound.PubSubInboundChannelAdapter}.
    * @return An Optional possibly containing a BasicAcknowledgeablePubsubMessage for acking and
    *     nacking.
    */

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/GcpPubSubHeaders.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/GcpPubSubHeaders.java
@@ -45,7 +45,7 @@ public abstract class GcpPubSubHeaders {
    * Message}.
    *
    * @param message The Spring Message that was converted by a {@link
-   * com.google.cloud.spring.pubsub.integration.inbound.PubSubInboundChannelAdapter}.
+   *     com.google.cloud.spring.pubsub.integration.inbound.PubSubInboundChannelAdapter}.
    * @return An Optional possibly containing a BasicAcknowledgeablePubsubMessage for acking and
    *     nacking.
    */

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/PubSubHeaderMapperTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/PubSubHeaderMapperTests.java
@@ -36,6 +36,24 @@ public class PubSubHeaderMapperTests {
   @Rule public ExpectedException expectedException = ExpectedException.none();
 
   @Test
+  public void testFilterGoogleClientHeaders() {
+    PubSubHeaderMapper mapper = new PubSubHeaderMapper();
+    Map<String, Object> originalHeaders = new HashMap<>();
+    originalHeaders.put("my header", "pantagruel's nativity");
+    MessageHeaders internalHeaders = new MessageHeaders(originalHeaders);
+
+    originalHeaders.put("googclient_deliveryattempt", "header attached when DLQ is enabled");
+    originalHeaders.put("googclient_anyHeader", "any other possible headers");
+
+    Map<String, String> filteredHeaders = new HashMap<>();
+    mapper.fromHeaders(internalHeaders, filteredHeaders);
+    assertThat(filteredHeaders)
+        .hasSize(1)
+        .containsEntry("my header", "pantagruel's nativity");
+  }
+
+
+  @Test
   public void testFilterHeaders() {
     PubSubHeaderMapper mapper = new PubSubHeaderMapper();
     Map<String, Object> originalHeaders = new HashMap<>();


### PR DESCRIPTION
Backports #845.