### PR TITLE
Spanner repository findAllById() returns empty result on empty input

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
@@ -22,6 +22,7 @@ import com.google.cloud.spring.data.spanner.core.SpannerOperations;
 import com.google.cloud.spring.data.spanner.core.SpannerPageableQueryOptions;
 import com.google.cloud.spring.data.spanner.core.SpannerTemplate;
 import com.google.cloud.spring.data.spanner.repository.SpannerRepository;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Function;
 import org.springframework.data.domain.Page;
@@ -108,10 +109,20 @@ public class SimpleSpannerRepository<T, I> implements SpannerRepository<T, I> {
 
   @Override
   public Iterable<T> findAllById(Iterable<I> ids) {
+    Assert.notNull(ids, "IDs must not be null");
+
     KeySet.Builder builder = KeySet.newBuilder();
+    int keyCount = 0;
+
     for (Object id : ids) {
       builder.addKey(toKey(id));
+      keyCount++;
     }
+
+    if (keyCount == 0) {
+      return Collections.EMPTY_LIST;
+    }
+
     return this.spannerTemplate.read(this.entityType, builder.build());
   }
 
@@ -164,6 +175,7 @@ public class SimpleSpannerRepository<T, I> implements SpannerRepository<T, I> {
 
   @Override
   public void deleteAllById(Iterable<? extends I> ids) {
+    Assert.notNull(ids, "IDs must not be null");
     KeySet.Builder builder = KeySet.newBuilder();
     for (Object id : ids) {
       builder.addKey(toKey(id));

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -227,6 +227,15 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
+  public void queryMethodsTest_deleteAllById_doesNothingOnEmptyIds() {
+    List<Trade> trades = insertTrades("trader1", "BUY", 5);
+    assertThat(this.tradeRepository.count()).isEqualTo(5);
+
+    this.tradeRepository.deleteAllById(new ArrayList<>());
+    assertThat(this.tradeRepository.count()).isEqualTo(5);
+  }
+
+  @Test
   public void queryMethodsTest_readsAndCounts() {
     List<Trade> trader1BuyTrades = insertTrades("trader1", "BUY", 3);
     List<Trade> trader1SellTrades = insertTrades("trader1", "SELL", 2);
@@ -574,6 +583,33 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
       // expected exception that causes roll-back;
     }
     assertThat(this.tradeRepository.count()).isZero();
+  }
+
+  @Test
+  public void findAllByIdReturnsOnlyRequestedRows() {
+    insertTrade("trader1", "BUY", 100);
+    Trade trade2 = insertTrade("trader2", "BUY", 101);
+    Trade trade3 = insertTrade("trader2", "SELL", 102);
+    insertTrade("trader2", "SELL", 103);
+
+
+    Iterable<Trade> foundTrades = this.tradeRepository.findAllById(
+        Arrays.asList(
+            Key.of(trade2.getTradeDetail().getId(), trade2.getTraderId()),
+            Key.of(trade3.getTradeDetail().getId(), trade3.getTraderId())
+        ));
+
+    assertThat(foundTrades).containsExactlyInAnyOrder(trade2, trade3);
+  }
+
+  @Test
+  public void findAllByIdReturnsNothingOnEmptyRequestIterable() {
+    insertTrade("trader1", "BUY", 100);
+    insertTrade("trader2", "BUY", 101);
+
+    Iterable<Trade> foundTrades = this.tradeRepository.findAllById(new ArrayList<>());
+
+    assertThat(foundTrades).isEmpty();
   }
 
   private List<Trade> insertTrades(String traderId, String action, int numTrades) {

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepositoryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepositoryTests.java
@@ -17,11 +17,13 @@
 package com.google.cloud.spring.data.spanner.repository.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.Key;
@@ -41,6 +43,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.util.Assert;
 
 /** Tests for the standard Spanner repository implementation. */
 public class SimpleSpannerRepositoryTests {
@@ -247,6 +250,25 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
+  public void findAllById_failsOnNull() {
+    SimpleSpannerRepository<Object, Key> repo =
+        new SimpleSpannerRepository<>(this.template, Object.class);
+    assertThatThrownBy(() -> repo.findAllById(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("IDs must not be null");
+    verifyNoInteractions(this.template);
+  }
+
+  @Test
+  public void findAllById_shortcutsToEmptyReturn() {
+    SimpleSpannerRepository<Object, Key> repo =
+        new SimpleSpannerRepository<>(this.template, Object.class);
+    assertThat(repo.findAllById(new ArrayList<>()))
+        .isEmpty();
+    verifyNoInteractions(this.template);
+  }
+
+  @Test
   public void countTest() {
     new SimpleSpannerRepository<Object, Key>(this.template, Object.class).count();
     verify(this.template, times(1)).count(Object.class);
@@ -273,6 +295,15 @@ public class SimpleSpannerRepositoryTests {
     verify(this.template).delete(eq(Object.class), argumentCaptor.capture());
     assertThat(argumentCaptor.getValue().getKeys())
         .containsExactlyInAnyOrder(Key.of("key2"), Key.of("key1"));
+  }
+
+  @Test
+  public void deleteAllById_failsOnNull() {
+    SimpleSpannerRepository<Object, Key> repo =
+        new SimpleSpannerRepository<>(this.template, Object.class);
+    assertThatThrownBy(() -> repo.deleteAllById(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("IDs must not be null");
   }
 
   @Test


### PR DESCRIPTION
Despite being a clear bug fix, it's a change in behavior, so we'll document it as such in the release notes.