### PR TITLE
Migrating tests to JUnit5 (GcpFirestoreEmulatorAutoConfigurationIntegrationTests, FirestoreDocumentationIntegrationTests, GcpStackdriverMetricsAutoConfigurationTest)

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfigurationIntegrationTests.java
@@ -17,19 +17,18 @@
 package com.google.cloud.spring.autoconfigure.firestore;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assume.assumeThat;
 
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 /** Tests for Firestore Emulator autoconfiguration. */
-public class GcpFirestoreEmulatorAutoConfigurationIntegrationTests {
+@EnabledIfSystemProperty(named = "it.firestore", matches = "true")
+class GcpFirestoreEmulatorAutoConfigurationIntegrationTests {
 
   ApplicationContextRunner contextRunner =
       new ApplicationContextRunner()
@@ -40,17 +39,8 @@ public class GcpFirestoreEmulatorAutoConfigurationIntegrationTests {
                   GcpFirestoreAutoConfiguration.class,
                   FirestoreTransactionManagerAutoConfiguration.class));
 
-  @BeforeClass
-  public static void checkToRun() {
-    assumeThat(
-        "Firestore emulator integration tests are disabled. "
-            + "Please use '-Dit.firestore=true' to enable them. ",
-        System.getProperty("it.firestore"),
-        is("true"));
-  }
-
   @Test
-  public void testAutoConfigurationEnabled() {
+  void testAutoConfigurationEnabled() {
     contextRunner
         .withPropertyValues(
             "spring.cloud.gcp.firestore.project-id=",
@@ -70,7 +60,7 @@ public class GcpFirestoreEmulatorAutoConfigurationIntegrationTests {
   }
 
   @Test
-  public void testAutoConfigurationDisabled() {
+  void testAutoConfigurationDisabled() {
     contextRunner.run(
         context -> {
           FirestoreOptions firestoreOptions = context.getBean(FirestoreOptions.class);
@@ -82,7 +72,7 @@ public class GcpFirestoreEmulatorAutoConfigurationIntegrationTests {
   }
 
   @Test
-  public void testThatIfProjectIdIsGivenItWillBeUsed() {
+  void testThatIfProjectIdIsGivenItWillBeUsed() {
     contextRunner
         .withPropertyValues(
             "spring.cloud.gcp.firestore.project-id=demo",

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/FirestoreDocumentationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/firestore/it/FirestoreDocumentationIntegrationTests.java
@@ -17,7 +17,6 @@
 package com.google.cloud.spring.autoconfigure.firestore.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.DocumentSnapshot;
@@ -30,15 +29,16 @@ import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 /**
  * @since 1.2
  */
-public class FirestoreDocumentationIntegrationTests {
+@EnabledIfSystemProperty(named = "it.firestore", matches = "true")
+class FirestoreDocumentationIntegrationTests {
   private final ApplicationContextRunner contextRunner =
       new ApplicationContextRunner()
           .withConfiguration(
@@ -47,13 +47,8 @@ public class FirestoreDocumentationIntegrationTests {
                   FirestoreTransactionManagerAutoConfiguration.class,
                   GcpFirestoreAutoConfiguration.class));
 
-  @BeforeClass
-  public static void enableTests() {
-    assumeThat(System.getProperty("it.firestore")).isEqualTo("true");
-  }
-
   @Test
-  public void writeDocumentFromObject() throws ExecutionException, InterruptedException {
+  void writeDocumentFromObject() throws ExecutionException, InterruptedException {
     this.contextRunner.run(
         context -> {
           Firestore firestore = context.getBean(Firestore.class);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/metrics/GcpStackdriverMetricsAutoConfigurationTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/metrics/GcpStackdriverMetricsAutoConfigurationTest.java
@@ -23,7 +23,7 @@ import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
 import io.micrometer.stackdriver.StackdriverConfig;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.stackdriver.StackdriverMetricsExportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;


### PR DESCRIPTION
Migrated the following tests to JUnit5 : 

1. GcpFirestoreEmulatorAutoConfigurationIntegrationTests.java
2. FirestoreDocumentationIntegrationTests.java
3. GcpStackdriverMetricsAutoConfigurationTest.java
