### PR TITLE
Migrating tests to JUnit5 (GcpPubSubReactiveAutoConfigurationTest, PubSubSubscriptionHealthIndicatorTests, PubSubAutoConfigurationIntegrationTests)

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubReactiveAutoConfigurationTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubReactiveAutoConfigurationTest.java
@@ -28,12 +28,12 @@ import com.google.cloud.spring.pubsub.core.subscriber.PubSubSubscriberTemplate;
 import com.google.cloud.spring.pubsub.reactive.PubSubReactiveFactory;
 import com.google.cloud.spring.pubsub.support.AcknowledgeablePubsubMessage;
 import java.util.Arrays;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -46,21 +46,21 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
-@RunWith(MockitoJUnitRunner.class)
-public class GcpPubSubReactiveAutoConfigurationTest {
+@ExtendWith(MockitoExtension.class)
+class GcpPubSubReactiveAutoConfigurationTest {
 
   @Mock PubSubSubscriberTemplate mockSubscriberTemplate;
 
   @Mock AcknowledgeablePubsubMessage mockMessage;
 
-  @Before
-  public void setUpMocks() {
+  @BeforeEach
+  void setUpMocks() {
     this.mockSubscriberTemplate = Mockito.mock(PubSubSubscriberTemplate.class);
     this.mockMessage = Mockito.mock(AcknowledgeablePubsubMessage.class);
   }
 
   @Test
-  public void reactiveFactoryAutoconfiguredByDefault() {
+  void reactiveFactoryAutoconfiguredByDefault() {
 
     ApplicationContextRunner contextRunner =
         new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(TestConfig.class));
@@ -71,7 +71,7 @@ public class GcpPubSubReactiveAutoConfigurationTest {
   }
 
   @Test
-  public void reactiveConfigDisabledWhenPubSubDisabled() {
+  void reactiveConfigDisabledWhenPubSubDisabled() {
 
     ApplicationContextRunner contextRunner =
         new ApplicationContextRunner()
@@ -85,7 +85,7 @@ public class GcpPubSubReactiveAutoConfigurationTest {
   }
 
   @Test
-  public void reactiveConfigDisabledWhenReactivePubSubDisabled() {
+  void reactiveConfigDisabledWhenReactivePubSubDisabled() {
 
     ApplicationContextRunner contextRunner =
         new ApplicationContextRunner()
@@ -99,7 +99,7 @@ public class GcpPubSubReactiveAutoConfigurationTest {
   }
 
   @Test
-  public void defaultSchedulerUsedWhenNoneProvided() {
+  void defaultSchedulerUsedWhenNoneProvided() {
     setUpThreadPrefixVerification("parallel");
 
     ApplicationContextRunner contextRunner =
@@ -111,7 +111,7 @@ public class GcpPubSubReactiveAutoConfigurationTest {
   }
 
   @Test
-  public void customSchedulerUsedWhenAvailable() {
+  void customSchedulerUsedWhenAvailable() {
 
     setUpThreadPrefixVerification("myCustomScheduler");
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubSubscriptionHealthIndicatorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubSubscriptionHealthIndicatorTests.java
@@ -27,16 +27,16 @@ import com.google.cloud.spring.pubsub.core.health.HealthTrackerRegistry;
 import com.google.cloud.spring.pubsub.core.health.HealthTrackerRegistryImpl;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import java.util.concurrent.ConcurrentHashMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
-@RunWith(MockitoJUnitRunner.class)
-public class PubSubSubscriptionHealthIndicatorTests {
+@ExtendWith(MockitoExtension.class)
+class PubSubSubscriptionHealthIndicatorTests {
 
   @Mock private MetricServiceClient metricServiceClient;
 
@@ -50,8 +50,8 @@ public class PubSubSubscriptionHealthIndicatorTests {
   private ConcurrentHashMap<ProjectSubscriptionName, HealthTracker> healthTrackers =
       new ConcurrentHashMap<>();
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeEach
+  void setUp() throws Exception {
     ExecutorProvider executorProvider = mock(ExecutorProvider.class);
     HealthTrackerRegistry trackerRegistry =
         new HealthTrackerRegistryImpl(
@@ -67,7 +67,7 @@ public class PubSubSubscriptionHealthIndicatorTests {
   }
 
   @Test
-  public void testHealthCheckFailure() throws Exception {
+  void testHealthCheckFailure() throws Exception {
     ProjectSubscriptionName goodSubscription =
         ProjectSubscriptionName.of("project", "good-subscription");
     HealthTracker goodTracker = mock(HealthTracker.class);
@@ -92,7 +92,7 @@ public class PubSubSubscriptionHealthIndicatorTests {
   }
 
   @Test
-  public void testHealthCheckSucceeded() throws Exception {
+  void testHealthCheckSucceeded() throws Exception {
     ProjectSubscriptionName key = ProjectSubscriptionName.of("project", "good-subscription");
     HealthTracker healthTracker = mock(HealthTracker.class);
     when(healthTracker.messagesOverThreshold()).thenReturn(0L);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -17,7 +17,6 @@
 package com.google.cloud.spring.autoconfigure.pubsub.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
@@ -34,14 +33,16 @@ import com.google.cloud.spring.pubsub.core.PubSubConfiguration;
 import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.threeten.bp.Duration;
 
-public class PubSubAutoConfigurationIntegrationTests {
+@EnabledIfSystemProperty(named = "it.pubsub", matches = "true")
+class PubSubAutoConfigurationIntegrationTests {
 
   private static final Log LOGGER =
       LogFactory.getLog(PubSubAutoConfigurationIntegrationTests.class);
@@ -71,14 +72,13 @@ public class PubSubAutoConfigurationIntegrationTests {
               AutoConfigurations.of(
                   GcpContextAutoConfiguration.class, GcpPubSubAutoConfiguration.class));
 
-  @BeforeClass
-  public static void enableTests() {
-    assumeThat(System.getProperty("it.pubsub")).isEqualTo("true");
+  @BeforeAll
+  static void enableTests() {
     projectIdProvider = new DefaultGcpProjectIdProvider();
   }
 
   @Test
-  public void testPull() {
+  void testPull() {
 
     this.contextRunner.run(
         context -> {
@@ -150,7 +150,7 @@ public class PubSubAutoConfigurationIntegrationTests {
   }
 
   @Test
-  public void testSubscribe() {
+  void testSubscribe() {
     this.contextRunner.run(
         context -> {
           PubSubAdmin pubSubAdmin = context.getBean(PubSubAdmin.class);


### PR DESCRIPTION
Migrated the following tests to JUnit5:

1. GcpPubSubReactiveAutoConfigurationTest.java
2. PubSubSubscriptionHealthIndicatorTests.java
3. PubSubAutoConfigurationIntegrationTests.java