### PR TITLE
Trying the trace sample in native mode

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -97,6 +97,157 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>appengine-maven-plugin</artifactId>
             </plugin>
+
+            <!-- These plugins enable building the application to a JAR *not* using Native Image -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>dependency-jars/</classpathPrefix>
+                            <mainClass>trace.TraceSampleApplication</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>
+                                ${project.build.directory}/dependency-jars/
+                            </outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>native</id>
+            <dependencies>
+                <dependency>
+                    <!-- TODO: remove this when it's no longer needed -->
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>native-image-support</artifactId>
+                    <version>0.12.8</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.google.cloud</groupId>
+                    <artifactId>spring-cloud-gcp-native-support</artifactId>
+                    <!-- spring-cloud-gcp-native-support is not part of the
+                      spring-cloud-gcp-dependencies BOM -->
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <!-- Wtihout this dependency, spring-aot-maven-plugin fails
+                    with NoClassDefFoundError: org/springframework/nativex/utils/NativeUtils
+                    -->
+                    <groupId>org.springframework.experimental</groupId>
+                    <artifactId>spring-native</artifactId>
+                    <version>0.11.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                    <version>5.8.2</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.graalvm.buildtools</groupId>
+                    <artifactId>junit-platform-native</artifactId>
+                    <version>0.9.9</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <!-- Because Spring Boot's JAR file has special directory
+                    structure with 'BOOT-INF/' we need this plugin
+                    https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/#getting-started-native-build-tools
+                    -->
+                    <plugin>
+                        <groupId>org.springframework.experimental</groupId>
+                        <artifactId>spring-aot-maven-plugin</artifactId>
+                        <!-- Latest 0.11.3 failed with ClassCastException: class java.lang.Integer cannot be cast to class java.util.List (java.lang.Integer and java.util.List are in module java.base of loader 'bootstrap') -->
+                        <version>0.10.6</version>
+                        <executions>
+                            <execution>
+                                <id>generate</id>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>test-generate</id>
+                                <goals>
+                                    <goal>test-generate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Avoid a clash between Spring Boot repackaging and native-maven-plugin -->
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <configuration>
+                            <classifier>exec</classifier>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <!-- Must use older version of surefire plugin for native-image testing. -->
+                        <version>2.22.2</version>
+                        <configuration>
+                            <includes>
+                                <include>**/IT*</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>0.9.9</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <mainClass>com.example.Application</mainClass>
+                            <buildArgs>
+                                <buildArg>--no-fallback</buildArg>
+                                <buildArg>--no-server</buildArg>
+                                <buildArg>--initialize-at-build-time</buildArg>
+                            </buildArgs>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                            <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -152,7 +152,8 @@
                     <version>${project.version}</version>
                 </dependency>
                 <dependency>
-                    <!-- Wtihout this dependency, spring-aot-maven-plugin fails
+                    <!--
+                    Without this dependency, spring-aot-maven-plugin fails
                     with NoClassDefFoundError: org/springframework/nativex/utils/NativeUtils
                     -->
                     <groupId>org.springframework.experimental</groupId>
@@ -173,8 +174,13 @@
             </dependencies>
             <build>
                 <plugins>
-                    <!-- Because Spring Boot's JAR file has special directory
-                    structure with 'BOOT-INF/' we need this plugin
+                    <!--
+                    This plugin creates configuration files by reading Spring
+                    annotations. For details, see "Ahead-of-time
+                    transformations" in
+                    https://spring.io/blog/2021/03/11/announcing-spring-native-beta
+                    For example, because Spring Boot's JAR file has special
+                    directory structure with 'BOOT-INF/' we need this plugin.
                     https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/#getting-started-native-build-tools
                     -->
                     <plugin>
@@ -227,6 +233,8 @@
                                 <buildArg>--no-fallback</buildArg>
                                 <buildArg>--no-server</buildArg>
                                 <buildArg>--initialize-at-build-time</buildArg>
+                                <!-- Added this for the error https://gist.github.com/suztomo/b348ae17a09e0a5ef8bd698c237c1a69 -->
+                                <buildArg>--initialize-at-run-time=com.sun.jmx.mbeanserver.JmxMBeanServer</buildArg>
                             </buildArgs>
                         </configuration>
                         <executions>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -105,25 +105,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.springframework.experimental</groupId>
-                <artifactId>spring-aot-maven-plugin</artifactId>
-                <version>${spring.native.version}</version>
-                <executions>
-                    <execution>
-                        <id>generate</id>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>test-generate</id>
-                        <goals>
-                            <goal>test-generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -14,6 +14,10 @@
         <version>3.2.0-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <spring.native.version>0.11.3</spring.native.version>
+    </properties>
+
     <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->
     <dependencyManagement>
         <dependencies>
@@ -97,38 +101,26 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>appengine-maven-plugin</artifactId>
             </plugin>
-
-            <!-- These plugins enable building the application to a JAR *not* using Native Image -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <classpathPrefix>dependency-jars/</classpathPrefix>
-                            <mainClass>trace.TraceSampleApplication</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.2.0</version>
+                <groupId>org.springframework.experimental</groupId>
+                <artifactId>spring-aot-maven-plugin</artifactId>
+                <version>${spring.native.version}</version>
                 <executions>
                     <execution>
-                        <id>copy-dependencies</id>
-                        <phase>package</phase>
+                        <id>generate</id>
                         <goals>
-                            <goal>copy-dependencies</goal>
+                            <goal>generate</goal>
                         </goals>
-                        <configuration>
-                            <outputDirectory>
-                                ${project.build.directory}/dependency-jars/
-                            </outputDirectory>
-                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-generate</id>
+                        <goals>
+                            <goal>test-generate</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -158,7 +150,7 @@
                     -->
                     <groupId>org.springframework.experimental</groupId>
                     <artifactId>spring-native</artifactId>
-                    <version>0.11.3</version>
+                    <version>${spring.native.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.junit.vintage</groupId>
@@ -186,8 +178,7 @@
                     <plugin>
                         <groupId>org.springframework.experimental</groupId>
                         <artifactId>spring-aot-maven-plugin</artifactId>
-                        <!-- Latest 0.11.3 failed with ClassCastException: class java.lang.Integer cannot be cast to class java.util.List (java.lang.Integer and java.util.List are in module java.base of loader 'bootstrap') -->
-                        <version>0.10.6</version>
+                        <version>${spring.native.version}</version>
                         <executions>
                             <execution>
                                 <id>generate</id>
@@ -225,18 +216,8 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
-                        <version>0.9.9</version>
+                        <version>0.9.10</version>
                         <extensions>true</extensions>
-                        <configuration>
-                            <mainClass>com.example.Application</mainClass>
-                            <buildArgs>
-                                <buildArg>--no-fallback</buildArg>
-                                <buildArg>--no-server</buildArg>
-                                <buildArg>--initialize-at-build-time</buildArg>
-                                <!-- Added this for the error https://gist.github.com/suztomo/b348ae17a09e0a5ef8bd698c237c1a69 -->
-                                <buildArg>--initialize-at-run-time=com.sun.jmx.mbeanserver.JmxMBeanServer</buildArg>
-                            </buildArgs>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>build-native</id>
@@ -253,6 +234,8 @@
                                 <phase>test</phase>
                             </execution>
                         </executions>
+                        <configuration>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Still draft

Current failure:

```
$  mvn package -P native -DskipTests -X
...
2022-03-10 12:51:37.204 DEBUG 90099 --- [           main] o.s.nativex.support.SpringAnalyzer       : Spring analysis running
2022-03-10 12:51:37.208  INFO 90099 --- [           main] o.s.nativex.support.SpringAnalyzer       : Spring Native operating mode: native
2022-03-10 12:51:37.208 DEBUG 90099 --- [           main] o.s.nativex.type.SpringConfiguration     : SpringConfiguration: Discovering hints
2022-03-10 12:51:37.209 DEBUG 90099 --- [-worker-ELG-1-5] i.g.n.s.i.grpc.netty.NettyClientHandler  : [id: 0x23f4f791, L:/10.190.55.145:52205 - R:logging.googleapis.com/142.251.35.170:443] INBOUND PING: ack=true bytes=1234
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.util.List (java.lang.Integer and java.util.List are in module java.base of loader 'bootstrap')
	at org.springframework.nativex.type.Type.unpackTypeHint(Type.java:1598)
	at org.springframework.nativex.type.Type.lambda$unpackNativeHint$16(Type.java:1498)
	at org.springframework.nativex.type.Type.processHintList(Type.java:1532)
	at org.springframework.nativex.type.Type.unpackNativeHint(Type.java:1498)
	at org.springframework.nativex.type.Type.unpackNativeHints(Type.java:1977)
	at org.springframework.nativex.type.Type.unpackHints(Type.java:1438)
	at org.springframework.nativex.type.Type.getCompilationHints(Type.java:2001)
	at org.springframework.nativex.type.SpringConfiguration.<init>(SpringConfiguration.java:55)
	at org.springframework.nativex.type.TypeSystem.ensureSpringConfigurationDiscovered(TypeSystem.java:874)
	at org.springframework.nativex.type.TypeSystem.findHints(TypeSystem.java:937)
	at org.springframework.nativex.type.TypeSystem.findActiveDefaultHints(TypeSystem.java:900)
	at org.springframework.nativex.support.ResourcesHandler.handleConstantHints(ResourcesHandler.java:94)
	at org.springframework.nativex.support.ResourcesHandler.register(ResourcesHandler.java:81)
	at org.springframework.nativex.support.SpringAnalyzer.analyze(SpringAnalyzer.java:85)
	at org.springframework.aot.nativex.ConfigurationContributor.contribute(ConfigurationContributor.java:72)
	at org.springframework.aot.build.BootstrapCodeGenerator.generate(BootstrapCodeGenerator.java:91)
	at org.springframework.aot.build.BootstrapCodeGenerator.generate(BootstrapCodeGenerator.java:71)
	at org.springframework.aot.build.GenerateBootstrapCommand.call(GenerateBootstrapCommand.java:107)
	at org.springframework.aot.build.GenerateBootstrapCommand.call(GenerateBootstrapCommand.java:42)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at org.springframework.aot.build.GenerateBootstrapCommand.main(GenerateBootstrapCommand.java:112)
[ERROR] 
org.apache.maven.plugin.MojoExecutionException: Could not exec java
    at org.springframework.aot.maven.AbstractBootstrapMojo.forkJvm (AbstractBootstrapMojo.java:187)
    at org.springframework.aot.maven.GenerateMojo.execute (GenerateMojo.java:132)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:972)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.MojoExecutionException: Bootstrap code generator finished with exit code: 1
    at org.springframework.aot.maven.AbstractBootstrapMojo.forkJvm (AbstractBootstrapMojo.java:184)
    at org.springframework.aot.maven.GenerateMojo.execute (GenerateMojo.java:132)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:972)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[ERROR] [org.springframework.aot.maven.AbstractBootstrapMojo.forkJvm(AbstractBootstrapMojo.java:187), org.springframework.aot.maven.GenerateMojo.execute(GenerateMojo.java:132), org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137), org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210), org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156), org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148), org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117), org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81), org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56), org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128), org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305), org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192), org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105), org.apache.maven.cli.MavenCli.execute(MavenCli.java:972), org.apache.maven.cli.MavenCli.doMain(MavenCli.java:293), org.apache.maven.cli.MavenCli.main(MavenCli.java:196), java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method), java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62), java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43), java.base/java.lang.reflect.Method.invoke(Method.java:566), org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282), org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225), org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406), org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.294 s
[INFO] Finished at: 2022-03-10T12:51:37-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.springframework.experimental:spring-aot-maven-plugin:0.11.3:generate (generate) on project spring-cloud-gcp-trace-sample: Build failed during Spring AOT code generation: Could not exec java: Bootstrap code generator finished with exit code: 1 -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.springframework.experimental:spring-aot-maven-plugin:0.11.3:generate (generate) on project spring-cloud-gcp-trace-sample: Build failed during Spring AOT code generation
```

Environment

```
~/spring-cloud-gcp/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample $ java -version               git[branch:native_sample]
openjdk version "11.0.14" 2022-01-18
OpenJDK Runtime Environment GraalVM CE 22.0.0.2 (build 11.0.14+9-jvmci-22.0-b05)
OpenJDK 64-Bit Server VM GraalVM CE 22.0.0.2 (build 11.0.14+9-jvmci-22.0-b05, mixed mode, sharing)
```

https://docs.spring.io/spring-native/docs/0.11.3/reference/htmlsingle/#support says GraalVM 22.0.0 is supported.