### PR TITLE
Migrating tests in "spring-cloud-gcp-data-firestore" to JUnit5

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/SimpleFirestoreReactiveRepositoryTests.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTests.java
@@ -17,8 +17,6 @@
 package com.google.cloud.spring.data.firestore.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assume.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -35,48 +33,44 @@ import com.google.cloud.spring.data.firestore.transaction.ReactiveFirestoreTrans
 import io.grpc.StatusRuntimeException;
 import java.util.List;
 import java.util.UUID;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.reactive.TransactionalOperator;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-@RunWith(SpringRunner.class)
+@EnabledIfSystemProperty(named = "it.firestore", matches = "true")
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = FirestoreIntegrationTestsConfiguration.class)
-public class FirestoreIntegrationTests {
+class FirestoreIntegrationTests {
 
   @Autowired FirestoreTemplate firestoreTemplate;
 
   @Autowired ReactiveFirestoreTransactionManager txManager;
 
-  @BeforeClass
-  public static void checkToRun() {
-    assumeThat(
-        "Firestore-sample tests are disabled. "
-            + "Please use '-Dit.firestore=true' to enable them. ",
-        System.getProperty("it.firestore"),
-        is("true"));
-
+  @BeforeAll
+  static void setLogger() {
     ch.qos.logback.classic.Logger root =
         (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("io.grpc.netty");
     root.setLevel(Level.INFO);
   }
 
-  @Before
-  public void cleanTestEnvironment() {
+  @BeforeEach
+  void cleanTestEnvironment() {
     this.firestoreTemplate.deleteAll(User.class).block();
   }
 
   @Test
-  public void generateIdTest() {
+  void generateIdTest() {
     User user = new User(null, 29);
     User bob = new User("Bob", 60);
 
@@ -89,7 +83,7 @@ public class FirestoreIntegrationTests {
   }
 
   @Test
-  public void updateTimeTest() {
+  void updateTimeTest() {
     User bob = new User("Bob", 60, null);
     this.firestoreTemplate.saveAll(Flux.just(bob)).collectList().block();
 
@@ -99,7 +93,7 @@ public class FirestoreIntegrationTests {
   }
 
   @Test
-  public void optimisticLockingTest() {
+  void optimisticLockingTest() {
     User bob = new User("Bob", 60, null);
 
     this.firestoreTemplate.saveAll(Flux.just(bob)).collectList().block();
@@ -138,7 +132,7 @@ public class FirestoreIntegrationTests {
   }
 
   @Test
-  public void optimisticLockingTransactionTest() {
+  void optimisticLockingTransactionTest() {
     User bob = new User("Bob", 60, null);
 
     TransactionalOperator operator = TransactionalOperator.create(txManager);
@@ -187,7 +181,7 @@ public class FirestoreIntegrationTests {
   }
 
   @Test
-  public void transactionTest() {
+  void transactionTest() {
     User alice = new User("Alice", 29);
     User bob = new User("Bob", 60);
 
@@ -254,7 +248,7 @@ public class FirestoreIntegrationTests {
   }
 
   @Test
-  public void writeReadDeleteTest() {
+  void writeReadDeleteTest() {
     User alice = new User("Alice", 29);
     User bob = new User("Bob", 60);
 
@@ -307,7 +301,7 @@ public class FirestoreIntegrationTests {
   }
 
   @Test
-  public void deleteAllByIdTest() {
+  void deleteAllByIdTest() {
     User alice = new User("Alice", 29);
     User bob = new User("Bob", 60);
 
@@ -323,7 +317,7 @@ public class FirestoreIntegrationTests {
   }
 
   @Test
-  public void saveTest() {
+  void saveTest() {
     assertThat(this.firestoreTemplate.count(User.class).block()).isZero();
 
     User u1 = new User("Cloud", 22);
@@ -334,7 +328,7 @@ public class FirestoreIntegrationTests {
   }
 
   @Test
-  public void saveAllTest() {
+  void saveAllTest() {
     User u1 = new User("Cloud", 22);
     User u2 = new User("Squall", 17);
     Flux<User> users = Flux.fromArray(new User[] {u1, u2});
@@ -348,7 +342,7 @@ public class FirestoreIntegrationTests {
   }
 
   @Test
-  public void saveAllBulkTest() {
+  void saveAllBulkTest() {
     int numEntities = 1000;
     Flux<User> users =
         Flux.create(
@@ -367,7 +361,7 @@ public class FirestoreIntegrationTests {
   }
 
   @Test
-  public void deleteTest() {
+  void deleteTest() {
     this.firestoreTemplate.save(new User("alpha", 45)).block();
     this.firestoreTemplate.save(new User("beta", 23)).block();
     this.firestoreTemplate.save(new User("gamma", 44)).block();

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -17,8 +17,6 @@
 package com.google.cloud.spring.data.firestore.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assume.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -33,16 +31,16 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.transaction.reactive.TransactionalOperator;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -50,9 +48,10 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-@RunWith(SpringRunner.class)
+@EnabledIfSystemProperty(named = "it.firestore", matches = "true")
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = FirestoreIntegrationTestsConfiguration.class)
-public class FirestoreRepositoryIntegrationTests {
+class FirestoreRepositoryIntegrationTests {
   // tag::autowire[]
   @Autowired UserRepository userRepository;
   // end::autowire[]
@@ -67,23 +66,14 @@ public class FirestoreRepositoryIntegrationTests {
 
   @Autowired ReactiveFirestoreTransactionManager transactionManager;
 
-  @BeforeClass
-  public static void checkToRun() {
-    assumeThat(
-        "Firestore-sample tests are disabled. "
-            + "Please use '-Dit.firestore=true' to enable them. ",
-        System.getProperty("it.firestore"),
-        is("true"));
-  }
-
-  @Before
-  public void cleanTestEnvironment() {
+  @BeforeEach
+  void cleanTestEnvironment() {
     this.userRepository.deleteAll().block();
     reset(this.transactionManager);
   }
 
   @Test
-  public void countTest() {
+  void countTest() {
     Flux<User> users =
         Flux.fromStream(IntStream.range(1, 10).boxed()).map(n -> new User("blah-person" + n, n));
 
@@ -95,7 +85,7 @@ public class FirestoreRepositoryIntegrationTests {
 
   @Test
   // tag::repository_built_in[]
-  public void writeReadDeleteTest() {
+  void writeReadDeleteTest() {
     List<User.Address> addresses =
         Arrays.asList(
             new User.Address("123 Alice st", "US"), new User.Address("1 Alice ave", "US"));
@@ -127,7 +117,7 @@ public class FirestoreRepositoryIntegrationTests {
   // end::repository_built_in[]
 
   @Test
-  public void transactionalOperatorTest() {
+  void transactionalOperatorTest() {
     // tag::repository_transactional_operator[]
     DefaultTransactionDefinition transactionDefinition = new DefaultTransactionDefinition();
     transactionDefinition.setReadOnly(false);
@@ -163,7 +153,7 @@ public class FirestoreRepositoryIntegrationTests {
 
   @Test
   // tag::repository_part_tree[]
-  public void partTreeRepositoryMethodTest() {
+  void partTreeRepositoryMethodTest() {
     User u1 = new User("Cloud", 22, null, null, new Address("1 First st., NYC", "USA"));
     u1.favoriteDrink = "tea";
     User u2 =
@@ -203,7 +193,7 @@ public class FirestoreRepositoryIntegrationTests {
   // end::repository_part_tree[]
 
   @Test
-  public void pageableQueryTest() {
+  void pageableQueryTest() {
     Flux<User> users =
         Flux.fromStream(IntStream.range(1, 11).boxed()).map(n -> new User("blah-person" + n, n));
     this.userRepository.saveAll(users).blockLast();
@@ -221,7 +211,7 @@ public class FirestoreRepositoryIntegrationTests {
   }
 
   @Test
-  public void sortQueryTest() {
+  void sortQueryTest() {
     Flux<User> users =
         Flux.fromStream(IntStream.range(1, 11).boxed()).map(n -> new User("blah-person" + n, n));
     this.userRepository.saveAll(users).blockLast();
@@ -238,7 +228,7 @@ public class FirestoreRepositoryIntegrationTests {
   }
 
   @Test
-  public void testOrderBy() {
+  void testOrderBy() {
     User alice = new User("Alice", 99);
     User bob = new User("Bob", 99);
     User zelda = new User("Zelda", 99);
@@ -261,7 +251,7 @@ public class FirestoreRepositoryIntegrationTests {
   }
 
   @Test
-  public void inFilterQueryTest() {
+  void inFilterQueryTest() {
     User u1 = new User("Cloud", 22);
     User u2 = new User("Squall", 17);
     Flux<User> users = Flux.fromArray(new User[] {u1, u2});
@@ -324,7 +314,7 @@ public class FirestoreRepositoryIntegrationTests {
   }
 
   @Test
-  public void containsFilterQueryTest() {
+  void containsFilterQueryTest() {
     User u1 = new User("Cloud", 22, Arrays.asList("cat", "dog"));
     User u2 = new User("Squall", 17, Collections.singletonList("pony"));
     Flux<User> users = Flux.fromArray(new User[] {u1, u2});
@@ -369,7 +359,7 @@ public class FirestoreRepositoryIntegrationTests {
   }
 
   @Test
-  public void declarativeTransactionRollbackTest() {
+  void declarativeTransactionRollbackTest() {
     this.userService.deleteUsers().onErrorResume(throwable -> Mono.empty()).block();
 
     verify(this.transactionManager, times(0)).commit(any());
@@ -378,7 +368,7 @@ public class FirestoreRepositoryIntegrationTests {
   }
 
   @Test
-  public void declarativeTransactionCommitTest() {
+  void declarativeTransactionCommitTest() {
     User alice = new User("Alice", 29);
     User bob = new User("Bob", 60);
 
@@ -395,7 +385,7 @@ public class FirestoreRepositoryIntegrationTests {
   }
 
   @Test
-  public void transactionPropagationTest() {
+  void transactionPropagationTest() {
     User alice = new User("Alice", 29);
     User bob = new User("Bob", 60);
 
@@ -412,7 +402,7 @@ public class FirestoreRepositoryIntegrationTests {
   }
 
   @Test
-  public void testDoubleSub() {
+  void testDoubleSub() {
     User alice = new User("Alice", 29);
     User bob = new User("Bob", 60);
     this.userRepository.save(alice).then(this.userRepository.save(bob)).block();

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/mapping/FirestorePersistentPropertyImplTest.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/mapping/FirestorePersistentPropertyImplTest.java
@@ -22,18 +22,18 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.firestore.FieldPath;
 import com.google.cloud.firestore.annotation.DocumentId;
 import java.util.Optional;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /** Tests for {@link FirestorePersistentPropertyImpl}. */
-@RunWith(MockitoJUnitRunner.class)
-public class FirestorePersistentPropertyImplTest {
+@ExtendWith(SpringExtension.class)
+class FirestorePersistentPropertyImplTest {
 
   @Mock Property mockProperty;
 
@@ -42,7 +42,7 @@ public class FirestorePersistentPropertyImplTest {
   @Mock SimpleTypeHolder mockSimpleTypeHolder;
 
   @Test
-  public void testGetFieldName_isIdProperty() throws NoSuchFieldException {
+  void testGetFieldName_isIdProperty() throws NoSuchFieldException {
     when(mockProperty.getName()).thenReturn("id");
     when(mockProperty.getField()).thenReturn(Optional.of(TestEntity.class.getField("id")));
     when(mockPersistentEntity.getTypeInformation())

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/repository/query/FirestoreRepositoryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/repository/query/FirestoreRepositoryTests.java
@@ -34,8 +34,8 @@ import com.google.firestore.v1.StructuredQuery;
 import com.google.firestore.v1.StructuredQuery.Direction;
 import com.google.firestore.v1.StructuredQuery.FieldReference;
 import com.google.firestore.v1.StructuredQuery.Order;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,20 +45,20 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Flux;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = FirestoreRepositoryTestsConfiguration.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-public class FirestoreRepositoryTests {
+class FirestoreRepositoryTests {
 
   @Autowired private UserRepository userRepository;
 
   @Autowired private FirestoreTemplate template;
 
   @Test
-  public void testSortQuery_sortParameter() {
+  void testSortQuery_sortParameter() {
     userRepository.findByAgeGreaterThan(0, Sort.by("name")).blockLast();
 
     ArgumentCaptor<StructuredQuery.Builder> captor =
@@ -76,7 +76,7 @@ public class FirestoreRepositoryTests {
   }
 
   @Test
-  public void testSortQuery_methodName_sortByAge() {
+  void testSortQuery_methodName_sortByAge() {
     userRepository.findAllByOrderByAge().blockLast();
 
     ArgumentCaptor<StructuredQuery.Builder> captor =
@@ -93,7 +93,7 @@ public class FirestoreRepositoryTests {
   }
 
   @Test
-  public void testSortQuery_methodName_sortByDocumentId() {
+  void testSortQuery_methodName_sortByDocumentId() {
     userRepository.findByAgeOrderByNameDesc(0).blockLast();
 
     ArgumentCaptor<StructuredQuery.Builder> captor =

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/transaction/ReactiveFirestoreTransactionManagerTest.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/transaction/ReactiveFirestoreTransactionManagerTest.java
@@ -42,12 +42,12 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.Timestamp;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-public class ReactiveFirestoreTransactionManagerTest {
+class ReactiveFirestoreTransactionManagerTest {
 
   private final FirestoreGrpc.FirestoreStub firestoreStub = mock(FirestoreGrpc.FirestoreStub.class);
 
@@ -57,7 +57,7 @@ public class ReactiveFirestoreTransactionManagerTest {
       new FirestoreDefaultClassMapper(new FirestoreMappingContext());
 
   @Test
-  public void triggerCommitCorrectly() {
+  void triggerCommitCorrectly() {
 
     FirestoreTemplate template = getFirestoreTemplate();
 
@@ -94,7 +94,7 @@ public class ReactiveFirestoreTransactionManagerTest {
   }
 
   @Test
-  public void triggerRollbackCorrectly() {
+  void triggerRollbackCorrectly() {
 
     FirestoreTemplate template = getFirestoreTemplate();
 
@@ -121,7 +121,7 @@ public class ReactiveFirestoreTransactionManagerTest {
   }
 
   @Test
-  public void writeTransaction() {
+  void writeTransaction() {
 
     FirestoreTemplate template = getFirestoreTemplate();
 


### PR DESCRIPTION
Migrated the following tests to JUnit5:

1. SimpleFirestoreReactiveRepositoryTests.java
2. FirestoreIntegrationTests.java
3. FirestoreRepositoryIntegrationTests.java
4. FirestorePersistentPropertyImplTest.java
5. FirestoreRepositoryTests.java
6. ReactiveFirestoreTransactionManagerTest.java
