### PR TITLE
Turn off option to append URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         child.project.url.inherit.append.path="false">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.google.cloud</groupId>


### PR DESCRIPTION
Unfortunately, testing maven deploy locally does not generate the child pom XMLs in the same way -- the inherited fields are not populated. So I'd like to merge this in, trigger a staging job, and then verify whether this change works.

If it does not work, I'll back out the property, and hardcode the URL in all deployable modules.