### PR TITLE
Migrating more pubsub tests to JUnit5

### DIFF
--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/PubSubHeaderMapperTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/PubSubHeaderMapperTests.java
@@ -17,24 +17,20 @@
 package com.google.cloud.spring.pubsub.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.springframework.integration.history.MessageHistory;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 
 /** Tests for the Pub/Sub message header. */
-public class PubSubHeaderMapperTests {
-
-  /** used to check for exception messages and types. */
-  @Rule public ExpectedException expectedException = ExpectedException.none();
+class PubSubHeaderMapperTests {
 
   @Test
-  public void testFilterGoogleClientHeaders() {
+  void testFilterGoogleClientHeaders() {
     PubSubHeaderMapper mapper = new PubSubHeaderMapper();
     Map<String, Object> originalHeaders = new HashMap<>();
     originalHeaders.put("my header", "pantagruel's nativity");
@@ -49,7 +45,7 @@ public class PubSubHeaderMapperTests {
   }
 
   @Test
-  public void testFilterHeaders() {
+  void testFilterHeaders() {
     PubSubHeaderMapper mapper = new PubSubHeaderMapper();
     Map<String, Object> originalHeaders = new HashMap<>();
     originalHeaders.put("my header", "pantagruel's nativity");
@@ -63,7 +59,7 @@ public class PubSubHeaderMapperTests {
   }
 
   @Test
-  public void testDontFilterHeaders() {
+  void testDontFilterHeaders() {
     PubSubHeaderMapper mapper = new PubSubHeaderMapper();
     mapper.setOutboundHeaderPatterns("*");
     Map<String, Object> originalHeaders = new HashMap<>();
@@ -76,7 +72,7 @@ public class PubSubHeaderMapperTests {
   }
 
   @Test
-  public void testToHeaders() {
+  void testToHeaders() {
     PubSubHeaderMapper mapper = new PubSubHeaderMapper();
     Map<String, String> originalHeaders = new HashMap<>();
     originalHeaders.put(MessageHeaders.ID, "pantagruel's nativity");
@@ -88,7 +84,7 @@ public class PubSubHeaderMapperTests {
   }
 
   @Test
-  public void testSetInboundHeaderPatterns() {
+  void testSetInboundHeaderPatterns() {
     PubSubHeaderMapper mapper = new PubSubHeaderMapper();
 
     mapper.setInboundHeaderPatterns("x-*");
@@ -107,20 +103,22 @@ public class PubSubHeaderMapperTests {
   }
 
   @Test
-  public void testSetInboundHeaderPatternsNullPatterns() {
-    this.expectedException.expect(IllegalArgumentException.class);
-    this.expectedException.expectMessage("Header patterns can't be null.");
+  void testSetInboundHeaderPatternsNullPatterns() {
 
     PubSubHeaderMapper mapper = new PubSubHeaderMapper();
-    mapper.setInboundHeaderPatterns(null);
+
+    assertThatThrownBy(() -> mapper.setInboundHeaderPatterns(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Header patterns can't be null.");
   }
 
   @Test
-  public void testSetInboundHeaderPatternsNullPatternElements() {
-    this.expectedException.expect(IllegalArgumentException.class);
-    this.expectedException.expectMessage("No header pattern can be null.");
+  void testSetInboundHeaderPatternsNullPatternElements() {
 
     PubSubHeaderMapper mapper = new PubSubHeaderMapper();
-    mapper.setInboundHeaderPatterns(new String[1]);
+
+    assertThatThrownBy(() -> mapper.setInboundHeaderPatterns(new String[1]))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("No header pattern can be null.");
   }
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -127,8 +127,7 @@ class PubSubInboundChannelAdapterTests {
 
     verify(mockAcknowledgeableMessage).nack();
 
-    assertThat(capturedOutput).contains("failed; message nacked automatically");
-    assertThat(capturedOutput).contains(EXCEPTION_MESSAGE);
+    assertThat(capturedOutput).contains("failed; message nacked automatically").contains(EXCEPTION_MESSAGE);
   }
 
   @Test
@@ -167,9 +166,9 @@ class PubSubInboundChannelAdapterTests {
     verify(mockAcknowledgeableMessage).nack();
     verify(mockAcknowledgeableMessage, times(0)).ack();
 
-    assertThat(capturedOutput).contains("failed; message nacked automatically");
     // original message handling exception
-    assertThat(capturedOutput).contains(EXCEPTION_MESSAGE);
+    assertThat(capturedOutput).contains("failed; message nacked automatically").contains(EXCEPTION_MESSAGE);
+
   }
 
   @Test
@@ -186,8 +185,7 @@ class PubSubInboundChannelAdapterTests {
     verify(mockAcknowledgeableMessage, times(0)).ack();
     verify(mockAcknowledgeableMessage, times(0)).nack();
 
-    assertThat(capturedOutput).contains("failed; message neither acked nor nacked");
-    assertThat(capturedOutput).contains(EXCEPTION_MESSAGE);
+    assertThat(capturedOutput).contains("failed; message neither acked nor nacked").contains(EXCEPTION_MESSAGE);
   }
 
   @Test

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -71,7 +71,7 @@ class PubSubInboundChannelAdapterTests {
 
   @BeforeEach
   @SuppressWarnings("unchecked")
-  void primarySetup() {
+  void setUp() {
 
     this.adapter =
         new PubSubInboundChannelAdapter(this.mockPubSubSubscriberOperations, "testSubscription");
@@ -80,7 +80,7 @@ class PubSubInboundChannelAdapterTests {
 
   }
 
-  void secondarySetup() {
+  void setupSubscribeAndConvert() {
     when(this.mockMessageChannel.send(any())).thenReturn(true);
 
     when(mockAcknowledgeableMessage.getPubsubMessage())
@@ -116,7 +116,7 @@ class PubSubInboundChannelAdapterTests {
 
   @Test
   void testAckModeAuto_nacksWhenDownstreamProcessingFails(CapturedOutput capturedOutput) {
-    secondarySetup();
+    setupSubscribeAndConvert();
 
     when(this.mockMessageChannel.send(any())).thenThrow(new RuntimeException(EXCEPTION_MESSAGE));
 
@@ -133,7 +133,7 @@ class PubSubInboundChannelAdapterTests {
   @Test
   void testAckModeAuto_nacksWhenDownstreamProcessingFailsWhenContextShutdown(CapturedOutput capturedOutput) {
 
-    secondarySetup();
+    setupSubscribeAndConvert();
     this.adapter.setAckMode(AckMode.AUTO);
     this.adapter.setOutputChannel(this.mockMessageChannel);
 
@@ -174,7 +174,7 @@ class PubSubInboundChannelAdapterTests {
   @Test
   void testAckModeAutoAck_neitherAcksNorNacksWhenMessageProcessingFails(CapturedOutput capturedOutput) {
 
-    secondarySetup();
+    setupSubscribeAndConvert();
     when(this.mockMessageChannel.send(any())).thenThrow(new RuntimeException(EXCEPTION_MESSAGE));
 
     this.adapter.setAckMode(AckMode.AUTO_ACK);
@@ -191,7 +191,7 @@ class PubSubInboundChannelAdapterTests {
   @Test
   void testSetHealthRegistry_Success() {
 
-    secondarySetup();
+    setupSubscribeAndConvert();
     HealthTrackerRegistry healthTrackerRegistry = mock(HealthTrackerRegistry.class);
     adapter.setHealthTrackerRegistry(healthTrackerRegistry);
     adapter.doStart();
@@ -202,7 +202,7 @@ class PubSubInboundChannelAdapterTests {
   @Test
   void testMessageProcessed_successWhenRegistrySet() {
 
-    secondarySetup();
+    setupSubscribeAndConvert();
     HealthTrackerRegistry healthTrackerRegistry = mock(HealthTrackerRegistry.class);
     adapter.setHealthTrackerRegistry(healthTrackerRegistry);
     adapter.doStart();
@@ -218,7 +218,7 @@ class PubSubInboundChannelAdapterTests {
   @Test
   void testAddingSubscription_successWhenSubscriberAdded() {
 
-    secondarySetup();
+    setupSubscribeAndConvert();
     HealthTrackerRegistry healthTrackerRegistry = mock(HealthTrackerRegistry.class);
     adapter.setHealthTrackerRegistry(healthTrackerRegistry);
     adapter.doStart();
@@ -230,7 +230,7 @@ class PubSubInboundChannelAdapterTests {
   @SuppressWarnings("unchecked")
   void customMessageBuilderFactoryUsedWhenAvailable() {
 
-    secondarySetup();
+    setupSubscribeAndConvert();
     MutableMessageBuilderFactory factory = mock(MutableMessageBuilderFactory.class);
     when(factory.withPayload(any()))
         .thenReturn(MutableMessageBuilder.withPayload("custom payload"));
@@ -248,7 +248,7 @@ class PubSubInboundChannelAdapterTests {
   @Test
   void consumeMessageAttachesOriginalMessageHeaderInManualMode() {
 
-    secondarySetup();
+    setupSubscribeAndConvert();
     this.adapter.setAckMode(AckMode.MANUAL);
     this.adapter.start();
     verifyOriginalMessage();
@@ -258,7 +258,7 @@ class PubSubInboundChannelAdapterTests {
   @Test
   void consumeMessageAttachesOriginalMessageHeaderInAutoMode() {
 
-    secondarySetup();
+    setupSubscribeAndConvert();
     this.adapter.setAckMode(AckMode.AUTO);
     this.adapter.start();
     verifyOriginalMessage();
@@ -268,7 +268,7 @@ class PubSubInboundChannelAdapterTests {
   @Test
   void consumeMessageAttachesOriginalMessageHeaderInAutoAckMode() {
 
-    secondarySetup();
+    setupSubscribeAndConvert();
     this.adapter.setAckMode(AckMode.AUTO_ACK);
     this.adapter.start();
     verifyOriginalMessage();

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java
@@ -32,15 +32,15 @@ import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
 import com.google.cloud.spring.pubsub.support.converter.ConvertedBasicAcknowledgeablePubsubMessage;
 import com.google.pubsub.v1.PubsubMessage;
 import java.util.function.Consumer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.boot.test.system.OutputCaptureRule;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.handler.ServiceActivatingHandler;
 import org.springframework.integration.support.MutableMessageBuilder;
@@ -53,8 +53,9 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.GenericMessage;
 
 /** {@link PubSubInboundChannelAdapter} unit tests. */
-@RunWith(MockitoJUnitRunner.class)
-public class PubSubInboundChannelAdapterTests {
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
+class PubSubInboundChannelAdapterTests {
 
   private TestUtils.TestApplicationContext context = TestUtils.createTestApplicationContext();
 
@@ -62,48 +63,48 @@ public class PubSubInboundChannelAdapterTests {
 
   static final String EXCEPTION_MESSAGE = "Simulated downstream message processing failure";
 
-  /** Output capture for validating warning messages. */
-  @Rule public OutputCaptureRule output = new OutputCaptureRule();
-
   @Mock PubSubSubscriberOperations mockPubSubSubscriberOperations;
 
   @Mock MessageChannel mockMessageChannel;
 
   @Mock ConvertedBasicAcknowledgeablePubsubMessage mockAcknowledgeableMessage;
 
-  @Before
+  @BeforeEach
   @SuppressWarnings("unchecked")
-  public void setUp() {
+  void primarySetup() {
 
     this.adapter =
         new PubSubInboundChannelAdapter(this.mockPubSubSubscriberOperations, "testSubscription");
     this.adapter.setOutputChannel(this.mockMessageChannel);
     this.adapter.setBeanFactory(this.context);
 
+  }
+
+  void secondarySetup() {
     when(this.mockMessageChannel.send(any())).thenReturn(true);
 
     when(mockAcknowledgeableMessage.getPubsubMessage())
-        .thenReturn(PubsubMessage.newBuilder().build());
+            .thenReturn(PubsubMessage.newBuilder().build());
     when(mockAcknowledgeableMessage.getPayload()).thenReturn("Test message payload.");
 
     when(this.mockPubSubSubscriberOperations.subscribeAndConvert(
             anyString(), any(Consumer.class), any(Class.class)))
-        .then(
-            invocationOnMock -> {
-              Consumer<ConvertedBasicAcknowledgeablePubsubMessage> messageConsumer =
-                  invocationOnMock.getArgument(1);
-              messageConsumer.accept(mockAcknowledgeableMessage);
-              return null;
-            });
+            .then(
+                    invocationOnMock -> {
+                      Consumer<ConvertedBasicAcknowledgeablePubsubMessage> messageConsumer =
+                              invocationOnMock.getArgument(1);
+                      messageConsumer.accept(mockAcknowledgeableMessage);
+                      return null;
+                    });
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     this.context.close();
   }
 
   @Test
-  public void testNonNullAckMode() {
+  void testNonNullAckMode() {
 
     assertThatThrownBy(
             () -> {
@@ -114,7 +115,8 @@ public class PubSubInboundChannelAdapterTests {
   }
 
   @Test
-  public void testAckModeAuto_nacksWhenDownstreamProcessingFails() {
+  void testAckModeAuto_nacksWhenDownstreamProcessingFails(CapturedOutput capturedOutput) {
+    secondarySetup();
 
     when(this.mockMessageChannel.send(any())).thenThrow(new RuntimeException(EXCEPTION_MESSAGE));
 
@@ -125,13 +127,14 @@ public class PubSubInboundChannelAdapterTests {
 
     verify(mockAcknowledgeableMessage).nack();
 
-    assertThat(output.getOut()).contains("failed; message nacked automatically");
-    assertThat(output.getOut()).contains(EXCEPTION_MESSAGE);
+    assertThat(capturedOutput).contains("failed; message nacked automatically");
+    assertThat(capturedOutput).contains(EXCEPTION_MESSAGE);
   }
 
   @Test
-  public void testAckModeAuto_nacksWhenDownstreamProcessingFailsWhenContextShutdown() {
+  void testAckModeAuto_nacksWhenDownstreamProcessingFailsWhenContextShutdown(CapturedOutput capturedOutput) {
 
+    secondarySetup();
     this.adapter.setAckMode(AckMode.AUTO);
     this.adapter.setOutputChannel(this.mockMessageChannel);
 
@@ -164,14 +167,15 @@ public class PubSubInboundChannelAdapterTests {
     verify(mockAcknowledgeableMessage).nack();
     verify(mockAcknowledgeableMessage, times(0)).ack();
 
-    assertThat(output.getOut()).contains("failed; message nacked automatically");
+    assertThat(capturedOutput).contains("failed; message nacked automatically");
     // original message handling exception
-    assertThat(output.getOut()).contains(EXCEPTION_MESSAGE);
+    assertThat(capturedOutput).contains(EXCEPTION_MESSAGE);
   }
 
   @Test
-  public void testAckModeAutoAck_neitherAcksNorNacksWhenMessageProcessingFails() {
+  void testAckModeAutoAck_neitherAcksNorNacksWhenMessageProcessingFails(CapturedOutput capturedOutput) {
 
+    secondarySetup();
     when(this.mockMessageChannel.send(any())).thenThrow(new RuntimeException(EXCEPTION_MESSAGE));
 
     this.adapter.setAckMode(AckMode.AUTO_ACK);
@@ -182,20 +186,25 @@ public class PubSubInboundChannelAdapterTests {
     verify(mockAcknowledgeableMessage, times(0)).ack();
     verify(mockAcknowledgeableMessage, times(0)).nack();
 
-    assertThat(output.getOut()).contains("failed; message neither acked nor nacked");
-    assertThat(output.getOut()).contains(EXCEPTION_MESSAGE);
+    assertThat(capturedOutput).contains("failed; message neither acked nor nacked");
+    assertThat(capturedOutput).contains(EXCEPTION_MESSAGE);
   }
 
   @Test
-  public void testSetHealthRegistry_Success() {
+  void testSetHealthRegistry_Success() {
+
+    secondarySetup();
     HealthTrackerRegistry healthTrackerRegistry = mock(HealthTrackerRegistry.class);
     adapter.setHealthTrackerRegistry(healthTrackerRegistry);
     adapter.doStart();
     verify(healthTrackerRegistry).registerTracker("testSubscription");
+
   }
 
   @Test
-  public void testMessageProcessed_successWhenRegistrySet() {
+  void testMessageProcessed_successWhenRegistrySet() {
+
+    secondarySetup();
     HealthTrackerRegistry healthTrackerRegistry = mock(HealthTrackerRegistry.class);
     adapter.setHealthTrackerRegistry(healthTrackerRegistry);
     adapter.doStart();
@@ -205,21 +214,25 @@ public class PubSubInboundChannelAdapterTests {
     this.mockMessageChannel.send(new GenericMessage<>("test-message"));
 
     verify(healthTrackerRegistry, times(1)).processedMessage(any());
+
   }
 
   @Test
-  public void testAddingSubscription_successWhenSubscriberAdded() {
+  void testAddingSubscription_successWhenSubscriberAdded() {
+
+    secondarySetup();
     HealthTrackerRegistry healthTrackerRegistry = mock(HealthTrackerRegistry.class);
     adapter.setHealthTrackerRegistry(healthTrackerRegistry);
     adapter.doStart();
-
     verify(healthTrackerRegistry, times(1)).addListener(any());
+
   }
 
   @Test
   @SuppressWarnings("unchecked")
-  public void customMessageBuilderFactoryUsedWhenAvailable() {
+  void customMessageBuilderFactoryUsedWhenAvailable() {
 
+    secondarySetup();
     MutableMessageBuilderFactory factory = mock(MutableMessageBuilderFactory.class);
     when(factory.withPayload(any()))
         .thenReturn(MutableMessageBuilder.withPayload("custom payload"));
@@ -235,31 +248,38 @@ public class PubSubInboundChannelAdapterTests {
   }
 
   @Test
-  public void consumeMessageAttachesOriginalMessageHeaderInManualMode() {
+  void consumeMessageAttachesOriginalMessageHeaderInManualMode() {
+
+    secondarySetup();
     this.adapter.setAckMode(AckMode.MANUAL);
     this.adapter.start();
-
     verifyOriginalMessage();
+
   }
 
   @Test
-  public void consumeMessageAttachesOriginalMessageHeaderInAutoMode() {
+  void consumeMessageAttachesOriginalMessageHeaderInAutoMode() {
+
+    secondarySetup();
     this.adapter.setAckMode(AckMode.AUTO);
     this.adapter.start();
-
     verifyOriginalMessage();
+
   }
 
   @Test
-  public void consumeMessageAttachesOriginalMessageHeaderInAutoAckMode() {
+  void consumeMessageAttachesOriginalMessageHeaderInAutoAckMode() {
+
+    secondarySetup();
     this.adapter.setAckMode(AckMode.AUTO_ACK);
     this.adapter.start();
-
     verifyOriginalMessage();
+
   }
 
   @SuppressWarnings("unchecked")
   private void verifyOriginalMessage() {
+
     ArgumentCaptor<Message<?>> argument = ArgumentCaptor.forClass(Message.class);
     verify(this.mockMessageChannel).send(argument.capture());
     MessageHeaders headers = argument.getValue().getHeaders();


### PR DESCRIPTION
Tests migrated to JUnit5:

1. PubSubHeaderMapperTests.java
2. PubSubInboundChannelAdapterTests.java - (splitting setup into two parts to avoid UnnecessaryStubbing) 