### PR TITLE
Pin setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/integrationTests-2.x.yaml
+++ b/.github/workflows/integrationTests-2.x.yaml
@@ -51,7 +51,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-unified-2.x-${{ steps.date.outputs.date }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
           project_id: spring-cloud-gcp-ci

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -63,7 +63,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: latest
           project_id: spring-cloud-gcp-ci


### PR DESCRIPTION
setup-gcloud will be updating the branch name from master to main in a future release. Even though GitHub will establish redirects, this will break any GitHub Actions workflows that pin to master. This PR updates your GitHub Actions workflows to pin to v0, which is the recommended best practice.