### PR TITLE
Remove startup pubsub validation

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicator.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicator.java
@@ -91,10 +91,6 @@ public class PubSubHealthIndicator extends AbstractHealthIndicator {
     this.acknowledgeMessages = acknowledgeMessages;
   }
 
-  void validateHealthCheck() {
-    doHealthCheck(() -> {}, this::validationFailed, this::validationFailed);
-  }
-
   @Override
   protected void doHealthCheck(Health.Builder builder) {
     doHealthCheck(builder::up, builder::down, e -> builder.withException(e).unknown());
@@ -142,10 +138,6 @@ public class PubSubHealthIndicator extends AbstractHealthIndicator {
       return errorCode == StatusCode.Code.NOT_FOUND || errorCode == Code.PERMISSION_DENIED;
     }
     return false;
-  }
-
-  private void validationFailed(Throwable e) {
-    throw new BeanInitializationException("Validation of health indicator failed", e);
   }
 
   boolean isSpecifiedSubscription() {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
@@ -71,7 +71,6 @@ public class PubSubHealthIndicatorAutoConfiguration
             this.pubSubHealthProperties.getSubscription(),
             this.pubSubHealthProperties.getTimeoutMillis(),
             this.pubSubHealthProperties.isAcknowledgeMessages());
-    indicator.validateHealthCheck();
     return indicator;
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicatorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicatorTests.java
@@ -155,14 +155,4 @@ class PubSubHealthIndicatorTests {
     testHealth(e, "testSubscription", Status.DOWN);
   }
 
-  @Test
-  void validateHealth() throws Exception {
-    doThrow(new RuntimeException()).when(future).get(anyLong(), any());
-    when(pubSubTemplate.pullAsync(anyString(), anyInt(), anyBoolean())).thenReturn(future);
-
-    PubSubHealthIndicator healthIndicator =
-        new PubSubHealthIndicator(pubSubTemplate, "test", 1000, true);
-    assertThatThrownBy(() -> healthIndicator.validateHealthCheck())
-        .isInstanceOf(BeanInitializationException.class);
-  }
 }


### PR DESCRIPTION
We've had failures reported on startup due to startup subscription checking taking too long. While this can be worked around with a longer timeout, actuator healthchecks are a cross-cutting concern that should not prevent application startup.