### PR TITLE
Migrating tests to JUnit5

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubMessageChannelBinderTests.java
@@ -39,11 +39,11 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -71,8 +71,8 @@ import org.springframework.messaging.MessageChannel;
  *
  * @since 1.1
  */
-@RunWith(MockitoJUnitRunner.class)
-public class PubSubMessageChannelBinderTests {
+@ExtendWith(MockitoExtension.class)
+class PubSubMessageChannelBinderTests {
   private static final Log LOGGER = LogFactory.getLog(PubSubMessageChannelBinderTests.class);
 
   PubSubMessageChannelBinder binder;
@@ -103,25 +103,20 @@ public class PubSubMessageChannelBinderTests {
               AutoConfigurations.of(
                   PubSubBinderConfiguration.class, PubSubExtendedBindingProperties.class));
 
-  @Before
-  public void before() {
-    this.binder =
-        new PubSubMessageChannelBinder(
-            new String[0], this.channelProvisioner, this.pubSubTemplate, this.properties);
-
-    when(producerDestination.getName()).thenReturn("test-topic");
-    when(consumerDestination.getName()).thenReturn("test-subscription");
-  }
-
   @Test
-  public void testAfterUnbindConsumer() {
+  void testAfterUnbindConsumer() {
+
+    this.binder = new PubSubMessageChannelBinder(new String[0], this.channelProvisioner, this.pubSubTemplate, this.properties);
     this.binder.afterUnbindConsumer(this.consumerDestination, "group1", this.consumerProperties);
 
     verify(this.channelProvisioner).afterUnbindConsumer(this.consumerDestination);
   }
 
   @Test
-  public void producerSyncPropertyFalseByDefault() {
+  void producerSyncPropertyFalseByDefault() {
+
+    this.binder = new PubSubMessageChannelBinder(new String[0], this.channelProvisioner, this.pubSubTemplate, this.properties);
+    when(producerDestination.getName()).thenReturn("test-topic");
     baseContext.run(
         ctx -> {
           PubSubMessageChannelBinder binder = ctx.getBean(PubSubMessageChannelBinder.class);
@@ -139,7 +134,10 @@ public class PubSubMessageChannelBinderTests {
   }
 
   @Test
-  public void producerSyncPropertyPropagatesToMessageHandler() {
+  void producerSyncPropertyPropagatesToMessageHandler() {
+
+    this.binder = new PubSubMessageChannelBinder(new String[0], this.channelProvisioner, this.pubSubTemplate, this.properties);
+    when(producerDestination.getName()).thenReturn("test-topic");
     baseContext
         .withPropertyValues("spring.cloud.stream.gcp.pubsub.default.producer.sync=true")
         .run(
@@ -161,7 +159,9 @@ public class PubSubMessageChannelBinderTests {
   }
 
   @Test
-  public void consumerMaxFetchPropertyPropagatesToMessageSource() {
+  void consumerMaxFetchPropertyPropagatesToMessageSource() {
+    this.binder = new PubSubMessageChannelBinder(new String[0], this.channelProvisioner, this.pubSubTemplate, this.properties);
+    when(consumerDestination.getName()).thenReturn("test-subscription");
     baseContext
         .withPropertyValues("spring.cloud.stream.gcp.pubsub.default.consumer.maxFetchSize=20")
         .run(
@@ -181,7 +181,10 @@ public class PubSubMessageChannelBinderTests {
   }
 
   @Test
-  public void testCreateConsumerWithRegistry() {
+  void testCreateConsumerWithRegistry() {
+
+    this.binder = new PubSubMessageChannelBinder(new String[0], this.channelProvisioner, this.pubSubTemplate, this.properties);
+    when(consumerDestination.getName()).thenReturn("test-subscription");
     baseContext.run(
         ctx -> {
           PubSubMessageChannelBinder binder = ctx.getBean(PubSubMessageChannelBinder.class);
@@ -204,7 +207,9 @@ public class PubSubMessageChannelBinderTests {
   }
 
   @Test
-  public void testProducerAndConsumerCustomizers() {
+  void testProducerAndConsumerCustomizers() {
+
+    this.binder = new PubSubMessageChannelBinder(new String[0], this.channelProvisioner, this.pubSubTemplate, this.properties);
     baseContext
         .withUserConfiguration(PubSubBinderTestConfig.class)
         .withPropertyValues("spring.cloud.stream.bindings.input.group=testGroup")
@@ -233,7 +238,10 @@ public class PubSubMessageChannelBinderTests {
   }
 
   @Test
-  public void testConsumerEndpointCreation() {
+  void testConsumerEndpointCreation() {
+
+    this.binder = new PubSubMessageChannelBinder(new String[0], this.channelProvisioner, this.pubSubTemplate, this.properties);
+    when(consumerDestination.getName()).thenReturn("test-subscription");
     baseContext
         .withPropertyValues(
             "spring.cloud.stream.bindings.input.group=testGroup",

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/config/PubSubBinderConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/config/PubSubBinderConfigurationTests.java
@@ -29,7 +29,7 @@ import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 import com.google.cloud.spring.pubsub.core.health.HealthTrackerRegistry;
 import com.google.cloud.spring.stream.binder.pubsub.PubSubMessageChannelBinder;
 import com.google.cloud.spring.stream.binder.pubsub.provisioning.PubSubChannelProvisioner;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -38,10 +38,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 /** Tests for PubSubBinderConfiguration and its interaction with other autoconfiguration classes. */
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-public class PubSubBinderConfigurationTests {
+class PubSubBinderConfigurationTests {
 
   @Test
-  public void testEverythingEnabled_implicit() {
+  void testEverythingEnabled_implicit() {
     ApplicationContextRunner baseContext =
         new ApplicationContextRunner()
             // no property values specified
@@ -55,7 +55,7 @@ public class PubSubBinderConfigurationTests {
   }
 
   @Test
-  public void testEverythingEnabled_explicit() {
+  void testEverythingEnabled_explicit() {
     ApplicationContextRunner baseContext =
         new ApplicationContextRunner()
             .withPropertyValues(
@@ -73,7 +73,7 @@ public class PubSubBinderConfigurationTests {
   }
 
   @Test
-  public void testBinderDisabled() {
+  void testBinderDisabled() {
     ApplicationContextRunner baseContext =
         new ApplicationContextRunner()
             .withPropertyValues(
@@ -89,7 +89,7 @@ public class PubSubBinderConfigurationTests {
   }
 
   @Test
-  public void testPubSubDisabled_noReplacements() {
+  void testPubSubDisabled_noReplacements() {
     ApplicationContextRunner baseContext =
         new ApplicationContextRunner()
             .withPropertyValues(
@@ -105,7 +105,7 @@ public class PubSubBinderConfigurationTests {
   }
 
   @Test
-  public void testPubSubDisabled_withReplacements() {
+  void testPubSubDisabled_withReplacements() {
     ApplicationContextRunner baseContext =
         new ApplicationContextRunner()
             .withPropertyValues(
@@ -123,7 +123,7 @@ public class PubSubBinderConfigurationTests {
   }
 
   @Test
-  public void testBothDisabled() {
+  void testBothDisabled() {
     ApplicationContextRunner baseContext =
         new ApplicationContextRunner()
             .withPropertyValues(
@@ -139,7 +139,7 @@ public class PubSubBinderConfigurationTests {
   }
 
   @Test
-  public void test_healthRegistryEnabled() {
+  void test_healthRegistryEnabled() {
     ApplicationContextRunner baseContext =
         new ApplicationContextRunner()
             .withPropertyValues(

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/properties/PubSubExtendedBindingsPropertiesTests.java
@@ -34,8 +34,8 @@ import com.google.cloud.spring.stream.binder.pubsub.PubSubMessageChannelBinder;
 import com.google.cloud.spring.stream.binder.pubsub.properties.PubSubExtendedBindingsPropertiesTests.PubSubBindingsTestConfiguration;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.Topic;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -50,10 +50,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /** Tests for extended binding properties. */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.NONE,
     classes = {PubSubBindingsTestConfiguration.class, BindingServiceConfiguration.class},
@@ -62,12 +62,12 @@ import org.springframework.test.context.junit4.SpringRunner;
       "spring.cloud.stream.gcp.pubsub.bindings.input.consumer.auto-create-resources=true",
       "spring.cloud.stream.gcp.pubsub.default.consumer.auto-create-resources=false"
     })
-public class PubSubExtendedBindingsPropertiesTests {
+class PubSubExtendedBindingsPropertiesTests {
 
   @Autowired private ConfigurableApplicationContext context;
 
   @Test
-  public void testExtendedPropertiesOverrideDefaults() {
+  void testExtendedPropertiesOverrideDefaults() {
     BinderFactory binderFactory = this.context.getBeanFactory().getBean(BinderFactory.class);
     PubSubMessageChannelBinder binder =
         (PubSubMessageChannelBinder) binderFactory.getBinder("pubsub", MessageChannel.class);

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -33,12 +33,14 @@ import com.google.cloud.spring.stream.binder.pubsub.properties.PubSubConsumerPro
 import com.google.pubsub.v1.DeadLetterPolicy;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.Topic;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.provisioning.ProvisioningException;
 
@@ -47,8 +49,9 @@ import org.springframework.cloud.stream.provisioning.ProvisioningException;
  *
  * @since 1.1
  */
-@RunWith(MockitoJUnitRunner.class)
-public class PubSubChannelProvisionerTests {
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PubSubChannelProvisionerTests {
 
   @Mock PubSubAdmin pubSubAdminMock;
 
@@ -59,8 +62,8 @@ public class PubSubChannelProvisionerTests {
   // class under test
   PubSubChannelProvisioner pubSubChannelProvisioner;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     when(this.pubSubAdminMock.getSubscription(any())).thenReturn(null);
     doAnswer(
             invocation -> {
@@ -89,7 +92,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testProvisionConsumerDestination_specifiedGroup() {
+  void testProvisionConsumerDestination_specifiedGroup() {
     PubSubConsumerDestination result =
         (PubSubConsumerDestination)
             this.pubSubChannelProvisioner.provisionConsumerDestination(
@@ -105,7 +108,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testProvisionConsumerDestination_specifiedGroupTopicInDifferentProject() {
+  void testProvisionConsumerDestination_specifiedGroupTopicInDifferentProject() {
     String fullTopicName = "projects/differentProject/topics/topic_A";
     when(this.pubSubAdminMock.getTopic(fullTopicName))
         .thenReturn(Topic.newBuilder().setName(fullTopicName).build());
@@ -126,7 +129,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testProvisionConsumerDestination_customSubscription() {
+  void testProvisionConsumerDestination_customSubscription() {
     when(this.properties.getExtension()).thenReturn(this.pubSubConsumerProperties);
     when(this.pubSubConsumerProperties.getSubscriptionName()).thenReturn("my-custom-subscription");
 
@@ -139,7 +142,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testProvisionConsumerDestination_noTopicException() {
+  void testProvisionConsumerDestination_noTopicException() {
     when(this.pubSubConsumerProperties.isAutoCreateResources()).thenReturn(false);
     when(this.pubSubAdminMock.getTopic("topic_A")).thenReturn(null);
 
@@ -152,7 +155,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testProvisionConsumerDestination_noSubscriptionException() {
+  void testProvisionConsumerDestination_noSubscriptionException() {
     when(this.pubSubConsumerProperties.isAutoCreateResources()).thenReturn(false);
 
     assertThatExceptionOfType(ProvisioningException.class)
@@ -164,7 +167,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testProvisionConsumerDestination_wrongTopicException() {
+  void testProvisionConsumerDestination_wrongTopicException() {
     when(this.pubSubConsumerProperties.isAutoCreateResources()).thenReturn(false);
     when(this.pubSubAdminMock.getSubscription("topic_A.group_A"))
         .thenReturn(Subscription.newBuilder().setTopic("topic_B").build());
@@ -178,7 +181,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testProvisionConsumerDestination_anonymousGroup() {
+  void testProvisionConsumerDestination_anonymousGroup() {
     // should work with auto-create = false
     when(this.pubSubConsumerProperties.isAutoCreateResources()).thenReturn(false);
 
@@ -199,7 +202,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testProvisionConsumerDestination_deadLetterQueue() {
+  void testProvisionConsumerDestination_deadLetterQueue() {
     PubSubConsumerProperties.DeadLetterPolicy dlp = new PubSubConsumerProperties.DeadLetterPolicy();
     dlp.setDeadLetterTopic("deadLetterTopic");
     dlp.setMaxDeliveryAttempts(12);
@@ -227,7 +230,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testAfterUnbindConsumer_anonymousGroup() {
+  void testAfterUnbindConsumer_anonymousGroup() {
     PubSubConsumerDestination result =
         (PubSubConsumerDestination)
             this.pubSubChannelProvisioner.provisionConsumerDestination(
@@ -239,7 +242,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testAfterUnbindConsumer_twice() {
+  void testAfterUnbindConsumer_twice() {
     PubSubConsumerDestination result =
         (PubSubConsumerDestination)
             this.pubSubChannelProvisioner.provisionConsumerDestination(
@@ -252,7 +255,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testAfterUnbindConsumer_nonAnonymous() {
+  void testAfterUnbindConsumer_nonAnonymous() {
     PubSubConsumerDestination result =
         (PubSubConsumerDestination)
             this.pubSubChannelProvisioner.provisionConsumerDestination(
@@ -264,7 +267,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testProvisionConsumerDestination_concurrentTopicCreation() {
+  void testProvisionConsumerDestination_concurrentTopicCreation() {
     when(this.pubSubAdminMock.createTopic(any())).thenThrow(AlreadyExistsException.class);
     when(this.pubSubAdminMock.getTopic("already_existing_topic"))
         .thenReturn(null)
@@ -278,7 +281,7 @@ public class PubSubChannelProvisionerTests {
   }
 
   @Test
-  public void testProvisionConsumerDestination_recursiveExistCalls() {
+  void testProvisionConsumerDestination_recursiveExistCalls() {
     when(this.pubSubAdminMock.getTopic("new_topic")).thenReturn(null);
     when(this.pubSubAdminMock.createTopic(any())).thenThrow(AlreadyExistsException.class);
 

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberTemplateTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberTemplateTests.java
@@ -57,20 +57,23 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
 
 /** Unit tests for {@link PubSubSubscriberTemplate}. */
-@RunWith(MockitoJUnitRunner.class)
-public class PubSubSubscriberTemplateTests {
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PubSubSubscriberTemplateTests {
 
   private PubSubSubscriberTemplate pubSubSubscriberTemplate;
 
@@ -107,8 +110,8 @@ public class PubSubSubscriberTemplateTests {
 
   @Mock private ApiFuture<Empty> ackApiFuture;
 
-  @Before
-  public void setUp() throws ExecutionException, InterruptedException {
+  @BeforeEach
+  void setUp() throws ExecutionException, InterruptedException {
     reset(this.subscriberFactory);
     reset(this.subscriberStub);
     reset(this.subscriber);
@@ -196,7 +199,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testSubscribe_AndManualAck()
+  void testSubscribe_AndManualAck()
       throws InterruptedException, ExecutionException, TimeoutException {
     this.pubSubSubscriberTemplate.subscribe("sub1", this.consumer);
 
@@ -220,7 +223,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testSubscribe_AndManualNack()
+  void testSubscribe_AndManualNack()
       throws InterruptedException, ExecutionException, TimeoutException {
     this.pubSubSubscriberTemplate.subscribe("sub1", this.consumer);
 
@@ -244,7 +247,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testSubscribeAndConvert_AndManualAck()
+  void testSubscribeAndConvert_AndManualAck()
       throws InterruptedException, ExecutionException, TimeoutException {
     this.pubSubSubscriberTemplate.subscribeAndConvert(
         "sub1", this.convertedConsumer, Boolean.class);
@@ -276,7 +279,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testSubscribeAndConvert_AndManualNack()
+  void testSubscribeAndConvert_AndManualNack()
       throws InterruptedException, ExecutionException, TimeoutException {
     this.pubSubSubscriberTemplate.subscribeAndConvert(
         "sub1", this.convertedConsumer, Boolean.class);
@@ -308,7 +311,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void destroyingBeanClosesSubscriberStub() {
+  void destroyingBeanClosesSubscriberStub() {
     this.pubSubSubscriberTemplate = new PubSubSubscriberTemplate(subscriberFactory);
 
     this.pubSubSubscriberTemplate.pull("sub2", 1, true);
@@ -322,7 +325,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPull_AndManualAck()
+  void testPull_AndManualAck()
       throws InterruptedException, ExecutionException, TimeoutException {
 
     List<AcknowledgeablePubsubMessage> result = this.pubSubSubscriberTemplate.pull("sub2", 1, true);
@@ -350,7 +353,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPull_AndManualNack()
+  void testPull_AndManualNack()
       throws InterruptedException, ExecutionException, TimeoutException {
     List<AcknowledgeablePubsubMessage> result = this.pubSubSubscriberTemplate.pull("sub2", 1, true);
 
@@ -377,7 +380,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPull_AndManualMultiSubscriptionAck()
+  void testPull_AndManualMultiSubscriptionAck()
       throws InterruptedException, ExecutionException, TimeoutException {
     ExecutorService mockExecutor = Mockito.mock(ExecutorService.class);
     this.pubSubSubscriberTemplate.setAckExecutor(mockExecutor);
@@ -406,7 +409,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPullAsync_AndManualAck()
+  void testPullAsync_AndManualAck()
       throws InterruptedException, ExecutionException, TimeoutException {
 
     ListenableFuture<List<AcknowledgeablePubsubMessage>> asyncResult =
@@ -440,7 +443,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPullAndAck() {
+  void testPullAndAck() {
     List<PubsubMessage> result = this.pubSubSubscriberTemplate.pullAndAck("sub2", 1, true);
 
     assertThat(result).hasSize(1);
@@ -452,7 +455,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPullAndAck_NoMessages() {
+  void testPullAndAck_NoMessages() {
     when(this.pullCallable.call(any(PullRequest.class)))
         .thenReturn(PullResponse.newBuilder().build());
 
@@ -464,7 +467,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPullAndAckAsync()
+  void testPullAndAckAsync()
       throws InterruptedException, ExecutionException, TimeoutException {
     ListenableFuture<List<PubsubMessage>> asyncResult =
         this.pubSubSubscriberTemplate.pullAndAckAsync("sub2", 1, true);
@@ -481,7 +484,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPullAndAckAsync_NoMessages()
+  void testPullAndAckAsync_NoMessages()
       throws InterruptedException, ExecutionException, TimeoutException {
     when(this.pullApiFuture.get()).thenReturn(PullResponse.newBuilder().build());
 
@@ -497,7 +500,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPullAndConvert() {
+  void testPullAndConvert() {
     List<ConvertedAcknowledgeablePubsubMessage<BigInteger>> result =
         this.pubSubSubscriberTemplate.pullAndConvert("sub2", 1, true, BigInteger.class);
 
@@ -510,7 +513,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPullAndConvertAsync()
+  void testPullAndConvertAsync()
       throws InterruptedException, ExecutionException, TimeoutException {
     ListenableFuture<List<ConvertedAcknowledgeablePubsubMessage<BigInteger>>> asyncResult =
         this.pubSubSubscriberTemplate.pullAndConvertAsync("sub2", 1, true, BigInteger.class);
@@ -528,7 +531,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPullNext() {
+  void testPullNext() {
 
     PubsubMessage message = this.pubSubSubscriberTemplate.pullNext("sub2");
 
@@ -539,7 +542,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPullNext_NoMessages() {
+  void testPullNext_NoMessages() {
     when(this.pullCallable.call(any(PullRequest.class)))
         .thenReturn(PullResponse.newBuilder().build());
 
@@ -552,7 +555,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPullNextAsync()
+  void testPullNextAsync()
       throws InterruptedException, ExecutionException, TimeoutException {
     ListenableFuture<PubsubMessage> asyncResult =
         this.pubSubSubscriberTemplate.pullNextAsync("sub2");
@@ -567,7 +570,7 @@ public class PubSubSubscriberTemplateTests {
   }
 
   @Test
-  public void testPullNextAsync_NoMessages()
+  void testPullNextAsync_NoMessages()
       throws InterruptedException, ExecutionException, TimeoutException {
     when(this.pullApiFuture.get()).thenReturn(PullResponse.newBuilder().build());
 

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubMessageSourceTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubMessageSourceTests.java
@@ -30,11 +30,13 @@ import com.google.cloud.spring.pubsub.support.converter.ConvertedAcknowledgeable
 import com.google.pubsub.v1.PubsubMessage;
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.endpoint.MessageSourcePollingTemplate;
@@ -46,8 +48,9 @@ import org.springframework.messaging.MessageHandlingException;
  *
  * @since 1.2
  */
-@RunWith(MockitoJUnitRunner.class)
-public class PubSubMessageSourceTests {
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PubSubMessageSourceTests {
 
   private PubSubSubscriberOperations mockPubSubSubscriberOperations;
 
@@ -57,8 +60,8 @@ public class PubSubMessageSourceTests {
 
   @Mock private ConvertedAcknowledgeablePubsubMessage<String> msg3;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     this.mockPubSubSubscriberOperations = mock(PubSubSubscriberOperations.class);
 
     when(this.msg1.getPayload()).thenReturn("msg1");
@@ -74,7 +77,7 @@ public class PubSubMessageSourceTests {
   }
 
   @Test
-  public void doReceive_returnsNullWhenNoMessagesAvailable() {
+  void doReceive_returnsNullWhenNoMessagesAvailable() {
     when(this.mockPubSubSubscriberOperations.pullAndConvert("sub1", 1, true, String.class))
         .thenReturn(Collections.emptyList());
 
@@ -90,7 +93,7 @@ public class PubSubMessageSourceTests {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void doReceive_callsPubsubAndCachesCorrectly() {
+  void doReceive_callsPubsubAndCachesCorrectly() {
     when(this.mockPubSubSubscriberOperations.pullAndConvert("sub1", 3, true, String.class))
         .thenReturn(Arrays.asList(this.msg1, this.msg2, this.msg3));
     PubSubMessageSource pubSubMessageSource =
@@ -115,7 +118,7 @@ public class PubSubMessageSourceTests {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void doReceive_pullsOneAtAtimeWhenMaxFetchSizeZero() {
+  void doReceive_pullsOneAtAtimeWhenMaxFetchSizeZero() {
     PubSubMessageSource pubSubMessageSource =
         new PubSubMessageSource(this.mockPubSubSubscriberOperations, "sub1");
     pubSubMessageSource.setPayloadType(String.class);
@@ -131,7 +134,7 @@ public class PubSubMessageSourceTests {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void doReceive_pullsOneAtAtimeWhenMaxFetchSizeNegative() {
+  void doReceive_pullsOneAtAtimeWhenMaxFetchSizeNegative() {
     PubSubMessageSource pubSubMessageSource =
         new PubSubMessageSource(this.mockPubSubSubscriberOperations, "sub1");
     pubSubMessageSource.setPayloadType(String.class);
@@ -147,7 +150,7 @@ public class PubSubMessageSourceTests {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void doReceive_manualAckModeAppliesAcknowledgmentHeaderAndDoesNotAck() {
+  void doReceive_manualAckModeAppliesAcknowledgmentHeaderAndDoesNotAck() {
 
     PubSubMessageSource pubSubMessageSource =
         new PubSubMessageSource(this.mockPubSubSubscriberOperations, "sub1");
@@ -173,7 +176,7 @@ public class PubSubMessageSourceTests {
   }
 
   @Test
-  public void doReceive_autoModeAcksAndAddsOriginalMessageHeader() {
+  void doReceive_autoModeAcksAndAddsOriginalMessageHeader() {
 
     PubSubMessageSource pubSubMessageSource =
         new PubSubMessageSource(this.mockPubSubSubscriberOperations, "sub1");
@@ -194,7 +197,7 @@ public class PubSubMessageSourceTests {
   }
 
   @Test
-  public void doReceive_autoAckModeAcksAndAddsOriginalMessageHeader() {
+  void doReceive_autoAckModeAcksAndAddsOriginalMessageHeader() {
 
     PubSubMessageSource pubSubMessageSource =
         new PubSubMessageSource(this.mockPubSubSubscriberOperations, "sub1");
@@ -215,7 +218,7 @@ public class PubSubMessageSourceTests {
   }
 
   @Test
-  public void doReceive_autoAckModeIsDefault() {
+  void doReceive_autoAckModeIsDefault() {
     PubSubMessageSource pubSubMessageSource =
         new PubSubMessageSource(this.mockPubSubSubscriberOperations, "sub1");
     pubSubMessageSource.setMaxFetchSize(1);
@@ -235,7 +238,7 @@ public class PubSubMessageSourceTests {
   }
 
   @Test
-  public void doReceive_autoModeNacksAutomatically() {
+  void doReceive_autoModeNacksAutomatically() {
 
     PubSubMessageSource pubSubMessageSource =
         new PubSubMessageSource(this.mockPubSubSubscriberOperations, "sub1");
@@ -257,7 +260,7 @@ public class PubSubMessageSourceTests {
   }
 
   @Test
-  public void doReceive_autoAckModeDoesNotNackAutomatically() {
+  void doReceive_autoAckModeDoesNotNackAutomatically() {
 
     PubSubMessageSource pubSubMessageSource =
         new PubSubMessageSource(this.mockPubSubSubscriberOperations, "sub1");
@@ -280,7 +283,7 @@ public class PubSubMessageSourceTests {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void blockOnPullSetsReturnImmediatelyToFalse() {
+  void blockOnPullSetsReturnImmediatelyToFalse() {
 
     when(this.mockPubSubSubscriberOperations.pullAndConvert("sub1", 1, false, String.class))
         .thenReturn(Collections.singletonList(msg1));

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/outbound/PubSubMessageHandlerTests.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spring.pubsub.integration.outbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,13 +33,13 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.expression.ValueExpression;
@@ -48,8 +49,9 @@ import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.util.concurrent.SettableListenableFuture;
 
 /** Tests for the Pub/Sub message handler. */
-@RunWith(MockitoJUnitRunner.class)
-public class PubSubMessageHandlerTests {
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PubSubMessageHandlerTests {
 
   @Mock private PubSubOperations pubSubTemplate;
 
@@ -57,11 +59,8 @@ public class PubSubMessageHandlerTests {
 
   private Message<?> message;
 
-  /** used to check exception messages and types. */
-  @Rule public ExpectedException expectedException = ExpectedException.none();
-
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     this.message =
         new GenericMessage<byte[]>(
             "testPayload".getBytes(),
@@ -74,13 +73,13 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void testPublish() {
+  void testPublish() {
     this.adapter.handleMessage(this.message);
     verify(this.pubSubTemplate).publish(eq("testTopic"), eq("testPayload".getBytes()), anyMap());
   }
 
   @Test
-  public void testPublishDynamicTopic() {
+  void testPublishDynamicTopic() {
     Message<?> dynamicMessage =
         new GenericMessage<byte[]>(
             "testPayload".getBytes(),
@@ -94,7 +93,7 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void testSendToExpressionTopic() {
+  void testSendToExpressionTopic() {
     this.adapter.setTopicExpressionString("headers['sendToTopic']");
     this.adapter.onInit();
     Message<?> expressionMessage =
@@ -111,7 +110,7 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void testPublishSync() {
+  void testPublishSync() {
     this.adapter.setSync(true);
     Expression timeout = spy(this.adapter.getPublishTimeoutExpression());
     this.adapter.setPublishTimeoutExpression(timeout);
@@ -121,7 +120,7 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void testPublishCallback() {
+  void testPublishCallback() {
     ListenableFutureCallback<String> callbackSpy =
         spy(
             new ListenableFutureCallback<String>() {
@@ -142,15 +141,15 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void testSetPublishTimeoutExpressionStringWithNull() {
-    this.expectedException.expect(IllegalArgumentException.class);
-    this.expectedException.expectMessage("Publish timeout expression can't be null.");
+  void testSetPublishTimeoutExpressionStringWithNull() {
 
-    this.adapter.setPublishTimeoutExpressionString(null);
+    assertThatThrownBy(() -> this.adapter.setPublishTimeoutExpressionString(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Publish timeout expression can't be null.");
   }
 
   @Test
-  public void testPublishTimeoutExpressionString() {
+  void testPublishTimeoutExpressionString() {
     String expressionString = "15";
 
     this.adapter.setPublishTimeoutExpressionString(expressionString);
@@ -161,7 +160,7 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void testPublishTimeout() {
+  void testPublishTimeout() {
     long timeout = 15;
 
     this.adapter.setPublishTimeout(timeout);
@@ -172,7 +171,7 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void testIsSync() {
+  void testIsSync() {
     this.adapter.setSync(true);
 
     assertThat(this.adapter.isSync()).isTrue();
@@ -183,15 +182,16 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void testTopicWithNull() {
-    this.expectedException.expect(IllegalArgumentException.class);
-    this.expectedException.expectMessage("The topic can't be null or empty");
+  void testTopicWithNull() {
 
-    this.adapter.setTopic(null);
+    assertThatThrownBy(() -> this.adapter.setTopic(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The topic can't be null or empty");
+
   }
 
   @Test
-  public void testTopic() {
+  void testTopic() {
     String topic = "pubsub";
     this.adapter.setTopic(topic);
 
@@ -202,7 +202,7 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void testTopicExpression() {
+  void testTopicExpression() {
     Expression expected = new ValueExpression<>("topic");
 
     this.adapter.setTopicExpression(expected);
@@ -211,15 +211,15 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void testSetHeaderMapperWithNull() {
-    this.expectedException.expect(IllegalArgumentException.class);
-    this.expectedException.expectMessage("The header mapper can't be null.");
+  void testSetHeaderMapperWithNull() {
 
-    this.adapter.setHeaderMapper(null);
+    assertThatThrownBy(() ->  this.adapter.setHeaderMapper(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The header mapper can't be null.");
   }
 
   @Test
-  public void testPublishWithOrderingKey() {
+  void testPublishWithOrderingKey() {
     this.message =
         new GenericMessage<byte[]>(
             "testPayload".getBytes(),
@@ -234,7 +234,7 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void publishWithSuccessCallback() throws Exception {
+  void publishWithSuccessCallback() throws Exception {
 
     SettableListenableFuture<String> future = new SettableListenableFuture<>();
     future.set("published12345");
@@ -261,7 +261,7 @@ public class PubSubMessageHandlerTests {
   }
 
   @Test
-  public void publishWithFailureCallback() throws Exception {
+  void publishWithFailureCallback() throws Exception {
 
     SettableListenableFuture<String> future = new SettableListenableFuture<>();
     future.setException(new RuntimeException("boom!"));

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/reactive/PubSubReactiveFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/reactive/PubSubReactiveFactoryTests.java
@@ -36,13 +36,13 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.annotation.AsyncResult;
 import reactor.test.StepVerifier;
 import reactor.test.scheduler.VirtualTimeScheduler;
@@ -52,20 +52,20 @@ import reactor.test.scheduler.VirtualTimeScheduler;
  *
  * @since 1.2
  */
-@RunWith(MockitoJUnitRunner.class)
-public class PubSubReactiveFactoryTests {
+@ExtendWith(MockitoExtension.class)
+class PubSubReactiveFactoryTests {
 
   @Mock PubSubSubscriberOperations subscriberOperations;
 
   PubSubReactiveFactory factory;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     factory = new PubSubReactiveFactory(subscriberOperations, VirtualTimeScheduler.getOrSet());
   }
 
   @Test
-  public void testIllegalArgumentExceptionWithMaxMessagesLessThanOne() {
+  void testIllegalArgumentExceptionWithMaxMessagesLessThanOne() {
     VirtualTimeScheduler vts = VirtualTimeScheduler.getOrSet();
     assertThatThrownBy(() -> new PubSubReactiveFactory(subscriberOperations, vts, 0))
         .isInstanceOf(IllegalArgumentException.class)
@@ -73,7 +73,7 @@ public class PubSubReactiveFactoryTests {
   }
 
   @Test
-  public void testSequentialRequests() throws InterruptedException {
+  void testSequentialRequests() throws InterruptedException {
     setUpMessages("msg1", "msg2", "msg3", "msg4");
 
     StepVerifier.withVirtualTime(() -> factory.poll("sub1", 10).map(this::messageToString), 1)
@@ -92,7 +92,7 @@ public class PubSubReactiveFactoryTests {
   }
 
   @Test
-  public void testSequentialRequestWithInsufficientDemandGetsSplitIntoTwoRequests()
+  void testSequentialRequestWithInsufficientDemandGetsSplitIntoTwoRequests()
       throws InterruptedException {
     setUpMessages("msg1", "stop", "msg2", "msg3", "msg4");
 
@@ -110,7 +110,7 @@ public class PubSubReactiveFactoryTests {
   }
 
   @Test
-  public void testDeadlineExceededCausesRetry() throws InterruptedException {
+  void testDeadlineExceededCausesRetry() throws InterruptedException {
     setUpMessages("timeout", "msg1", "msg2");
 
     StepVerifier.withVirtualTime(() -> factory.poll("sub1", 10).map(this::messageToString), 2)
@@ -126,7 +126,7 @@ public class PubSubReactiveFactoryTests {
   }
 
   @Test
-  public void testExceptionThrownByPubSubClientResultingInErrorStream()
+  void testExceptionThrownByPubSubClientResultingInErrorStream()
       throws InterruptedException {
     setUpMessages("msg1", "msg2", "throw");
 
@@ -143,7 +143,7 @@ public class PubSubReactiveFactoryTests {
   }
 
   @Test
-  public void testUnlimitedDemand() throws InterruptedException {
+  void testUnlimitedDemand() throws InterruptedException {
     setUpMessages("msg1", "msg2", "stop", "msg3", "msg4", "stop", "msg5", "stop");
 
     StepVerifier.withVirtualTime(() -> factory.poll("sub1", 10).map(this::messageToString))
@@ -164,7 +164,7 @@ public class PubSubReactiveFactoryTests {
   }
 
   @Test
-  public void testUnlimitedDemandWithMaxMessages() throws InterruptedException {
+  void testUnlimitedDemandWithMaxMessages() throws InterruptedException {
     setUpMessages("msg1", "msg2", "stop", "msg3", "stop", "msg4", "msg5", "msg6", "stop");
 
     PubSubReactiveFactory factory =
@@ -188,7 +188,7 @@ public class PubSubReactiveFactoryTests {
   }
 
   @Test
-  public void testUnlimitedDemandWithException() throws InterruptedException {
+  void testUnlimitedDemandWithException() throws InterruptedException {
     setUpMessages("msg1", "msg2", "stop", "throw");
 
     StepVerifier.withVirtualTime(() -> factory.poll("sub1", 10).map(this::messageToString))

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/CachingPublisherFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/CachingPublisherFactoryTests.java
@@ -22,14 +22,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.pubsub.v1.Publisher;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /** Tests for the {@link CachingPublisherFactory}. */
-@RunWith(MockitoJUnitRunner.class)
-public class CachingPublisherFactoryTests {
+@ExtendWith(MockitoExtension.class)
+class CachingPublisherFactoryTests {
 
   @Mock private PublisherFactory delegate;
 
@@ -38,7 +38,7 @@ public class CachingPublisherFactoryTests {
   @Mock private Publisher publisher2;
 
   @Test
-  public void testGetPublisherCaching() {
+  void testGetPublisherCaching() {
     CachingPublisherFactory cachingPublisherFactory = new CachingPublisherFactory(delegate);
 
     when(delegate.createPublisher("topic1")).thenReturn(publisher1);

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -47,18 +47,16 @@ import com.google.pubsub.v1.PullRequest;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.threeten.bp.Duration;
 
 /** Tests for the subscriber factory. */
-@RunWith(MockitoJUnitRunner.class)
-public class DefaultSubscriberFactoryTests {
+@ExtendWith(MockitoExtension.class)
+class DefaultSubscriberFactoryTests {
 
   @Mock private ExecutorProvider mockExecutorProvider;
 
@@ -76,18 +74,8 @@ public class DefaultSubscriberFactoryTests {
 
   @Mock private HealthTrackerRegistry healthTrackerRegistry;
 
-  /** used to check exception messages and types. */
-  @Rule public ExpectedException expectedException = ExpectedException.none();
-
-  @Before
-  public void setUp() {
-    when(this.mockTransportChannel.getEmptyCallContext()).thenReturn(this.mockApiCallContext);
-    when(this.mockApiCallContext.withCredentials(any())).thenReturn(this.mockApiCallContext);
-    when(this.mockApiCallContext.withTransportChannel(any())).thenReturn(this.mockApiCallContext);
-  }
-
   @Test
-  public void testNewSubscriber() {
+  void testNewSubscriber() {
     DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "angeldust");
     factory.setCredentialsProvider(this.credentialsProvider);
 
@@ -98,7 +86,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testNewSubscriber_constructorWithPubSubConfiguration() {
+  void testNewSubscriber_constructorWithPubSubConfiguration() {
     GcpProjectIdProvider projectIdProvider = () -> "angeldust";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
@@ -111,38 +99,42 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testNewSubscriber_constructorWithPubSubConfiguration_nullPubSubConfiguration() {
-    this.expectedException.expect(IllegalArgumentException.class);
-    this.expectedException.expectMessage("The pub/sub configuration can't be null.");
-    new DefaultSubscriberFactory(() -> "angeldust", null);
+  void testNewSubscriber_constructorWithPubSubConfiguration_nullPubSubConfiguration() {
+
+    assertThatThrownBy(() -> new DefaultSubscriberFactory(() -> "angeldust", null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The pub/sub configuration can't be null.");
   }
 
   @Test
-  public void testNewDefaultSubscriberFactory_nullProjectProvider() {
-    this.expectedException.expect(IllegalArgumentException.class);
-    this.expectedException.expectMessage("The project ID provider can't be null.");
-    new DefaultSubscriberFactory(null);
+  void testNewDefaultSubscriberFactory_nullProjectProvider() {
+
+    assertThatThrownBy(() -> new DefaultSubscriberFactory(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The project ID provider can't be null.");
   }
 
   @Test
-  public void testNewDefaultSubscriberFactory_nullProject() {
-    this.expectedException.expect(IllegalArgumentException.class);
-    this.expectedException.expectMessage("The project ID can't be null or empty.");
-    new DefaultSubscriberFactory(() -> null);
+  void testNewDefaultSubscriberFactory_nullProject() {
+
+    assertThatThrownBy(() -> new DefaultSubscriberFactory(() -> null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The project ID can't be null or empty.");
+
   }
 
   @Test
-  public void testCreatePullRequest_greaterThanZeroMaxMessages() {
+  void testCreatePullRequest_greaterThanZeroMaxMessages() {
     DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project");
     factory.setCredentialsProvider(this.credentialsProvider);
 
-    this.expectedException.expect(IllegalArgumentException.class);
-    this.expectedException.expectMessage("The maxMessages must be greater than 0.");
-    factory.createPullRequest("test", -1, true);
+    assertThatThrownBy(() -> factory.createPullRequest("test", -1, true))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The maxMessages must be greater than 0.");
   }
 
   @Test
-  public void testCreatePullRequest_nonNullMaxMessages() {
+  void testCreatePullRequest_nonNullMaxMessages() {
     DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "project");
     factory.setCredentialsProvider(this.credentialsProvider);
 
@@ -151,7 +143,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetExecutorProvider_userProvidedBean() {
+  void testGetExecutorProvider_userProvidedBean() {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
     factory.setExecutorProvider(mockExecutorProvider);
@@ -159,7 +151,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetExecutorProvider_presentInMap() {
+  void testGetExecutorProvider_presentInMap() {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
@@ -172,7 +164,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetExecutorProvider_fullyQualifiedNameNotInMap_pickGlobal() {
+  void testGetExecutorProvider_fullyQualifiedNameNotInMap_pickGlobal() {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
@@ -187,7 +179,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetExecutorProvider_notPresentInMap_pickGlobal() {
+  void testGetExecutorProvider_notPresentInMap_pickGlobal() {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
     factory.setExecutorProvider(mockGlobalExecutorProvider);
@@ -196,7 +188,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetRetrySettings_userProvidedBean() {
+  void testGetRetrySettings_userProvidedBean() {
     RetrySettings expectedRetrySettings =
         RetrySettings.newBuilder()
             .setTotalTimeout(Duration.ofSeconds(10))
@@ -225,7 +217,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetRetrySettings_presentInMap_pickSelective() {
+  void testGetRetrySettings_presentInMap_pickSelective() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
@@ -257,7 +249,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetRetrySettings_notPresentInMap_pickGlobal() {
+  void testGetRetrySettings_notPresentInMap_pickGlobal() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
@@ -287,7 +279,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testBuildGlobalSubscriberStubSettings_retry_pickUserBean() throws IOException {
+  void testBuildGlobalSubscriberStubSettings_retry_pickUserBean() throws IOException {
     RetrySettings expectedRetrySettings =
         RetrySettings.newBuilder()
             .setTotalTimeout(Duration.ofSeconds(10L))
@@ -317,7 +309,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testBuildGlobalSubscriberStubSettings_retry_pickGlobalConfiguration()
+  void testBuildGlobalSubscriberStubSettings_retry_pickGlobalConfiguration()
       throws IOException {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
@@ -349,7 +341,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testCreateSubscriber_validateSetProperties() {
+  void testCreateSubscriber_validateSetProperties() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
@@ -377,7 +369,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetFlowControlSettings_userProvidedBean() {
+  void testGetFlowControlSettings_userProvidedBean() {
     FlowControlSettings expectedFlowSettings =
         FlowControlSettings.newBuilder()
             .setLimitExceededBehavior(FlowController.LimitExceededBehavior.Block)
@@ -397,7 +389,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetFlowControlSettings_presentInMap_pickSubscriptionSpecific() {
+  void testGetFlowControlSettings_presentInMap_pickSubscriptionSpecific() {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
@@ -415,7 +407,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetFlowControlSettings_notPresentInMap_pickGlobal() {
+  void testGetFlowControlSettings_notPresentInMap_pickGlobal() {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
@@ -431,7 +423,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetMaxAckExtensionPeriod_userSetValue() {
+  void testGetMaxAckExtensionPeriod_userSetValue() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
@@ -442,7 +434,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetMaxAckExtensionPeriod_configurationIsPresent() {
+  void testGetMaxAckExtensionPeriod_configurationIsPresent() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
@@ -455,7 +447,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetMaxAckExtensionPeriod_newConfiguration() {
+  void testGetMaxAckExtensionPeriod_newConfiguration() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
@@ -465,7 +457,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetParallelPullCount_userSetValue() {
+  void testGetParallelPullCount_userSetValue() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
@@ -475,7 +467,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetParallelPullCount_configurationIsPresent() {
+  void testGetParallelPullCount_configurationIsPresent() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
@@ -487,7 +479,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetParallelPullCount_newConfiguration() {
+  void testGetParallelPullCount_newConfiguration() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
@@ -496,7 +488,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetPullEndpoint_userSetValue() {
+  void testGetPullEndpoint_userSetValue() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
@@ -506,7 +498,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetPullEndpoint_configurationIsPresent() {
+  void testGetPullEndpoint_configurationIsPresent() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
@@ -518,7 +510,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testGetPullEndpoint_newConfiguration() {
+  void testGetPullEndpoint_newConfiguration() {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", new PubSubConfiguration());
 
@@ -526,7 +518,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testBuildGlobalSubscriberStubSettings_pullEndpoint_pickUserProvidedBean()
+  void testBuildGlobalSubscriberStubSettings_pullEndpoint_pickUserProvidedBean()
       throws IOException {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", new PubSubConfiguration());
@@ -536,7 +528,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testBuildGlobalSubscriberStubSettings_pullEndpoint_pickGlobalConfiguration()
+  void testBuildGlobalSubscriberStubSettings_pullEndpoint_pickGlobalConfiguration()
       throws IOException {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
@@ -548,7 +540,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testBuildSubscriberStubSettings_retryableCodes_pickUserProvidedValue()
+  void testBuildSubscriberStubSettings_retryableCodes_pickUserProvidedValue()
       throws IllegalAccessException, IOException {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
@@ -563,7 +555,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testBuildSubscriberStubSettings_retryableCodes_pickConfiguration()
+  void testBuildSubscriberStubSettings_retryableCodes_pickConfiguration()
       throws IllegalAccessException, IOException {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
@@ -579,7 +571,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testBuildGlobalSubscriberStubSettings_retryableCodes_userProvidedValue()
+  void testBuildGlobalSubscriberStubSettings_retryableCodes_userProvidedValue()
       throws IOException, IllegalAccessException {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
@@ -594,7 +586,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testBuildGlobalSubscriberStubSettings_retryableCodes_pickConfiguration()
+  void testBuildGlobalSubscriberStubSettings_retryableCodes_pickConfiguration()
       throws IOException {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
@@ -607,7 +599,12 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void createSubscriberStubSucceeds_noSubscriptionNameAndNewConfiguration() {
+  void createSubscriberStubSucceeds_noSubscriptionNameAndNewConfiguration() {
+
+    when(this.mockTransportChannel.getEmptyCallContext()).thenReturn(this.mockApiCallContext);
+    when(this.mockApiCallContext.withCredentials(any())).thenReturn(this.mockApiCallContext);
+    when(this.mockApiCallContext.withTransportChannel(any())).thenReturn(this.mockApiCallContext);
+
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
@@ -619,7 +616,12 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void createSubscriberStubSucceeds() {
+  void createSubscriberStubSucceeds() {
+
+    when(this.mockTransportChannel.getEmptyCallContext()).thenReturn(this.mockApiCallContext);
+    when(this.mockApiCallContext.withCredentials(any())).thenReturn(this.mockApiCallContext);
+    when(this.mockApiCallContext.withTransportChannel(any())).thenReturn(this.mockApiCallContext);
+
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
@@ -631,7 +633,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void createSubscriberStubFailsOnBadCredentials() throws IOException {
+  void createSubscriberStubFailsOnBadCredentials() throws IOException {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
@@ -648,7 +650,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testNewSubscriber_shouldNotAddToHealthCheck() {
+  void testNewSubscriber_shouldNotAddToHealthCheck() {
     ProjectSubscriptionName subscriptionName =
         ProjectSubscriptionName.of("angeldust", "midnight cowboy");
 
@@ -667,7 +669,7 @@ public class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  public void testNewSubscriber_shouldAddToHealthCheck() {
+  void testNewSubscriber_shouldAddToHealthCheck() {
     ProjectSubscriptionName subscriptionName =
         ProjectSubscriptionName.of("angeldust", "midnight cowboy");
 

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/converter/SimplePubSubMessageConverterTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/converter/SimplePubSubMessageConverterTests.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spring.pubsub.support.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.cloud.spring.core.util.MapBuilder;
 import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
@@ -28,80 +29,75 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.convert.converter.Converter;
 
 /** Tests for the simple message converter. */
-public class SimplePubSubMessageConverterTests {
+class SimplePubSubMessageConverterTests {
 
   private static final String TEST_STRING = "test";
 
   private static final Map<String, String> TEST_HEADERS =
       new MapBuilder<String, String>().put("key1", "value1").put("key2", "value2").build();
 
-  /** used to test exception messages and types. */
-  @Rule public ExpectedException expectedException = ExpectedException.none();
-
   @Test
-  public void testToString() {
+  void testToString() {
     doToTestForType(String.class, a -> a);
   }
 
   @Test
-  public void testFromString() {
+  void testFromString() {
     doFromTest(TEST_STRING);
   }
 
   @Test
-  public void testToByteString() {
+  void testToByteString() {
     doToTestForType(ByteString.class, a -> new String(a.toByteArray()));
   }
 
   @Test
-  public void testFromByteString() {
+  void testFromByteString() {
     doFromTest(ByteString.copyFrom(TEST_STRING.getBytes()));
   }
 
   @Test
-  public void testToByteArray() {
+  void testToByteArray() {
     doToTestForType(byte[].class, a -> new String(a));
   }
 
   @Test
-  public void testFromByteArray() {
+  void testFromByteArray() {
     doFromTest(TEST_STRING.getBytes());
   }
 
   @Test
-  public void testToByteBuffer() {
+  void testToByteBuffer() {
     doToTestForType(ByteBuffer.class, a -> new String(a.array()));
   }
 
   @Test
-  public void testFromByteBuffer() {
+  void testFromByteBuffer() {
     doFromTest(ByteBuffer.wrap(TEST_STRING.getBytes()));
   }
 
   @Test
-  public void testToUnknown() {
-    this.expectedException.expect(PubSubMessageConversionException.class);
-    this.expectedException.expectMessage(
-        "Unable to convert Pub/Sub message to " + "payload of type java.lang.Integer.");
-    doToTestForType(Integer.class, a -> toString());
+  void testToUnknown() {
+
+    assertThatThrownBy(() -> doToTestForType(Integer.class, a -> toString()))
+            .isInstanceOf(PubSubMessageConversionException.class)
+            .hasMessage("Unable to convert Pub/Sub message to " + "payload of type java.lang.Integer.");
   }
 
   @Test
-  public void testFromUnknown() {
-    this.expectedException.expect(PubSubMessageConversionException.class);
-    this.expectedException.expectMessage(
-        "Unable to convert payload of type java.lang.Class " + "to byte[] for sending to Pub/Sub.");
-    doFromTest(Integer.class);
+  void testFromUnknown() {
+
+    assertThatThrownBy(() ->   doFromTest(Integer.class))
+            .isInstanceOf(PubSubMessageConversionException.class)
+            .hasMessage("Unable to convert payload of type java.lang.Class " + "to byte[] for sending to Pub/Sub.");
   }
 
   @Test
-  public void testNullHeaders() {
+  void testNullHeaders() {
     SimplePubSubMessageConverter converter = new SimplePubSubMessageConverter();
     PubsubMessage pubsubMessage = converter.toPubSubMessage(TEST_STRING, null);
 
@@ -137,7 +133,7 @@ public class SimplePubSubMessageConverterTests {
   }
 
   @Test
-  public void testOrderingKeyHeader() throws JSONException {
+  void testOrderingKeyHeader() throws JSONException {
     SimplePubSubMessageConverter converter = new SimplePubSubMessageConverter();
     PubsubMessage pubsubMessage =
         converter.toPubSubMessage(


### PR DESCRIPTION
Tests Migrated:

1. PubSubMessageChannelBinderTests.java
2. PubSubBinderConfigurationTests.java
3. PubSubExtendedBindingsPropertiesTests.java
4. PubSubChannelProvisionerTests.java
5. PubSubSubscriberTemplateTests.java
6. PubSubMessageSourceTests.java
7.  PubSubMessageHandlerTests.java
8.  PubSubReactiveFactoryTests.java
9.  CachingPublisherFactoryTests.java
10. DefaultSubscriberFactoryTests.java
11. SimplePubSubMessageConverterTests.java
