### PR TITLE
Migrating "spring-cloud-gcp-vision" tests to JUnit5

### DIFF
--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/CloudVisionTemplateTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/CloudVisionTemplateTests.java
@@ -18,6 +18,7 @@ package com.google.cloud.spring.vision;
 
 import static com.google.cloud.spring.vision.CloudVisionTemplate.EMPTY_RESPONSE_ERROR_MESSAGE;
 import static com.google.cloud.spring.vision.CloudVisionTemplate.READ_BYTES_ERROR_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -42,10 +43,8 @@ import com.google.rpc.Status;
 import io.grpc.Status.Code;
 import java.io.IOException;
 import java.io.InputStream;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.ByteArrayResource;
@@ -56,10 +55,7 @@ import org.springframework.core.io.Resource;
  *
  * @since 1.1
  */
-public class CloudVisionTemplateTests {
-
-  /** Used to test exception messages and types. * */
-  @Rule public ExpectedException expectedException = ExpectedException.none();
+class CloudVisionTemplateTests {
 
   // Resource representing a fake image blob
   private static final Resource FAKE_IMAGE = new ByteArrayResource("fake_image".getBytes());
@@ -82,14 +78,14 @@ public class CloudVisionTemplateTests {
 
   private CloudVisionTemplate cloudVisionTemplate;
 
-  @Before
-  public void setupVisionTemplateMock() {
+  @BeforeEach
+  void setupVisionTemplateMock() {
     this.imageAnnotatorClient = Mockito.mock(ImageAnnotatorClient.class);
     this.cloudVisionTemplate = new CloudVisionTemplate(this.imageAnnotatorClient);
   }
 
   @Test
-  public void testAddImageContext_analyzeImage() throws IOException {
+  void testAddImageContext_analyzeImage() throws IOException {
     when(this.imageAnnotatorClient.batchAnnotateImages(any(BatchAnnotateImagesRequest.class)))
         .thenReturn(DEFAULT_API_RESPONSE);
 
@@ -113,7 +109,7 @@ public class CloudVisionTemplateTests {
   }
 
   @Test
-  public void testAddImageContext_extractText() throws IOException {
+  void testAddImageContext_extractText() throws IOException {
     when(this.imageAnnotatorClient.batchAnnotateImages(any(BatchAnnotateImagesRequest.class)))
         .thenReturn(DEFAULT_API_RESPONSE);
 
@@ -137,7 +133,7 @@ public class CloudVisionTemplateTests {
   }
 
   @Test
-  public void testAddInputConfig_extractText() throws IOException {
+  void testAddInputConfig_extractText() throws IOException {
     when(this.imageAnnotatorClient.batchAnnotateFiles(any(BatchAnnotateFilesRequest.class)))
         .thenReturn(DEFAULT_FILES_API_RESPONSE);
 
@@ -160,29 +156,28 @@ public class CloudVisionTemplateTests {
   }
 
   @Test
-  public void testEmptyClientResponseError() {
+  void testEmptyClientResponseError() {
     when(this.imageAnnotatorClient.batchAnnotateImages(any(BatchAnnotateImagesRequest.class)))
         .thenReturn(BatchAnnotateImagesResponse.getDefaultInstance());
 
-    this.expectedException.expect(CloudVisionException.class);
-    this.expectedException.expectMessage(EMPTY_RESPONSE_ERROR_MESSAGE);
-
-    this.cloudVisionTemplate.analyzeImage(FAKE_IMAGE, Type.TEXT_DETECTION);
+    assertThatThrownBy(() -> this.cloudVisionTemplate.analyzeImage(FAKE_IMAGE, Type.TEXT_DETECTION))
+            .isInstanceOf(CloudVisionException.class)
+            .hasMessage(EMPTY_RESPONSE_ERROR_MESSAGE);
   }
 
   @Test
-  public void testEmptyClientAnnotateFileResponseError() {
+  void testEmptyClientAnnotateFileResponseError() {
     when(this.imageAnnotatorClient.batchAnnotateFiles(any(BatchAnnotateFilesRequest.class)))
         .thenReturn(BatchAnnotateFilesResponse.getDefaultInstance());
 
-    this.expectedException.expect(CloudVisionException.class);
-    this.expectedException.expectMessage(EMPTY_RESPONSE_ERROR_MESSAGE);
+    assertThatThrownBy(() ->  this.cloudVisionTemplate.analyzeFile(FAKE_PDF, "application/pdf", Type.TEXT_DETECTION))
+            .isInstanceOf(CloudVisionException.class)
+            .hasMessage(EMPTY_RESPONSE_ERROR_MESSAGE);
 
-    this.cloudVisionTemplate.analyzeFile(FAKE_PDF, "application/pdf", Type.TEXT_DETECTION);
   }
 
   @Test
-  public void testExtractTextError() {
+  void testExtractTextError() {
     AnnotateImageResponse response =
         AnnotateImageResponse.newBuilder()
             .setError(
@@ -197,27 +192,26 @@ public class CloudVisionTemplateTests {
     when(this.imageAnnotatorClient.batchAnnotateImages(any(BatchAnnotateImagesRequest.class)))
         .thenReturn(responseBatch);
 
-    this.expectedException.expect(CloudVisionException.class);
-    this.expectedException.expectMessage("Error Message from Vision API.");
 
-    this.cloudVisionTemplate.extractTextFromImage(FAKE_IMAGE);
+    assertThatThrownBy(() -> this.cloudVisionTemplate.extractTextFromImage(FAKE_IMAGE))
+            .isInstanceOf(CloudVisionException.class)
+            .hasMessage("Error Message from Vision API.");
   }
 
   @Test
-  public void testResourceReadingError() {
-    this.expectedException.expect(CloudVisionException.class);
-    this.expectedException.expectMessage(READ_BYTES_ERROR_MESSAGE);
+  void testResourceReadingError() {
 
-    this.cloudVisionTemplate.analyzeImage(new BadResource(), Type.LABEL_DETECTION);
+    assertThatThrownBy(() -> this.cloudVisionTemplate.analyzeImage(new BadResource(), Type.LABEL_DETECTION))
+            .isInstanceOf(CloudVisionException.class)
+            .hasMessageContaining(READ_BYTES_ERROR_MESSAGE);
   }
 
   @Test
-  public void testFileResourceReadingError() {
-    this.expectedException.expect(CloudVisionException.class);
-    this.expectedException.expectMessage(READ_BYTES_ERROR_MESSAGE);
+  void testFileResourceReadingError() {
 
-    this.cloudVisionTemplate.analyzeFile(
-        new BadResource(), "application/pdf", Type.LABEL_DETECTION);
+    assertThatThrownBy(() ->  this.cloudVisionTemplate.analyzeFile(new BadResource(), "application/pdf", Type.LABEL_DETECTION))
+            .isInstanceOf(CloudVisionException.class)
+            .hasMessageContaining(READ_BYTES_ERROR_MESSAGE);
   }
 
   private static final class BadResource extends AbstractResource {

--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/CloudVisionTemplateTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/CloudVisionTemplateTests.java
@@ -201,7 +201,8 @@ class CloudVisionTemplateTests {
   @Test
   void testResourceReadingError() {
 
-    assertThatThrownBy(() -> this.cloudVisionTemplate.analyzeImage(new BadResource(), Type.LABEL_DETECTION))
+    Resource imageResource = new BadResource();
+    assertThatThrownBy(() -> this.cloudVisionTemplate.analyzeImage(imageResource, Type.LABEL_DETECTION))
             .isInstanceOf(CloudVisionException.class)
             .hasMessageContaining(READ_BYTES_ERROR_MESSAGE);
   }
@@ -209,7 +210,8 @@ class CloudVisionTemplateTests {
   @Test
   void testFileResourceReadingError() {
 
-    assertThatThrownBy(() ->  this.cloudVisionTemplate.analyzeFile(new BadResource(), "application/pdf", Type.LABEL_DETECTION))
+    Resource imageResource = new BadResource();
+    assertThatThrownBy(() ->  this.cloudVisionTemplate.analyzeFile(imageResource, "application/pdf", Type.LABEL_DETECTION))
             .isInstanceOf(CloudVisionException.class)
             .hasMessageContaining(READ_BYTES_ERROR_MESSAGE);
   }

--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/DocumentOcrTemplateTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/DocumentOcrTemplateTests.java
@@ -21,14 +21,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.cloud.spring.storage.GoogleStorageLocation;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.vision.v1.ImageAnnotatorClient;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-public class DocumentOcrTemplateTests {
+@ExtendWith(SpringExtension.class)
+class DocumentOcrTemplateTests {
 
   private Storage storage;
 
@@ -36,16 +36,15 @@ public class DocumentOcrTemplateTests {
 
   private DocumentOcrTemplate documentOcrTemplate;
 
-  @Before
-  public void setupDocumentTemplateMocks() {
+  @BeforeEach
+  void setupDocumentTemplateMocks() {
     this.storage = Mockito.mock(Storage.class);
     this.imageAnnotatorClient = Mockito.mock(ImageAnnotatorClient.class);
-    this.documentOcrTemplate =
-        new DocumentOcrTemplate(imageAnnotatorClient, storage, Runnable::run, 10);
+    this.documentOcrTemplate = new DocumentOcrTemplate(imageAnnotatorClient, storage, Runnable::run, 10);
   }
 
   @Test
-  public void testValidateGcsFileInputs() {
+  void testValidateGcsFileInputs() {
     GoogleStorageLocation folder = GoogleStorageLocation.forFolder("bucket", "path/to/folder/");
 
     assertThatThrownBy(() -> this.documentOcrTemplate.runOcrForDocument(folder, folder))

--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/DocumentOcrTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/DocumentOcrTemplateIntegrationTests.java
@@ -17,7 +17,6 @@
 package com.google.cloud.spring.vision.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.google.cloud.spring.storage.GoogleStorageLocation;
 import com.google.cloud.spring.vision.DocumentOcrResultSet;
@@ -29,31 +28,23 @@ import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.concurrent.ListenableFuture;
 
-@RunWith(SpringRunner.class)
+@EnabledIfSystemProperty(named = "it.vision", matches = "true")
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {VisionTestConfiguration.class})
-public class DocumentOcrTemplateIntegrationTests {
+class DocumentOcrTemplateIntegrationTests {
 
   @Autowired private DocumentOcrTemplate documentOcrTemplate;
 
-  @BeforeClass
-  public static void prepare() {
-    assumeThat(System.getProperty("it.vision"))
-        .as(
-            "Vision Sample integration tests are disabled. "
-                + "Please use '-Dit.vision=true' to enable them.")
-        .isEqualTo("true");
-  }
-
   @Test
-  public void testDocumentOcrTemplate()
+  void testDocumentOcrTemplate()
       throws ExecutionException, InterruptedException, InvalidProtocolBufferException,
           TimeoutException {
 
@@ -89,7 +80,7 @@ public class DocumentOcrTemplateIntegrationTests {
   }
 
   @Test
-  public void testParseOcrResultSet() throws InvalidProtocolBufferException {
+  void testParseOcrResultSet() throws InvalidProtocolBufferException {
     GoogleStorageLocation ocrOutputPrefix =
         GoogleStorageLocation.forFolder("vision-integration-test-bucket", "json_output_set/");
 
@@ -100,7 +91,7 @@ public class DocumentOcrTemplateIntegrationTests {
   }
 
   @Test
-  public void testParseOcrFile() throws InvalidProtocolBufferException {
+  void testParseOcrFile() throws InvalidProtocolBufferException {
     GoogleStorageLocation ocrOutputFile =
         GoogleStorageLocation.forFile(
             "vision-integration-test-bucket", "json_output_set/test_output-2-to-2.json");


### PR DESCRIPTION
Tests Migrated:

1. CloudVisionTemplateTests.java
2. DocumentOcrTemplateTests.java
3. DocumentOcrTemplateIntegrationTests.java
