### PR TITLE
Backport: Pageable parameter not in last position fix

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryExecutor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryExecutor.java
@@ -107,13 +107,14 @@ public final class SpannerStatementQueryExecutor {
   private static Map<String, Parameter> preparePartTreeSqlTagParameterMap(
       Parameter[] paramsMetadata, SqlStringAndPlaceholders sqlStringAndPlaceholders) {
     Map<String, Parameter> paramMetadataMap = new HashMap<>();
-    for (int i = 0; i < paramsMetadata.length; i++) {
-      Parameter param = paramsMetadata[i];
+    int nextPlaceholderIdx = 0;
+    for (int paramIdx = 0; paramIdx < paramsMetadata.length; paramIdx++) {
+      Parameter param = paramsMetadata[paramIdx];
       // Skip Pageable and Sort parameters because they don't need to be bound to the tags in the
       // query.
       // They are processed separately in applySort and buildLimit methods.
       if (param.getType() != Pageable.class && param.getType() != Sort.class) {
-        paramMetadataMap.put(sqlStringAndPlaceholders.getPlaceholders().get(i), param);
+        paramMetadataMap.put(sqlStringAndPlaceholders.getPlaceholders().get(nextPlaceholderIdx++), param);
       }
     }
     return paramMetadataMap;

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
@@ -326,6 +326,54 @@ public class SpannerStatementQueryTests {
   }
 
   @Test
+  public void pageableNotLastParameterTest() throws NoSuchMethodException {
+    // Test that preparePartTreeSqlTagParameterMap() can process cases
+    // where Pageable is not the last parameter
+    Object[] params = new Object[] {"BUY", PageRequest.of(1, 10, Sort.by("traderId")), "STOCK1"};
+    Method method = QueryHolder.class.getMethod("repositoryMethod7", String.class, Pageable.class, String.class);
+
+    when(this.queryMethod.getQueryMethod()).thenReturn(method);
+    String expectedSql =
+        "SELECT shares, trader_id, ticker, price, action, id, value "
+            + "FROM trades "
+            + "WHERE ( action=@tag0 AND ticker=@tag1 ) "
+            + "ORDER BY trader_id ASC LIMIT 10 OFFSET 10";
+
+
+    when(this.queryMethod.getName()).thenReturn("findByActionAndSymbol");
+    this.partTreeSpannerQuery = spy(createQuery());
+
+    when(this.spannerTemplate.query((Function<Struct, Object>) any(), any(), any()))
+        .thenReturn(Collections.singletonList(1L));
+
+    doReturn(new DefaultParameters(method)).when(this.queryMethod).getParameters();
+
+    when(this.spannerTemplate.query((Class) any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              Statement statement = invocation.getArgument(1);
+
+              assertThat(statement.getSql()).isEqualTo(expectedSql);
+
+              Map<String, Value> paramMap = statement.getParameters();
+
+              assertThat(paramMap.get("tag0").getString()).isEqualTo(params[0]);
+              // Correctly skips Pageable parameter because it doesn't need to be bound to
+              // the tags in the query.
+              assertThat(paramMap.get("tag1").getString()).isEqualTo(params[2]);
+              assertThat(paramMap).hasSize(2);
+
+              return null;
+            });
+
+    doReturn(Object.class).when(this.partTreeSpannerQuery).getReturnedSimpleConvertableItemType();
+    doReturn(null).when(this.partTreeSpannerQuery).convertToSimpleReturnType(any(), any());
+
+    this.partTreeSpannerQuery.execute(params);
+    verify(this.spannerTemplate).query((Class) any(), any(), any());
+  }
+
+  @Test
   public void unspecifiedParametersTest() throws NoSuchMethodException {
     this.expectedEx.expect(IllegalArgumentException.class);
     this.expectedEx.expectMessage("The number of tags does not match the number of params.");
@@ -468,6 +516,10 @@ public class SpannerStatementQueryTests {
     }
 
     public long repositoryMethod6(Double tag0, Sort tag1) {
+      return 0;
+    }
+
+    public long repositoryMethod7(String tag0, Pageable tag1, String tag2) {
       return 0;
     }
   }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/main/java/com/example/SpannerRepositoryExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/main/java/com/example/SpannerRepositoryExample.java
@@ -28,6 +28,7 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.PageRequest;
 
 /**
  * Example repository usage.
@@ -79,6 +80,15 @@ public class SpannerRepositoryExample {
 
     LOGGER.info("All trades:");
     for (Trade t : allTrades) {
+      LOGGER.info(t);
+    }
+
+    LOGGER.info("Make a pageable query:");
+    List<Trade> tradesPageOne = this.tradeRepository.findByActionAndSymbol(PageRequest.of(0, 1),
+        "BUY",
+        "STOCK1"
+        );
+    for (Trade t : tradesPageOne) {
       LOGGER.info(t);
     }
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/main/java/com/example/TradeRepository.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/main/java/com/example/TradeRepository.java
@@ -20,6 +20,7 @@ import com.google.cloud.spanner.Key;
 import com.google.cloud.spring.data.spanner.repository.SpannerRepository;
 import com.google.cloud.spring.data.spanner.repository.query.Query;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
@@ -45,4 +46,6 @@ public interface TradeRepository extends SpannerRepository<Trade, Key> {
   // This method uses the query from the properties file instead of one generated based on
   // name.
   List<Trade> fetchByActionNamedQuery(@Param("tag0") String action);
+
+  List<Trade> findByActionAndSymbol(Pageable pageable, String action, String symbol);
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/test/java/com/example/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/test/java/com/example/SpannerRepositoryIntegrationTests.java
@@ -38,6 +38,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -139,6 +140,11 @@ class SpannerRepositoryIntegrationTests {
             "demo_trader_json3");
 
     assertThat(this.tradeRepository.findAll()).hasSize(8);
+
+    assertThat(this.tradeRepository.findByActionAndSymbol(PageRequest.of(0, 1),
+        "BUY",
+        "STOCK1"
+    )).hasSize(1);
 
     Set<String> tradeSpannerKeys = new HashSet<>();
     this.tradeRepository


### PR DESCRIPTION
Backporting from #958.
This is a quick fix for issue #943 to correctly skip Pageable/Sort when it might not be the last parameter.