### PR TITLE
Migrating spanner tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,7 @@
 						<includes>
 							<include>${integration-test.pattern}</include>
 						</includes>
+						<argLine>-Xms512m -Xmx512m --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED</argLine>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/it/CommitTimestampIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/it/CommitTimestampIntegrationTests.java
@@ -36,22 +36,22 @@ import com.google.cloud.spring.data.spanner.test.domain.CommitTimestamps;
 import java.lang.reflect.Field;
 import java.util.Objects;
 import java.util.UUID;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /** Integration tests for the {@link CommitTimestamp} feature. */
-@RunWith(SpringRunner.class)
-public class CommitTimestampIntegrationTests extends AbstractSpannerIntegrationTest {
+@ExtendWith(SpringExtension.class)
+class CommitTimestampIntegrationTests extends AbstractSpannerIntegrationTest {
 
   @Autowired private SpannerOperations spannerOperations;
   @Autowired private DatabaseClient databaseClient;
   @Autowired private SpannerMutationFactory mutationFactory;
 
   @Test
-  public void testCommitTimestamp() {
+  void testCommitTimestamp() {
 
     final CommitTimestamps entity = new CommitTimestamps();
     final String id = UUID.randomUUID().toString();

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/it/CommitTimestampIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/it/CommitTimestampIntegrationTests.java
@@ -37,12 +37,14 @@ import java.lang.reflect.Field;
 import java.util.Objects;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /** Integration tests for the {@link CommitTimestamp} feature. */
+@EnabledIfSystemProperty(named = "it.spanner", matches = "true")
 @ExtendWith(SpringExtension.class)
 class CommitTimestampIntegrationTests extends AbstractSpannerIntegrationTest {
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/it/SpannerTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/it/SpannerTemplateIntegrationTests.java
@@ -34,12 +34,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Integration tests that use many features of the Spanner Template. */
+@EnabledIfSystemProperty(named = "it.spanner", matches = "true")
 @ExtendWith(SpringExtension.class)
 public class SpannerTemplateIntegrationTests extends AbstractSpannerIntegrationTest {
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerKeyPropertyTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerKeyPropertyTests.java
@@ -17,28 +17,24 @@
 package com.google.cloud.spring.data.spanner.core.mapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import com.google.cloud.spanner.Key;
 import java.lang.annotation.Annotation;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.data.util.ClassTypeInformation;
 
 /** Tests for the Spanner custom key property. */
-public class SpannerKeyPropertyTests {
-
-  /** checks the messages and types of exceptions. */
-  @Rule public ExpectedException expectedEx = ExpectedException.none();
+class SpannerKeyPropertyTests {
 
   private SpannerCompositeKeyProperty spannerKeyProperty;
 
   private SpannerPersistentEntity spannerPersistentEntity;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     this.spannerPersistentEntity = mock(SpannerPersistentEntity.class);
     this.spannerKeyProperty =
         new SpannerCompositeKeyProperty(
@@ -46,181 +42,184 @@ public class SpannerKeyPropertyTests {
   }
 
   @Test
-  public void nullSpannerPersistentEntityTest() {
-    this.expectedEx.expect(IllegalArgumentException.class);
-    this.expectedEx.expectMessage("A valid Cloud Spanner persistent entity is required.");
-    new SpannerCompositeKeyProperty(null, new SpannerPersistentProperty[] {});
+  void nullSpannerPersistentEntityTest() {
+
+    assertThatThrownBy(() -> new SpannerCompositeKeyProperty(null, new SpannerPersistentProperty[] {}))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A valid Cloud Spanner persistent entity is required.");
   }
 
   @Test
-  public void nullPropertiesTest() {
-    this.expectedEx.expect(IllegalArgumentException.class);
-    this.expectedEx.expectMessage("A valid array of primary key properties is required.");
-    new SpannerCompositeKeyProperty(this.spannerPersistentEntity, null);
+  void nullPropertiesTest() {
+
+    assertThatThrownBy(() -> new SpannerCompositeKeyProperty(this.spannerPersistentEntity, null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A valid array of primary key properties is required.");
+
   }
 
   @Test
-  public void getColumnNameTest() {
+  void getColumnNameTest() {
     assertThat(this.spannerKeyProperty.getColumnName()).isNull();
   }
 
   @Test
-  public void getColumnInnerTypeTest() {
+  void getColumnInnerTypeTest() {
     assertThat(this.spannerKeyProperty.getColumnInnerType()).isNull();
   }
 
   @Test
-  public void getPrimaryKeyOrderTest() {
+  void getPrimaryKeyOrderTest() {
     assertThat(this.spannerKeyProperty.getPrimaryKeyOrder()).isNull();
   }
 
   @Test
-  public void getOwnerTest() {
+  void getOwnerTest() {
     assertThat(this.spannerKeyProperty.getOwner()).isSameAs(this.spannerPersistentEntity);
   }
 
   @Test
-  public void getNameTest() {
+  void getNameTest() {
     assertThat(this.spannerKeyProperty.getName()).isNull();
   }
 
   @Test
-  public void getTypeTest() {
+  void getTypeTest() {
     assertThat(this.spannerKeyProperty.getType()).isEqualTo(Key.class);
   }
 
   @Test
-  public void getTypeInformationTest() {
+  void getTypeInformationTest() {
     assertThat(this.spannerKeyProperty.getTypeInformation())
         .isEqualTo(ClassTypeInformation.from(Key.class));
   }
 
   @Test
   @SuppressWarnings("deprecation")
-  public void getPersistentEntityTypeTest() {
+  void getPersistentEntityTypeTest() {
     assertThat(this.spannerKeyProperty.getPersistentEntityTypes().iterator().hasNext()).isFalse();
   }
 
   @Test
-  public void getPersistentEntityTypeInformationTest() {
+  void getPersistentEntityTypeInformationTest() {
     assertThat(this.spannerKeyProperty.getPersistentEntityTypeInformation().iterator().hasNext())
         .isFalse();
   }
 
   @Test
-  public void getGetterTest() {
+  void getGetterTest() {
     assertThat(this.spannerKeyProperty.getGetter()).isNull();
   }
 
   @Test
-  public void getSetterTest() {
+  void getSetterTest() {
     assertThat(this.spannerKeyProperty.getSetter()).isNull();
   }
 
   @Test
-  public void getFieldTest() {
+  void getFieldTest() {
     assertThat(this.spannerKeyProperty.getField()).isNull();
   }
 
   @Test
-  public void getSpelExpressionTest() {
+  void getSpelExpressionTest() {
     assertThat(this.spannerKeyProperty.getSpelExpression()).isNull();
   }
 
   @Test
-  public void getAssociationTest() {
+  void getAssociationTest() {
     assertThat(this.spannerKeyProperty.getAssociation()).isNull();
   }
 
   @Test
-  public void isEntityTest() {
+  void isEntityTest() {
     assertThat(this.spannerKeyProperty.isEntity()).isFalse();
   }
 
   @Test
-  public void isIdPropertyTest() {
+  void isIdPropertyTest() {
     assertThat(this.spannerKeyProperty.isIdProperty()).isTrue();
   }
 
   @Test
-  public void isVersionPropertyTest() {
+  void isVersionPropertyTest() {
     assertThat(this.spannerKeyProperty.isVersionProperty()).isFalse();
   }
 
   @Test
-  public void isCollectionLikeTest() {
+  void isCollectionLikeTest() {
     assertThat(this.spannerKeyProperty.isCollectionLike()).isFalse();
   }
 
   @Test
-  public void isMapTest() {
+  void isMapTest() {
     assertThat(this.spannerKeyProperty.isMap()).isFalse();
   }
 
   @Test
-  public void isArrayTest() {
+  void isArrayTest() {
     assertThat(this.spannerKeyProperty.isArray()).isFalse();
   }
 
   @Test
-  public void isTransientTest() {
+  void isTransientTest() {
     assertThat(this.spannerKeyProperty.isTransient()).isFalse();
   }
 
   @Test
-  public void isWritableTest() {
+  void isWritableTest() {
     assertThat(this.spannerKeyProperty.isWritable()).isFalse();
   }
 
   @Test
-  public void isAssociationTest() {
+  void isAssociationTest() {
     assertThat(this.spannerKeyProperty.isAssociation()).isFalse();
   }
 
   @Test
-  public void getComponentTypeTest() {
+  void getComponentTypeTest() {
     assertThat(this.spannerKeyProperty.getComponentType()).isNull();
   }
 
   @Test
-  public void getRawTypeTest() {
+  void getRawTypeTest() {
     assertThat(this.spannerKeyProperty.getRawType()).isEqualTo(Key.class);
   }
 
   @Test
-  public void getMapValueTypeTest() {
+  void getMapValueTypeTest() {
     assertThat(this.spannerKeyProperty.getMapValueType()).isNull();
   }
 
   @Test
-  public void getActualTypeTest() {
+  void getActualTypeTest() {
     assertThat(this.spannerKeyProperty.getActualType()).isEqualTo(Key.class);
   }
 
   @Test
-  public void findAnnotationTest() {
+  void findAnnotationTest() {
     Annotation annotation = this.spannerKeyProperty.findAnnotation(null);
     assertThat(annotation).isNull();
   }
 
   @Test
-  public void findPropertyOrOwnerAnnotationTest() {
+  void findPropertyOrOwnerAnnotationTest() {
     Annotation annotation = this.spannerKeyProperty.findPropertyOrOwnerAnnotation(null);
     assertThat(annotation).isNull();
   }
 
   @Test
-  public void isAnnotationPresentTest() {
+  void isAnnotationPresentTest() {
     assertThat(this.spannerKeyProperty.isAnnotationPresent(null)).isFalse();
   }
 
   @Test
-  public void usePropertyAccessTest() {
+  void usePropertyAccessTest() {
     assertThat(this.spannerKeyProperty.usePropertyAccess()).isFalse();
   }
 
   @Test
-  public void getAssociationTargetTypeInformationTest() {
+  void getAssociationTargetTypeInformationTest() {
     assertThat(this.spannerKeyProperty.getAssociationTargetTypeInformation()).isNull();
   }
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerMappingContextTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerMappingContextTests.java
@@ -23,21 +23,21 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.mapping.model.FieldNamingStrategy;
 import org.springframework.data.mapping.model.PropertyNameFieldNamingStrategy;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /** Tests for the Spanner mapping context. */
-@RunWith(SpringRunner.class)
-public class SpannerMappingContextTests {
+@ExtendWith(SpringExtension.class)
+class SpannerMappingContextTests {
 
   @Test
-  public void testNullSetFieldNamingStrategy() {
+  void testNullSetFieldNamingStrategy() {
     SpannerMappingContext context = new SpannerMappingContext();
 
     context.setFieldNamingStrategy(null);
@@ -46,7 +46,7 @@ public class SpannerMappingContextTests {
   }
 
   @Test
-  public void testSetFieldNamingStrategy() {
+  void testSetFieldNamingStrategy() {
     SpannerMappingContext context = new SpannerMappingContext();
     FieldNamingStrategy strat = mock(FieldNamingStrategy.class);
     context.setFieldNamingStrategy(strat);
@@ -54,7 +54,7 @@ public class SpannerMappingContextTests {
   }
 
   @Test
-  public void testApplicationContextPassing() {
+  void testApplicationContextPassing() {
     SpannerPersistentEntityImpl mockEntity = mock(SpannerPersistentEntityImpl.class);
     SpannerMappingContext context = createSpannerMappingContextWith(mockEntity);
     ApplicationContext applicationContext = mock(ApplicationContext.class);
@@ -66,7 +66,7 @@ public class SpannerMappingContextTests {
   }
 
   @Test
-  public void testApplicationContextIsNotSet() {
+  void testApplicationContextIsNotSet() {
     SpannerPersistentEntityImpl mockEntity = mock(SpannerPersistentEntityImpl.class);
     SpannerMappingContext context = createSpannerMappingContextWith(mockEntity);
 
@@ -76,7 +76,7 @@ public class SpannerMappingContextTests {
   }
 
   @Test
-  public void testGetInvalidSpannerEntity() {
+  void testGetInvalidSpannerEntity() {
     SpannerPersistentEntityImpl mockEntity = mock(SpannerPersistentEntityImpl.class);
     SpannerMappingContext context = createSpannerMappingContextWith(mockEntity);
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImplTests.java
@@ -112,7 +112,8 @@ class SpannerPersistentEntityImplTests {
   @Test
   void testDuplicatePrimaryKeyOrder() {
 
-    assertThatThrownBy(() -> new SpannerMappingContext().getPersistentEntity(EntityWithDuplicatePrimaryKeyOrder.class))
+    SpannerMappingContext spannerMappingContext = new SpannerMappingContext();
+    assertThatThrownBy(() -> spannerMappingContext.getPersistentEntity(EntityWithDuplicatePrimaryKeyOrder.class))
             .isInstanceOf(SpannerDataException.class)
             .hasMessage("Two properties were annotated with the same primary key order: id2 and id in EntityWithDuplicatePrimaryKeyOrder.");
   }
@@ -120,10 +121,9 @@ class SpannerPersistentEntityImplTests {
   @Test
   void testInvalidPrimaryKeyOrder() {
 
+    SpannerMappingContext spannerMappingContext = new SpannerMappingContext();
 
-    SpannerMappingContext spannerPersistentEntity = new SpannerMappingContext();
-
-    assertThatThrownBy(() -> spannerPersistentEntity.getPersistentEntity(EntityWithWronglyOrderedKeys.class).getIdProperty())
+    assertThatThrownBy(() -> spannerMappingContext.getPersistentEntity(EntityWithWronglyOrderedKeys.class))
             .isInstanceOf(SpannerDataException.class)
             .hasMessage("The primary key columns were not given a consecutive order. There is no property annotated with order 2 in EntityWithWronglyOrderedKeys.");
 
@@ -174,7 +174,9 @@ class SpannerPersistentEntityImplTests {
     MultiIdsEntity t = new MultiIdsEntity();
     PersistentPropertyAccessor propertyAccessor = entity.getPropertyAccessor(t);
 
-    assertThatThrownBy(() -> propertyAccessor.setProperty(idProperty, Key.of("blah", 123L, 123.45D, "abc")))
+    Key testKey = Key.of("blah", 123L, 123.45D, "abc");
+
+    assertThatThrownBy(() -> propertyAccessor.setProperty(idProperty, testKey))
             .isInstanceOf(SpannerDataException.class)
             .hasMessage("The number of key parts is not equal to the number of primary key properties");
   }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/ParallelSpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/ParallelSpannerRepositoryIntegrationTests.java
@@ -28,11 +28,13 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /** Tests multiple threads using a single repository instance. */
+@EnabledIfSystemProperty(named = "it.spanner", matches = "true")
 @ExtendWith(SpringExtension.class)
 public class ParallelSpannerRepositoryIntegrationTests extends AbstractSpannerIntegrationTest {
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/ParallelSpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/ParallelSpannerRepositoryIntegrationTests.java
@@ -36,7 +36,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /** Tests multiple threads using a single repository instance. */
 @EnabledIfSystemProperty(named = "it.spanner", matches = "true")
 @ExtendWith(SpringExtension.class)
-public class ParallelSpannerRepositoryIntegrationTests extends AbstractSpannerIntegrationTest {
+class ParallelSpannerRepositoryIntegrationTests extends AbstractSpannerIntegrationTest {
 
   private static final int PARALLEL_OPERATIONS = 2;
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/ParallelSpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/ParallelSpannerRepositoryIntegrationTests.java
@@ -25,29 +25,29 @@ import com.google.cloud.spring.data.spanner.test.domain.TradeRepository;
 import java.util.List;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /** Tests multiple threads using a single repository instance. */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class ParallelSpannerRepositoryIntegrationTests extends AbstractSpannerIntegrationTest {
 
   private static final int PARALLEL_OPERATIONS = 2;
 
   @Autowired TradeRepository tradeRepository;
 
-  @Before
-  @After
-  public void cleanUpData() {
+  @BeforeEach
+  @AfterEach
+  void cleanUpData() {
     this.spannerOperations.delete(Trade.class, KeySet.all());
   }
 
   @Test
-  public void testParallelOperations() {
+  void testParallelOperations() {
 
     this.tradeRepository.performReadWriteTransaction(
         repo -> {

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryInsertIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryInsertIntegrationTests.java
@@ -29,12 +29,15 @@ import java.util.Collections;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /** Integration tests for Spanner Repository. */
+
+@EnabledIfSystemProperty(named = "it.spanner", matches = "true")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {IntegrationTestConfiguration.class})
 class SpannerRepositoryInsertIntegrationTests {

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryInsertIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryInsertIntegrationTests.java
@@ -26,19 +26,18 @@ import com.google.cloud.spring.data.spanner.test.IntegrationTestConfiguration;
 import com.google.cloud.spring.data.spanner.test.domain.Singer;
 import com.google.cloud.spring.data.spanner.test.domain.SingerRepository;
 import java.util.Collections;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /** Integration tests for Spanner Repository. */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {IntegrationTestConfiguration.class})
-public class SpannerRepositoryInsertIntegrationTests {
+class SpannerRepositoryInsertIntegrationTests {
 
   @Autowired SingerRepository singerRepository;
 
@@ -48,17 +47,8 @@ public class SpannerRepositoryInsertIntegrationTests {
 
   @Autowired SpannerDatabaseAdminTemplate spannerDatabaseAdminTemplate;
 
-  @BeforeClass
-  public static void checkToRun() {
-    assumeThat(System.getProperty("it.spanner"))
-        .as(
-            "Spanner integration tests are disabled. "
-                + "Please use '-Dit.spanner=true' to enable them. ")
-        .isEqualTo("true");
-  }
-
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     if (!this.spannerDatabaseAdminTemplate.tableExists("singers_list")) {
       this.spannerDatabaseAdminTemplate.executeDdlStrings(
           Collections.singleton(this.spannerSchemaUtils.getCreateTableDdlString(Singer.class)),
@@ -67,13 +57,13 @@ public class SpannerRepositoryInsertIntegrationTests {
     this.singerRepository.deleteAll();
   }
 
-  @After
-  public void clearData() {
+  @AfterEach
+  void clearData() {
     this.singerRepository.deleteAll();
   }
 
   @Test
-  public void insertTest() {
+  void insertTest() {
     singerRepository.insert(1, "Cher", null);
     Iterable<Singer> singers = singerRepository.findAll();
     assertThat(singers).containsExactly(new Singer(1, "Cher", null));

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -47,10 +47,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.util.Sets;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
@@ -62,12 +62,12 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Integration tests for Spanner Repository that uses many features. */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegrationTest {
 
   @Autowired TradeRepository tradeRepository;
@@ -82,14 +82,14 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
 
   @SpyBean SpannerTemplate spannerTemplate;
 
-  @Before
-  @After
-  public void cleanUpData() {
+  @BeforeEach
+  @AfterEach
+  void cleanUpData() {
     this.tradeRepository.deleteAll();
   }
 
   @Test
-  public void queryOptionalSingleValueTest() {
+  void queryOptionalSingleValueTest() {
     Trade trade = Trade.makeTrade(null, 0);
     this.spannerOperations.insert(trade);
 
@@ -101,7 +101,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_simple() {
+  void queryMethodsTest_simple() {
     final int subTrades = 42;
     Trade trade = Trade.makeTrade(null, subTrades);
     this.spannerOperations.insert(trade);
@@ -135,7 +135,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_updateActionTradeById() {
+  void queryMethodsTest_updateActionTradeById() {
     List<Trade> trader1BuyTrades = insertTrades("trader1", "BUY", 3);
 
     Trade buyTrade1 = trader1BuyTrades.get(0);
@@ -155,7 +155,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_BoundParameters() {
+  void queryMethodsTest_BoundParameters() {
     insertTrades("trader1", "BUY", 3);
     insertTrades("trader1", "SELL", 2);
     insertTrades("trader2", "SELL", 3);
@@ -179,7 +179,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_deleteByAction() {
+  void queryMethodsTest_deleteByAction() {
     insertTrades("trader1", "BUY", 3);
     insertTrades("trader1", "SELL", 2);
     insertTrades("trader2", "SELL", 3);
@@ -189,7 +189,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_deleteBySymbol() {
+  void queryMethodsTest_deleteBySymbol() {
     insertTrades("trader1", "SELL", 2);
     insertTrades("trader2", "SELL", 3);
 
@@ -198,7 +198,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_deleteBySymbolAndAction() {
+  void queryMethodsTest_deleteBySymbolAndAction() {
     insertTrades("trader1", "SELL", 2);
     insertTrades("trader2", "SELL", 3);
 
@@ -208,7 +208,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_deleteAllById() {
+  void queryMethodsTest_deleteAllById() {
     List<Trade> trades = insertTrades("trader1", "BUY", 5);
 
     Trade someTrade1 = trades.get(0);
@@ -227,7 +227,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_deleteAllById_doesNothingOnEmptyIds() {
+  void queryMethodsTest_deleteAllById_doesNothingOnEmptyIds() {
     List<Trade> trades = insertTrades("trader1", "BUY", 5);
     assertThat(this.tradeRepository.count()).isEqualTo(5);
 
@@ -236,7 +236,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_readsAndCounts() {
+  void queryMethodsTest_readsAndCounts() {
     List<Trade> trader1BuyTrades = insertTrades("trader1", "BUY", 3);
     List<Trade> trader1SellTrades = insertTrades("trader1", "SELL", 2);
     List<Trade> trader2Trades = insertTrades("trader2", "SELL", 3);
@@ -258,7 +258,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_Trader2() {
+  void queryMethodsTest_Trader2() {
     List<Trade> trader2Trades = insertTrades("trader2", "SELL", 3);
 
     List<Trade> trader2TradesRetrieved = this.tradeRepository.findByTraderId("trader2");
@@ -301,7 +301,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_caseSensitive() {
+  void queryMethodsTest_caseSensitive() {
     insertTrades("trader1", "BUY", 3);
 
     List<TradeProjection> tradeProjectionsRetrieved =
@@ -314,7 +314,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_sortingAndPaging() {
+  void queryMethodsTest_sortingAndPaging() {
     List<Trade> trader1BuyTrades = insertTrades("trader1", "BUY", 3);
     insertTrades("trader1", "SELL", 2);
     insertTrades("trader2", "SELL", 3);
@@ -347,7 +347,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_CustomSort() {
+  void queryMethodsTest_CustomSort() {
     insertTrades("trader1", "BUY", 3);
     insertTrades("trader1", "SELL", 2);
     insertTrades("trader2", "SELL", 3);
@@ -361,7 +361,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_Wildcards() {
+  void queryMethodsTest_Wildcards() {
     insertTrades("trader1", "BUY", 3);
 
     this.tradeRepository
@@ -383,7 +383,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_NullColumns() {
+  void queryMethodsTest_NullColumns() {
     insertTrades("trader1", "BUY", 3);
 
     Trade someTrade = this.tradeRepository.findBySymbolContains("ABCD").get(0);
@@ -401,7 +401,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_ParentChildOperations() {
+  void queryMethodsTest_ParentChildOperations() {
     insertTrades("trader1", "BUY", 3);
 
     Trade someTrade = this.tradeRepository.findBySymbolContains("ABCD").get(0);
@@ -471,7 +471,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_EagerFetch() {
+  void queryMethodsTest_EagerFetch() {
     Mockito.clearInvocations(spannerTemplate);
 
     final Trade aTrade = Trade.makeTrade("trader1", 0, 0);
@@ -492,7 +492,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void queryMethodsTest_SoftDelete() {
+  void queryMethodsTest_SoftDelete() {
     Trade someTrade = insertTrade("trader1", "BUY", 1);
     SubTrade subTrade1 =
         new SubTrade(someTrade.getTradeDetail().getId(), someTrade.getTraderId(), "subTrade1");
@@ -524,7 +524,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void existsTest() {
+  void existsTest() {
     Trade trade = Trade.makeTrade();
     this.tradeRepository.save(trade);
     SpannerPersistentEntity<?> persistentEntity =
@@ -538,14 +538,14 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void testNonNull() {
+  void testNonNull() {
     assertThatThrownBy(() -> this.tradeRepository.getByAction("non-existing-action"))
         .isInstanceOf(EmptyResultDataAccessException.class)
         .hasMessageMatching("Result must not be null!");
   }
 
   @Test
-  public void testWithJsonField() {
+  void testWithJsonField() {
     Trade trade1 = Trade.makeTrade();
     trade1.setOptionalDetails(new Details("abc", "def"));
     trade1.setBackupDetails(new Details("backup context", "backup context continued"));
@@ -569,13 +569,13 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void testTransaction() {
+  void testTransaction() {
     this.tradeRepositoryTransactionalService.testTransactionalAnnotation(2);
     assertThat(this.tradeRepository.count()).isEqualTo(1L);
   }
 
   @Test
-  public void testTransactionRolledBack() {
+  void testTransactionRolledBack() {
     assertThat(this.tradeRepository.count()).isZero();
     try {
       this.tradeRepositoryTransactionalService.testTransactionRolledBack();
@@ -586,7 +586,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void findAllByIdReturnsOnlyRequestedRows() {
+  void findAllByIdReturnsOnlyRequestedRows() {
     insertTrade("trader1", "BUY", 100);
     Trade trade2 = insertTrade("trader2", "BUY", 101);
     Trade trade3 = insertTrade("trader2", "SELL", 102);
@@ -603,7 +603,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
-  public void findAllByIdReturnsNothingOnEmptyRequestIterable() {
+  void findAllByIdReturnsNothingOnEmptyRequestIterable() {
     insertTrade("trader1", "BUY", 100);
     insertTrade("trader2", "BUY", 101);
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -50,6 +50,7 @@ import org.assertj.core.util.Sets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,6 +68,7 @@ import org.springframework.test.util.AopTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Integration tests for Spanner Repository that uses many features. */
+@EnabledIfSystemProperty(named = "it.spanner", matches = "true")
 @ExtendWith(SpringExtension.class)
 public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegrationTest {
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
@@ -56,9 +56,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import org.assertj.core.data.Offset;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -77,7 +77,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 /** Tests Spanner SQL Query Methods. */
-public class SqlSpannerQueryTests {
+class SqlSpannerQueryTests {
 
   private static final Offset<Double> DELTA = Offset.offset(0.00001);
 
@@ -99,11 +99,8 @@ public class SqlSpannerQueryTests {
 
   private final DatabaseClient databaseClient = mock(DatabaseClient.class);
 
-  /** checks messages and types for exceptions. */
-  @Rule public ExpectedException expectedEx = ExpectedException.none();
-
-  @Before
-  public void initMocks() throws NoSuchMethodException {
+  @BeforeEach
+  void initMocks() throws NoSuchMethodException {
     this.queryMethod = mock(SpannerQueryMethod.class);
     // this is a dummy object. it is not mockable otherwise.
     Method method = Object.class.getMethod("toString");
@@ -136,7 +133,7 @@ public class SqlSpannerQueryTests {
   }
 
   @Test
-  public void noPageableParamQueryTest() throws NoSuchMethodException {
+  void noPageableParamQueryTest() throws NoSuchMethodException {
     String sql =
         "SELECT DISTINCT * FROM "
             + ":com.google.cloud.spring.data.spanner.repository.query.SqlSpannerQueryTests$Trade:";
@@ -185,7 +182,7 @@ public class SqlSpannerQueryTests {
   }
 
   @Test
-  public void pageableParamQueryTest() throws NoSuchMethodException {
+  void pageableParamQueryTest() throws NoSuchMethodException {
 
     String sql =
         "SELECT * FROM"
@@ -249,7 +246,7 @@ public class SqlSpannerQueryTests {
   }
 
   @Test
-  public void sortParamQueryTest() throws NoSuchMethodException {
+  void sortParamQueryTest() throws NoSuchMethodException {
 
     String sql =
         "SELECT * FROM"
@@ -312,7 +309,7 @@ public class SqlSpannerQueryTests {
   }
 
   @Test
-  public void sortAndPageableQueryTest() throws NoSuchMethodException {
+  void sortAndPageableQueryTest() throws NoSuchMethodException {
 
     String sql =
         "SELECT * FROM"
@@ -376,7 +373,7 @@ public class SqlSpannerQueryTests {
   }
 
   @Test
-  public void compoundNameConventionTest() throws NoSuchMethodException {
+  void compoundNameConventionTest() throws NoSuchMethodException {
 
     String sql =
         "SELECT DISTINCT * FROM "
@@ -507,7 +504,7 @@ public class SqlSpannerQueryTests {
   }
 
   @Test
-  public void dmlTest() throws NoSuchMethodException {
+  void dmlTest() throws NoSuchMethodException {
     String sql = "dml statement here";
 
     TransactionContext context = mock(TransactionContext.class);
@@ -537,7 +534,7 @@ public class SqlSpannerQueryTests {
   }
 
   @Test
-  public void sqlCountWithWhereTest() throws NoSuchMethodException {
+  void sqlCountWithWhereTest() throws NoSuchMethodException {
     String sql =
         "SELECT count(1) FROM"
             + " :com.google.cloud.spring.data.spanner.repository.query.SqlSpannerQueryTests$Child:"
@@ -604,7 +601,7 @@ public class SqlSpannerQueryTests {
   }
 
   @Test
-  public void sqlReturnTypeIsJsonFieldTest() throws NoSuchMethodException {
+  void sqlReturnTypeIsJsonFieldTest() throws NoSuchMethodException {
     String sql = "SELECT details from singer where stageName = @stageName";
 
     Object[] params = new Object[] {"STAGENAME"};

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepositoryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepositoryTests.java
@@ -36,17 +36,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.util.Assert;
 
 /** Tests for the standard Spanner repository implementation. */
-public class SimpleSpannerRepositoryTests {
+class SimpleSpannerRepositoryTests {
 
   private SpannerTemplate template;
 
@@ -54,32 +51,31 @@ public class SimpleSpannerRepositoryTests {
 
   private static final Key A_KEY = Key.of("key");
 
-  /** checks exceptions for messages and types. */
-  @Rule public ExpectedException expectedEx = ExpectedException.none();
-
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     this.template = mock(SpannerTemplate.class);
     this.entityProcessor = mock(SpannerEntityProcessor.class);
     when(this.template.getSpannerEntityProcessor()).thenReturn(this.entityProcessor);
   }
 
   @Test
-  public void constructorNullSpannerOperationsTest() {
-    this.expectedEx.expect(IllegalArgumentException.class);
-    this.expectedEx.expectMessage("A valid SpannerTemplate object is required.");
-    new SimpleSpannerRepository<Object, Key>(null, Object.class);
+  void constructorNullSpannerOperationsTest() {
+
+    assertThatThrownBy(() -> new SimpleSpannerRepository<Object, Key>(null, Object.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A valid SpannerTemplate object is required.");
   }
 
   @Test
-  public void constructorNullEntityTypeTest() {
-    this.expectedEx.expect(IllegalArgumentException.class);
-    this.expectedEx.expectMessage("A valid entity type is required.");
-    new SimpleSpannerRepository<Object, Key>(this.template, null);
+  void constructorNullEntityTypeTest() {
+
+    assertThatThrownBy(() -> new SimpleSpannerRepository<Object, Key>(this.template, null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A valid entity type is required.");
   }
 
   @Test
-  public void getSpannerOperationsTest() {
+  void getSpannerOperationsTest() {
     assertThat(this.template)
         .isSameAs(
             new SimpleSpannerRepository<Object, Key>(this.template, Object.class)
@@ -87,56 +83,79 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void saveNullObjectTest() {
-    this.expectedEx.expect(IllegalArgumentException.class);
-    this.expectedEx.expectMessage("A non-null entity is required for saving.");
-    new SimpleSpannerRepository<Object, Key>(this.template, Object.class).save(null);
+  void saveNullObjectTest() {
+    SimpleSpannerRepository spannerRepository = new SimpleSpannerRepository<Object, Key>(this.template, Object.class);
+
+    assertThatThrownBy(() -> spannerRepository.save(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A non-null entity is required for saving.");
   }
 
   @Test
-  public void findNullIdTest() {
-    this.expectedEx.expect(IllegalArgumentException.class);
-    this.expectedEx.expectMessage("A non-null ID is required.");
-    new SimpleSpannerRepository<Object, Key>(this.template, Object.class).findById(null);
+  void findNullIdTest() {
+    SimpleSpannerRepository spannerRepository = new SimpleSpannerRepository<Object, Key>(this.template, Object.class);
+
+    assertThatThrownBy(() -> spannerRepository.findById(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A non-null ID is required.");
+
+
   }
 
   @Test
-  public void existsNullIdTest() {
-    this.expectedEx.expect(IllegalArgumentException.class);
-    this.expectedEx.expectMessage("A non-null ID is required.");
-    new SimpleSpannerRepository<Object, Key>(this.template, Object.class).existsById(null);
+  void existsNullIdTest() {
+
+    SimpleSpannerRepository spannerRepository = new SimpleSpannerRepository<Object, Key>(this.template, Object.class);
+
+    assertThatThrownBy(() -> spannerRepository.existsById(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A non-null ID is required.");
+
   }
 
   @Test
-  public void deleteNullIdTest() {
-    this.expectedEx.expect(IllegalArgumentException.class);
-    this.expectedEx.expectMessage("A non-null ID is required.");
-    new SimpleSpannerRepository<Object, Key>(this.template, Object.class).deleteById(null);
+  void deleteNullIdTest() {
+
+    SimpleSpannerRepository spannerRepository = new SimpleSpannerRepository<Object, Key>(this.template, Object.class);
+
+    assertThatThrownBy(() -> spannerRepository.deleteById(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A non-null ID is required.");
   }
 
   @Test
-  public void deleteNullEntityTest() {
-    this.expectedEx.expect(IllegalArgumentException.class);
-    this.expectedEx.expectMessage("A non-null entity is required.");
-    new SimpleSpannerRepository<Object, Key>(this.template, Object.class).delete(null);
+  void deleteNullEntityTest() {
+
+    SimpleSpannerRepository spannerRepository = new SimpleSpannerRepository<Object, Key>(this.template, Object.class);
+
+    assertThatThrownBy(() -> spannerRepository.delete(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A non-null entity is required.");
+
   }
 
   @Test
-  public void deleteAllNullEntityTest() {
-    this.expectedEx.expect(IllegalArgumentException.class);
-    this.expectedEx.expectMessage("A non-null list of entities is required.");
-    new SimpleSpannerRepository<Object, Key>(this.template, Object.class).deleteAll(null);
+  void deleteAllNullEntityTest() {
+
+    SimpleSpannerRepository spannerRepository = new SimpleSpannerRepository<Object, Key>(this.template, Object.class);
+
+    assertThatThrownBy(() -> spannerRepository.deleteAll(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A non-null list of entities is required.");
   }
 
   @Test
-  public void saveAllNullEntityTest() {
-    this.expectedEx.expect(IllegalArgumentException.class);
-    this.expectedEx.expectMessage("A non-null list of entities is required for saving.");
-    new SimpleSpannerRepository<Object, Key>(this.template, Object.class).saveAll(null);
+  void saveAllNullEntityTest() {
+
+    SimpleSpannerRepository spannerRepository = new SimpleSpannerRepository<Object, Key>(this.template, Object.class);
+
+    assertThatThrownBy(() -> spannerRepository.saveAll(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A non-null list of entities is required for saving.");
   }
 
   @Test
-  public void saveTest() {
+  void saveTest() {
     Object ob = new Object();
     assertThat(new SimpleSpannerRepository<Object, Key>(this.template, Object.class).save(ob))
         .isEqualTo(ob);
@@ -144,7 +163,7 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void saveAllTest() {
+  void saveAllTest() {
     Object ob = new Object();
     Object ob2 = new Object();
     Iterable<Object> ret =
@@ -155,7 +174,7 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void findByIdTest() {
+  void findByIdTest() {
     Object ret = new Object();
     when(this.entityProcessor.convertToKey(A_KEY)).thenReturn(A_KEY);
     when(this.template.read(Object.class, A_KEY)).thenReturn(ret);
@@ -166,15 +185,18 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void findByIdKeyWritingThrowsAnException() {
-    this.expectedEx.expect(SpannerDataException.class);
+  void findByIdKeyWritingThrowsAnException() {
     when(this.entityProcessor.convertToKey(any())).thenThrow(SpannerDataException.class);
-    new SimpleSpannerRepository<Object, Object[]>(this.template, Object.class)
-        .findById(new Object[] {});
+
+    SimpleSpannerRepository spannerRepository = new SimpleSpannerRepository<Object, Object[]>(this.template, Object.class);
+
+    assertThatThrownBy(() -> spannerRepository.findById(new Object[] {}))
+            .isInstanceOf(SpannerDataException.class);
   }
 
+
   @Test
-  public void existsByIdTestFound() {
+  void existsByIdTestFound() {
     when(this.entityProcessor.convertToKey(A_KEY)).thenReturn(A_KEY);
     when(this.template.existsById(Object.class, A_KEY)).thenReturn(true);
     assertThat(
@@ -183,7 +205,7 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void existsByIdTestNotFound() {
+  void existsByIdTestNotFound() {
     when(this.entityProcessor.convertToKey(A_KEY)).thenReturn(A_KEY);
     when(this.template.existsById(Object.class, A_KEY)).thenReturn(false);
     assertThat(
@@ -192,13 +214,13 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void findAllTest() {
+  void findAllTest() {
     new SimpleSpannerRepository<Object, Key>(this.template, Object.class).findAll();
     verify(this.template, times(1)).readAll(Object.class);
   }
 
   @Test
-  public void findAllSortTest() {
+  void findAllSortTest() {
     Sort sort = mock(Sort.class);
     when(this.template.queryAll(eq(Object.class), any()))
         .thenAnswer(
@@ -212,7 +234,7 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void findAllPageableTest() {
+  void findAllPageableTest() {
     Pageable pageable = mock(Pageable.class);
     Sort sort = mock(Sort.class);
     when(pageable.getSort()).thenReturn(sort);
@@ -232,7 +254,7 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void findAllByIdTest() {
+  void findAllByIdTest() {
     List<Key> unconvertedKey = Arrays.asList(Key.of("key1"), Key.of("key2"));
 
     when(this.entityProcessor.convertToKey(Key.of("key1"))).thenReturn(Key.of("key1"));
@@ -250,7 +272,7 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void findAllById_failsOnNull() {
+  void findAllById_failsOnNull() {
     SimpleSpannerRepository<Object, Key> repo =
         new SimpleSpannerRepository<>(this.template, Object.class);
     assertThatThrownBy(() -> repo.findAllById(null))
@@ -260,7 +282,7 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void findAllById_shortcutsToEmptyReturn() {
+  void findAllById_shortcutsToEmptyReturn() {
     SimpleSpannerRepository<Object, Key> repo =
         new SimpleSpannerRepository<>(this.template, Object.class);
     assertThat(repo.findAllById(new ArrayList<>()))
@@ -269,13 +291,13 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void countTest() {
+  void countTest() {
     new SimpleSpannerRepository<Object, Key>(this.template, Object.class).count();
     verify(this.template, times(1)).count(Object.class);
   }
 
   @Test
-  public void deleteByIdTest() {
+  void deleteByIdTest() {
     when(this.entityProcessor.convertToKey(A_KEY)).thenReturn(A_KEY);
     new SimpleSpannerRepository<Object, Key>(this.template, Object.class).deleteById(A_KEY);
     verify(this.template, times(1)).delete(Object.class, A_KEY);
@@ -283,7 +305,7 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void deleteAllByIdTest() {
+  void deleteAllByIdTest() {
     List<String> unconvertedKey = Arrays.asList("key1", "key2");
 
     when(this.entityProcessor.convertToKey("key1")).thenReturn(Key.of("key1"));
@@ -298,7 +320,7 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void deleteAllById_failsOnNull() {
+  void deleteAllById_failsOnNull() {
     SimpleSpannerRepository<Object, Key> repo =
         new SimpleSpannerRepository<>(this.template, Object.class);
     assertThatThrownBy(() -> repo.deleteAllById(null))
@@ -307,20 +329,20 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void deleteTest() {
+  void deleteTest() {
     Object ob = new Object();
     new SimpleSpannerRepository<Object, Key>(this.template, Object.class).delete(ob);
     verify(this.template, times(1)).delete(ob);
   }
 
   @Test
-  public void deleteAllTest() {
+  void deleteAllTest() {
     new SimpleSpannerRepository<Object, Key>(this.template, Object.class).deleteAll();
     verify(this.template, times(1)).delete(Object.class, KeySet.all());
   }
 
   @Test
-  public void readOnlyTransactionTest() {
+  void readOnlyTransactionTest() {
     when(this.template.performReadOnlyTransaction(any(), any()))
         .thenAnswer(
             invocation -> {
@@ -335,7 +357,7 @@ public class SimpleSpannerRepositoryTests {
   }
 
   @Test
-  public void readWriteTransactionTest() {
+  void readWriteTransactionTest() {
     when(this.template.performReadWriteTransaction(any()))
         .thenAnswer(
             invocation -> {

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryFactoryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SpannerRepositoryFactoryTests.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spring.data.spanner.repository.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import com.google.cloud.spanner.Key;
@@ -27,10 +28,8 @@ import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.cloud.spring.data.spanner.core.mapping.Table;
 import com.google.cloud.spring.data.spanner.repository.query.SpannerQueryLookupStrategy;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.repository.core.EntityInformation;
@@ -39,17 +38,14 @@ import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
 
 /** Tests for the Spanner repository factory. */
-public class SpannerRepositoryFactoryTests {
+class SpannerRepositoryFactoryTests {
 
   private SpannerRepositoryFactory spannerRepositoryFactory;
 
   private SpannerTemplate spannerTemplate;
 
-  /** used to check exception messages and types. */
-  @Rule public ExpectedException expectedEx = ExpectedException.none();
-
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     SpannerMappingContext spannerMappingContext = new SpannerMappingContext();
     this.spannerTemplate = mock(SpannerTemplate.class);
     this.spannerRepositoryFactory =
@@ -57,7 +53,7 @@ public class SpannerRepositoryFactoryTests {
   }
 
   @Test
-  public void getEntityInformationTest() {
+  void getEntityInformationTest() {
     EntityInformation<TestEntity, Key> entityInformation =
         this.spannerRepositoryFactory.getEntityInformation(TestEntity.class);
     assertThat(entityInformation.getJavaType()).isEqualTo(TestEntity.class);
@@ -71,19 +67,19 @@ public class SpannerRepositoryFactoryTests {
   }
 
   @Test
-  public void getEntityInformationNotAvailableTest() {
-    this.expectedEx.expect(MappingException.class);
-    this.expectedEx.expectMessage(
-        "Could not lookup mapping metadata for domain "
-            + "class com.google.cloud.spring.data.spanner.repository.support."
-            + "SpannerRepositoryFactoryTests$TestEntity!");
+  void getEntityInformationNotAvailableTest() {
     SpannerRepositoryFactory factory =
         new SpannerRepositoryFactory(mock(SpannerMappingContext.class), this.spannerTemplate);
-    factory.getEntityInformation(TestEntity.class);
+
+    assertThatThrownBy(() -> factory.getEntityInformation(TestEntity.class))
+            .isInstanceOf(MappingException.class)
+            .hasMessage("Could not lookup mapping metadata for domain "
+                    + "class com.google.cloud.spring.data.spanner.repository.support."
+                    + "SpannerRepositoryFactoryTests$TestEntity!");
   }
 
   @Test
-  public void getTargetRepositoryTest() {
+  void getTargetRepositoryTest() {
     RepositoryInformation repoInfo = mock(RepositoryInformation.class);
     // @formatter:off
     Mockito.<Class<?>>when(repoInfo.getRepositoryBaseClass())
@@ -95,13 +91,13 @@ public class SpannerRepositoryFactoryTests {
   }
 
   @Test
-  public void getRepositoryBaseClassTest() {
+  void getRepositoryBaseClassTest() {
     Class baseClass = this.spannerRepositoryFactory.getRepositoryBaseClass(null);
     assertThat(baseClass).isEqualTo(SimpleSpannerRepository.class);
   }
 
   @Test
-  public void getQueryLookupStrategyTest() {
+  void getQueryLookupStrategyTest() {
     Optional<QueryLookupStrategy> qls =
         this.spannerRepositoryFactory.getQueryLookupStrategy(
             null, mock(QueryMethodEvaluationContextProvider.class));

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/AbstractSpannerIntegrationTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/AbstractSpannerIntegrationTest.java
@@ -25,8 +25,8 @@ import com.google.cloud.spring.data.spanner.core.admin.SpannerSchemaUtils;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.cloud.spring.data.spanner.test.domain.CommitTimestamps;
 import com.google.cloud.spring.data.spanner.test.domain.Trade;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -53,6 +53,7 @@ import org.springframework.test.context.TestExecutionListeners;
  * are generated to have a unique suffix, which is updated on the entity annotations as well
  * dynamically to avoid collisions of multiple parallel tests running against the same instance.
  */
+@EnabledIfSystemProperty(named = "it.spanner", matches = "true")
 @ContextConfiguration(classes = {IntegrationTestConfiguration.class})
 @TestExecutionListeners(
     listeners = SpannerTestExecutionListener.class,
@@ -68,15 +69,6 @@ public abstract class AbstractSpannerIntegrationTest {
   @Autowired protected SpannerSchemaUtils spannerSchemaUtils;
 
   @Autowired SpannerMappingContext spannerMappingContext;
-
-  @BeforeClass
-  public static void checkToRun() {
-    assumeThat(System.getProperty("it.spanner"))
-        .as(
-            "Spanner integration tests are disabled. Please use '-Dit.spanner=true' to enable"
-                + " them.")
-        .isEqualTo("true");
-  }
 
   @Test
   public void tableCreatedTest() {


### PR DESCRIPTION
Tests Migrated:

1. CommitTimestampIntegrationTests.java
2. SpannerTemplateIntegrationTests.java
3. SpannerKeyPropertyTests.java
4. SpannerMappingContextTests.java
5. SpannerPersistentEntityImplTests.java
6.  SpannerPersistentPropertyImplTests.java
7. ParallelSpannerRepositoryIntegrationTests.java
8. SpannerRepositoryInsertIntegrationTests.java
9. SpannerRepositoryIntegrationTests.java
10. SpannerStatementQueryTests.java
11. SqlSpannerQueryTests.java
12. SimpleSpannerRepositoryTests.java
13. SpannerRepositoryFactoryTests.java
14. AbstractSpannerIntegrationTest.java