### PR TITLE
minor fix: address errorprone complains about .equals()

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/main/java/com/example/Address.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/main/java/com/example/Address.java
@@ -36,11 +36,11 @@ public class Address {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Address)) {
       return false;
     }
     Address that = (Address) o;
-    return active == that.active
+    return Objects.equals(active, that.active)
         && Objects.equals(streetName, that.streetName)
         && Objects.equals(streetNumber, that.streetNumber);
   }


### PR DESCRIPTION
This is a class used in spanner sample code. For some reason, errorprone seems only complaining on my local and fails to build.

Errorprone complains:
- Prefer instanceof to getClass
- Boxedclass equals