### PR TITLE
Bump spring-boot-dependencies from 2.6.5 to 2.6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
 		<!-- Dependency versions -->
 		<spring-cloud-dependencies.version>2021.0.0</spring-cloud-dependencies.version>
-		<spring-boot-dependencies.version>2.6.5</spring-boot-dependencies.version>
+		<spring-boot-dependencies.version>2.6.6</spring-boot-dependencies.version>
 		<zipkin-gcp.version>1.0.4</zipkin-gcp.version>
 		<java-cfenv.version>2.4.0</java-cfenv.version>
 		<spring-native.version>0.10.5</spring-native.version>


### PR DESCRIPTION
It may take some time for dependabot to pick this up. Bump the version manually in response to [this vulnerability](https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement).