### PR TITLE
bump spring-boot-starter-parent from 2.6.2 to 2.6.6

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.2</version>
+		<version>2.6.6</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
This has not been picked up for 3.x by dependabot since 2.6.2. Possible because we tried to let dependabot ignore in #725.