### PR TITLE
Update spring cloud functions versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,15 +80,6 @@
 	<dependencyManagement>
 		<dependencies>
 
-			<!-- Addresses https://tanzu.vmware.com/security/cve-2022-22963 -->
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-function-dependencies</artifactId>
-				<version>3.2.3</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-
 			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>spring-cloud-gcp-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
 	<dependencyManagement>
 		<dependencies>
 
+			<!-- Addresses https://tanzu.vmware.com/security/cve-2022-22963 -->
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-function-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,15 @@
 
 	<dependencyManagement>
 		<dependencies>
+
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-function-dependencies</artifactId>
+				<version>3.2.3</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
 			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>spring-cloud-gcp-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
 
 	<dependencyManagement>
 		<dependencies>
-
 			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>spring-cloud-gcp-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 	<properties>
 
 		<!-- Dependency versions -->
-		<spring-cloud-dependencies.version>2021.0.0</spring-cloud-dependencies.version>
+		<spring-cloud-dependencies.version>2021.0.1</spring-cloud-dependencies.version>
 		<spring-boot-dependencies.version>2.6.6</spring-boot-dependencies.version>
 		<zipkin-gcp.version>1.0.4</zipkin-gcp.version>
 		<java-cfenv.version>2.4.0</java-cfenv.version>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -31,6 +31,15 @@
 	<dependencyManagement>
 		<dependencies>
 
+			<!-- Addresses https://tanzu.vmware.com/security/cve-2022-22963 -->
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-function-dependencies</artifactId>
+				<version>3.2.3</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
 			<!-- Overriding Guava from libraries-bom; Spring Cloud GCP does not require Java 7 support -->
 			<dependency>
 				<groupId>com.google.guava</groupId>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -31,15 +31,6 @@
 	<dependencyManagement>
 		<dependencies>
 
-			<!-- Addresses https://tanzu.vmware.com/security/cve-2022-22963 -->
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-function-dependencies</artifactId>
-				<version>3.2.3</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-
 			<!-- Overriding Guava from libraries-bom; Spring Cloud GCP does not require Java 7 support -->
 			<dependency>
 				<groupId>com.google.guava</groupId>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -2,12 +2,6 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.cloud</groupId>
-		<artifactId>spring-cloud-dependencies-parent</artifactId>
-		<version>3.0.4</version>
-		<relativePath/>
-	</parent>
 
 	<groupId>com.google.cloud</groupId>
 	<artifactId>spring-cloud-gcp-dependencies</artifactId>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-dependencies-parent</artifactId>
+		<version>3.0.4</version>
+		<relativePath/>
+	</parent>
 
 	<groupId>com.google.cloud</groupId>
 	<artifactId>spring-cloud-gcp-dependencies</artifactId>

--- a/spring-cloud-gcp-pubsub-stream-binder/pom.xml
+++ b/spring-cloud-gcp-pubsub-stream-binder/pom.xml
@@ -13,24 +13,42 @@
 	<name>Spring Cloud GCP Module - Stream</name>
 	<description>Google Cloud Pub/Sub Binder for Spring Cloud Stream</description>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.google.cloud</groupId>
-			<artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <!-- Addresses https://tanzu.vmware.com/security/cve-2022-22963 -->
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-function-dependencies</artifactId>
+        <version>3.2.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
+    </dependency>
+    <!-- intentionally redundant dependency to force parent POM version -->
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-function-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream-binder-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/spring-cloud-gcp-pubsub-stream-binder/pom.xml
+++ b/spring-cloud-gcp-pubsub-stream-binder/pom.xml
@@ -31,7 +31,8 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
     </dependency>
-    <!-- intentionally redundant dependency to force parent POM version -->
+    <!-- intentionally redundant dependency to force version lookup in
+         this pom's dependencyManagement, and not in spring-cloud-stream -->
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-function-context</artifactId>


### PR DESCRIPTION
The next Spring Cloud train release is next week. Update spring-cloud-functions versions in the meantime.

Also:
* update Spring Cloud BOM manually; dependabot missed the last one because we applied second-to-last manually.
* Remove the unnecessary `spring-cloud-dependencies-parent`; this was only needed for when the code was under Spring Cloud org.