### PR TITLE
Back out the workaround and force dependency in our BOM

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -37,6 +37,15 @@
 	<dependencyManagement>
 		<dependencies>
 
+			<!-- Addresses https://tanzu.vmware.com/security/cve-2022-22963 -->
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-function-dependencies</artifactId>
+				<version>3.2.3</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			
 			<!-- Overriding Guava from libraries-bom; Spring Cloud GCP does not require Java 7 support -->
 			<dependency>
 				<groupId>com.google.guava</groupId>

--- a/spring-cloud-gcp-pubsub-stream-binder/pom.xml
+++ b/spring-cloud-gcp-pubsub-stream-binder/pom.xml
@@ -13,29 +13,10 @@
 	<name>Spring Cloud GCP Module - Stream</name>
 	<description>Google Cloud Pub/Sub Binder for Spring Cloud Stream</description>
 
-  <dependencyManagement>
-    <dependencies>
-      <!-- Addresses https://tanzu.vmware.com/security/cve-2022-22963 -->
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-function-dependencies</artifactId>
-        <version>3.2.3</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
-    </dependency>
-    <!-- intentionally redundant dependency to force version lookup in
-         this pom's dependencyManagement, and not in spring-cloud-stream -->
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-function-context</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
With the workaround directly in Spring Cloud GCP binder, the `spring-cloud-gcp-starter-bus-pubsub` and its sample applications still pick up the bad version of `spring-cloud-function-context` from the Spring Cloud Stream dependency tree.

Forcing dependency in the Spring Cloud GCP BOM seems to be the only way to make sure Spring Cloud GCP users who follow [our documentation](https://googlecloudplatform.github.io/spring-cloud-gcp/3.0.0/reference/html/index.html#bill-of-materials) get the correct version of Spring Cloud Function.