### PR TITLE
(backport) Force patched version of Spring Cloud Function

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -37,6 +37,15 @@
 	<dependencyManagement>
 		<dependencies>
 
+			<!-- Addresses https://tanzu.vmware.com/security/cve-2022-22963 -->
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-function-dependencies</artifactId>
+				<version>3.1.7</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
 			<!-- Overriding Guava from libraries-bom; Spring Cloud GCP does not require Java 7 support -->
 			<dependency>
 				<groupId>com.google.guava</groupId>


### PR DESCRIPTION
Overrides Spring Cloud Function dependencies with ones patched for [CVE-2022-22963](https://tanzu.vmware.com/security/cve-2022-22963).