### PR TITLE
bump spring-cloud-build for docs/pom.xml, fix build failure by pin dependency version.

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>3.0.4</version>
+		<version>3.1.1</version>
 		<relativePath/>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
@@ -21,6 +21,9 @@
 		<main.basedir>${basedir}/..</main.basedir>
 		<configprops.inclusionPattern>spring.cloud.gcp.*</configprops.inclusionPattern>
 		<upload-docs-zip.phase>none</upload-docs-zip.phase>
+
+		<!--maven-resources-plugin:3.2.0:copy-resources fails: https://issues.apache.org/jira/browse/MSHARED-966-->
+		<maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
 	</properties>
 
 	<repositories>
@@ -60,6 +63,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-resources-plugin</artifactId>
+						<version>${maven-resources-plugin.version}</version>
 					</plugin>
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Looked into #1076 releaseCheck failure with debug mode, error:
```
Caused by: java.nio.file.NoSuchFileException: /path/to/repo/spring-cloud-gcp/docs/target/refdocs/index.adoc
```
Found these related issues on maven side: [MRESOURCES-278](https://issues.apache.org/jira/browse/MRESOURCES-278), [MSHARED-966](https://issues.apache.org/jira/browse/MSHARED-966).

For the meantime, use `maven-resources-plugin:3.1.0` instead.


