### PR TITLE
Fully qualified subscription configuration support + immutable configuration in Pub/Sub

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -96,6 +96,7 @@ This is useful in conjunction with enabling message ordering because sending mes
 
 |===
 | Name | Description | Required | Default value
+| `spring.cloud.gcp.pubsub.subscription.[subscription-name].fully-qualified-name` | The fully-qualified subscription name in the `projects/[PROJECT]/subscriptions/[SUBSCRIPTION]` format. When this property is present, the `[subscription-name]` key does not have to match any actual resources; it's used only for logical grouping. | No | 1
 | `spring.cloud.gcp.pubsub.subscription.[subscription-name].parallel-pull-count` | The number of pull workers. | No | 1
 | `spring.cloud.gcp.pubsub.subscription.[subscription-name].max-ack-extension-period` | The maximum period a message ack deadline will be extended, in seconds. | No | 0
 | `spring.cloud.gcp.pubsub.subscription.[subscription-name].pull-endpoint` | The endpoint for synchronous pulling messages. | No | pubsub.googleapis.com:443

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
@@ -74,6 +74,7 @@ public class GcpBigQueryAutoConfiguration {
             .setProjectId(this.projectId)
             .setCredentials(this.credentialsProvider.getCredentials())
             .setHeaderProvider(new UserAgentHeaderProvider(GcpBigQueryAutoConfiguration.class))
+            .set
             .build();
     return bigQueryOptions.getService();
   }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
@@ -74,7 +74,6 @@ public class GcpBigQueryAutoConfiguration {
             .setProjectId(this.projectId)
             .setCredentials(this.credentialsProvider.getCredentials())
             .setHeaderProvider(new UserAgentHeaderProvider(GcpBigQueryAutoConfiguration.class))
-            .set
             .build();
     return bigQueryOptions.getService();
   }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -596,12 +596,12 @@ public class GcpPubSubAutoConfiguration {
     for (Map.Entry<ProjectSubscriptionName, ThreadPoolTaskScheduler> schedulerSet :
         this.threadPoolTaskSchedulerMap.entrySet()) {
       ProjectSubscriptionName fullSubscriptionName = schedulerSet.getKey();
-      String fullyQualifiedName = fullSubscriptionName.toString();
+      String qualifiedName = fullSubscriptionName.toString();
       if (!this.executorProviderMap.containsKey(fullSubscriptionName)) {
         ThreadPoolTaskScheduler scheduler = schedulerSet.getValue();
         ExecutorProvider executorProvider =
             createAndRegisterExecutorProvider(
-                "subscriberExecutorProvider-" + fullyQualifiedName,
+                "subscriberExecutorProvider-" + qualifiedName,
                 scheduler,
                 context);
         this.executorProviderMap.putIfAbsent(fullSubscriptionName, executorProvider);
@@ -626,14 +626,14 @@ public class GcpPubSubAutoConfiguration {
 
     for (Map.Entry<ProjectSubscriptionName, PubSubConfiguration.Subscriber> subscription :
         subscriberMap.entrySet()) {
-      ProjectSubscriptionName fullyQualifiedName = subscription.getKey();
+      ProjectSubscriptionName qualifiedName = subscription.getKey();
 
       PubSubConfiguration.Retry retry =
-          this.gcpPubSubProperties.computeSubscriberRetrySettings(fullyQualifiedName);
+          this.gcpPubSubProperties.computeSubscriberRetrySettings(qualifiedName);
       RetrySettings retrySettings = buildRetrySettings(retry);
       if (retrySettings != null && !retrySettings.equals(this.globalRetrySettings)) {
-        this.subscriberRetrySettingsMap.putIfAbsent(fullyQualifiedName, retrySettings);
-        String beanName = "subscriberRetrySettings-" + fullyQualifiedName.toString();
+        this.subscriberRetrySettingsMap.putIfAbsent(qualifiedName, retrySettings);
+        String beanName = "subscriberRetrySettings-" + qualifiedName.toString();
         context.registerBeanDefinition(
             beanName,
             BeanDefinitionBuilder.genericBeanDefinition(RetrySettings.class, () -> retrySettings)

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -1154,7 +1154,7 @@ class GcpPubSubAutoConfigurationTests {
           // settings property set
           PubSubConfiguration.FlowControl flowControlForOtherSubscriber =
               gcpPubSubProperties.computeSubscriberFlowControlSettings(
-                  ProjectSubscriptionName.of("other", projectIdProvider.getProjectId()));
+                  ProjectSubscriptionName.of(projectIdProvider.getProjectId(), "other"));
           assertThat(flowControlForOtherSubscriber.getMaxOutstandingElementCount()).isEqualTo(10L);
           assertThat(flowControlForOtherSubscriber.getMaxOutstandingRequestBytes()).isEqualTo(10L);
           assertThat(flowControlForOtherSubscriber.getLimitExceededBehavior())

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -1144,7 +1144,7 @@ class GcpPubSubAutoConfigurationTests {
           // property set
           PubSubConfiguration.FlowControl flowControl =
               gcpPubSubProperties.computeSubscriberFlowControlSettings(
-                  "subscription-name", projectIdProvider.getProjectId());
+                  ProjectSubscriptionName.of(projectIdProvider.getProjectId(), "subscription-name"));
           assertThat(flowControl.getMaxOutstandingElementCount()).isEqualTo(11L);
           assertThat(flowControl.getMaxOutstandingRequestBytes()).isEqualTo(12L);
           assertThat(flowControl.getLimitExceededBehavior())
@@ -1154,7 +1154,7 @@ class GcpPubSubAutoConfigurationTests {
           // settings property set
           PubSubConfiguration.FlowControl flowControlForOtherSubscriber =
               gcpPubSubProperties.computeSubscriberFlowControlSettings(
-                  "other", projectIdProvider.getProjectId());
+                  ProjectSubscriptionName.of("other", projectIdProvider.getProjectId()));
           assertThat(flowControlForOtherSubscriber.getMaxOutstandingElementCount()).isEqualTo(10L);
           assertThat(flowControlForOtherSubscriber.getMaxOutstandingRequestBytes()).isEqualTo(10L);
           assertThat(flowControlForOtherSubscriber.getLimitExceededBehavior())
@@ -1211,7 +1211,7 @@ class GcpPubSubAutoConfigurationTests {
 
           PubSubConfiguration.FlowControl flowControl =
               gcpPubSubProperties.computeSubscriberFlowControlSettings(
-                  "subscription-name", projectIdProvider.getProjectId());
+                  ProjectSubscriptionName.of(projectIdProvider.getProjectId(), "subscription-name"));
           assertThat(flowControl.getMaxOutstandingElementCount()).isEqualTo(11L);
           assertThat(flowControl.getMaxOutstandingRequestBytes()).isEqualTo(12L);
           assertThat(flowControl.getLimitExceededBehavior())
@@ -1255,7 +1255,7 @@ class GcpPubSubAutoConfigurationTests {
 
           PubSubConfiguration.FlowControl flowControl =
               gcpPubSubProperties.computeSubscriberFlowControlSettings(
-                  "subscription-name", projectIdProvider.getProjectId());
+                  ProjectSubscriptionName.of(projectIdProvider.getProjectId(), "subscription-name"));
           assertThat(flowControl.getMaxOutstandingElementCount()).isEqualTo(11L);
           assertThat(flowControl.getMaxOutstandingRequestBytes()).isEqualTo(12L);
           assertThat(flowControl.getLimitExceededBehavior())

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -38,6 +38,7 @@ import com.google.cloud.spring.pubsub.support.CachingPublisherFactory;
 import com.google.cloud.spring.pubsub.support.DefaultPublisherFactory;
 import com.google.cloud.spring.pubsub.support.DefaultSubscriberFactory;
 import com.google.cloud.spring.pubsub.support.PublisherFactory;
+import com.google.pubsub.v1.ProjectSubscriptionName;
 import java.util.List;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.Test;
@@ -383,11 +384,11 @@ class GcpPubSubAutoConfigurationTests {
 
           // Verify that selective and global beans have been created
           ThreadPoolTaskScheduler selectiveScheduler =
-              (ThreadPoolTaskScheduler) ctx.getBean("threadPoolScheduler_subscription-name");
+              (ThreadPoolTaskScheduler) ctx.getBean("threadPoolScheduler_projects/fake project/subscriptions/subscription-name");
           ThreadPoolTaskScheduler globalScheduler =
               (ThreadPoolTaskScheduler) ctx.getBean("globalPubSubSubscriberThreadPoolScheduler");
           assertThat(selectiveScheduler.getThreadNamePrefix())
-              .isEqualTo("gcp-pubsub-subscriber-subscription-name");
+              .isEqualTo("gcp-pubsub-subscriber-projects/fake project/subscriptions/subscription-name");
           assertThat(selectiveScheduler.isDaemon()).isTrue();
           assertThat(FieldUtils.readField(selectiveScheduler, "poolSize", true)).isEqualTo(7);
           assertThat(globalScheduler.getThreadNamePrefix())
@@ -411,7 +412,7 @@ class GcpPubSubAutoConfigurationTests {
           DefaultSubscriberFactory factory =
               (DefaultSubscriberFactory) ctx.getBean("defaultSubscriberFactory");
           ExecutorProvider selectiveExecutorProvider =
-              (ExecutorProvider) ctx.getBean("subscriberExecutorProvider-subscription-name");
+              (ExecutorProvider) ctx.getBean("subscriberExecutorProvider-projects/fake project/subscriptions/subscription-name");
           ExecutorProvider globalExecutorProvider =
               (ExecutorProvider) ctx.getBean("globalSubscriberExecutorProvider");
 
@@ -437,11 +438,11 @@ class GcpPubSubAutoConfigurationTests {
 
           // Verify that selective and global beans have been created
           ThreadPoolTaskScheduler selectiveScheduler =
-              (ThreadPoolTaskScheduler) ctx.getBean("threadPoolScheduler_subscription-name");
+              (ThreadPoolTaskScheduler) ctx.getBean("threadPoolScheduler_projects/fake project/subscriptions/subscription-name");
           ThreadPoolTaskScheduler globalScheduler =
               (ThreadPoolTaskScheduler) ctx.getBean("globalPubSubSubscriberThreadPoolScheduler");
           assertThat(selectiveScheduler.getThreadNamePrefix())
-              .isEqualTo("gcp-pubsub-subscriber-subscription-name");
+              .isEqualTo("gcp-pubsub-subscriber-projects/fake project/subscriptions/subscription-name");
           assertThat(FieldUtils.readField(selectiveScheduler, "poolSize", true)).isEqualTo(3);
           assertThat(selectiveScheduler.isDaemon()).isTrue();
           assertThat(globalScheduler.getThreadNamePrefix())
@@ -514,7 +515,7 @@ class GcpPubSubAutoConfigurationTests {
           DefaultSubscriberFactory factory =
               (DefaultSubscriberFactory) ctx.getBean("defaultSubscriberFactory");
           ExecutorProvider selectiveExecutorProvider =
-              (ExecutorProvider) ctx.getBean("subscriberExecutorProvider-subscription-name");
+              (ExecutorProvider) ctx.getBean("subscriberExecutorProvider-projects/fake project/subscriptions/subscription-name");
           ExecutorProvider globalExecutorProvider =
               (ExecutorProvider) ctx.getBean("globalSubscriberExecutorProvider");
 
@@ -587,8 +588,9 @@ class GcpPubSubAutoConfigurationTests {
                   gcpPubSubProperties.computePullEndpoint(
                       "subscription-name", projectIdProvider.getProjectId()))
               .isEqualTo("my-endpoint");
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/subscription-name");
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties())
+              .containsKey(ProjectSubscriptionName.parse(
+                  "projects/fake project/subscriptions/subscription-name"));
         });
   }
 
@@ -635,11 +637,9 @@ class GcpPubSubAutoConfigurationTests {
                       "other", projectIdProvider.getProjectId()))
               .isEqualTo("other-endpoint");
 
-          assertThat(gcpPubSubProperties.getSubscription()).hasSize(2);
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/subscription-name");
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/other");
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties()).hasSize(1);
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties())
+              .containsKey(ProjectSubscriptionName.parse("projects/fake project/subscriptions/subscription-name"));
         });
   }
 
@@ -671,8 +671,8 @@ class GcpPubSubAutoConfigurationTests {
                   gcpPubSubProperties.computePullEndpoint(
                       "subscription-name", projectIdProvider.getProjectId()))
               .isEqualTo("other-endpoint");
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/subscription-name");
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties())
+              .containsKey(ProjectSubscriptionName.parse("projects/fake project/subscriptions/subscription-name"));
         });
   }
 
@@ -780,9 +780,9 @@ class GcpPubSubAutoConfigurationTests {
           assertThat(retrySettings.getInitialRpcTimeoutSeconds()).isEqualTo(6);
           assertThat(retrySettings.getRpcTimeoutMultiplier()).isEqualTo(7);
           assertThat(retrySettings.getMaxRpcTimeoutSeconds()).isEqualTo(8);
-          assertThat(gcpPubSubProperties.getSubscription()).hasSize(1);
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/subscription-name");
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties()).hasSize(1);
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties())
+              .containsKey(ProjectSubscriptionName.parse("projects/fake project/subscriptions/subscription-name"));
 
           DefaultSubscriberFactory subscriberFactory =
               ctx.getBean("defaultSubscriberFactory", DefaultSubscriberFactory.class);
@@ -799,7 +799,7 @@ class GcpPubSubAutoConfigurationTests {
                   .build();
           assertThat(subscriberFactory.getRetrySettings("subscription-name"))
               .isEqualTo(expectedRetrySettings);
-          assertThat(ctx.getBean("subscriberRetrySettings-subscription-name", RetrySettings.class))
+          assertThat(ctx.getBean("subscriberRetrySettings-projects/fake project/subscriptions/subscription-name", RetrySettings.class))
               .isEqualTo(expectedRetrySettings);
         });
   }
@@ -838,8 +838,8 @@ class GcpPubSubAutoConfigurationTests {
           PubSubConfiguration.Retry retrySettings =
               gcpPubSubProperties.computeSubscriberRetrySettings(
                   "subscription-name", projectIdProvider.getProjectId());
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/subscription-name");
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties())
+              .containsKey(ProjectSubscriptionName.parse("projects/fake project/subscriptions/subscription-name"));
           assertThat(retrySettings.getTotalTimeoutSeconds()).isEqualTo(1L);
           assertThat(retrySettings.getInitialRetryDelaySeconds()).isEqualTo(2L);
           assertThat(retrySettings.getRetryDelayMultiplier()).isEqualTo(3);
@@ -864,11 +864,9 @@ class GcpPubSubAutoConfigurationTests {
           assertThat(retrySettingsForOtherSubscriber.getInitialRpcTimeoutSeconds()).isEqualTo(10);
           assertThat(retrySettingsForOtherSubscriber.getRpcTimeoutMultiplier()).isEqualTo(10);
           assertThat(retrySettingsForOtherSubscriber.getMaxRpcTimeoutSeconds()).isEqualTo(10);
-          assertThat(gcpPubSubProperties.getSubscription()).hasSize(2);
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/subscription-name");
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/other");
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties()).hasSize(1);
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties())
+              .containsKey(ProjectSubscriptionName.parse("projects/fake project/subscriptions/subscription-name"));
 
           // Verify that beans for selective and global retry settings are created. Also
           // verify that selective retry setting takes precedence.
@@ -898,7 +896,7 @@ class GcpPubSubAutoConfigurationTests {
                   .build();
           assertThat(subscriberFactory.getRetrySettings("subscription-name"))
               .isEqualTo(expectedRetrySettingsForSubscriptionName);
-          assertThat(ctx.getBean("subscriberRetrySettings-subscription-name", RetrySettings.class))
+          assertThat(ctx.getBean("subscriberRetrySettings-projects/fake project/subscriptions/subscription-name", RetrySettings.class))
               .isEqualTo(expectedRetrySettingsForSubscriptionName);
           assertThat(subscriberFactory.getRetrySettings("other"))
               .isEqualTo(expectedRetrySettingsForOther);
@@ -1013,7 +1011,7 @@ class GcpPubSubAutoConfigurationTests {
               RetrySettings.newBuilder().setTotalTimeout(Duration.ofSeconds(10L)).build();
           assertThat(subscriberFactory.getRetrySettings("subscription-name"))
               .isEqualTo(expectedRetrySettingsForSubscriptionName);
-          assertThat(ctx.getBean("subscriberRetrySettings-subscription-name", RetrySettings.class))
+          assertThat(ctx.getBean("subscriberRetrySettings-projects/fake project/subscriptions/subscription-name", RetrySettings.class))
               .isEqualTo(expectedRetrySettingsForSubscriptionName);
           assertThat(ctx.getBean("globalSubscriberRetrySettings", RetrySettings.class))
               .isEqualTo(expectedGlobalRetrySettings);
@@ -1102,9 +1100,9 @@ class GcpPubSubAutoConfigurationTests {
           assertThat(flowControl.getMaxOutstandingRequestBytes()).isEqualTo(12L);
           assertThat(flowControl.getLimitExceededBehavior())
               .isEqualTo(FlowController.LimitExceededBehavior.Ignore);
-          assertThat(gcpPubSubProperties.getSubscription()).hasSize(1);
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/subscription-name");
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties()).hasSize(1);
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties())
+              .containsKey(ProjectSubscriptionName.parse("projects/fake project/subscriptions/subscription-name"));
 
           DefaultSubscriberFactory subscriberFactory =
               ctx.getBean("defaultSubscriberFactory", DefaultSubscriberFactory.class);
@@ -1118,7 +1116,7 @@ class GcpPubSubAutoConfigurationTests {
               .isEqualTo(expectedFlowControlForSubscriptionName);
           assertThat(
                   ctx.getBean(
-                      "subscriberFlowControlSettings-subscription-name", FlowControlSettings.class))
+                      "subscriberFlowControlSettings-projects/fake project/subscriptions/subscription-name", FlowControlSettings.class))
               .isEqualTo(expectedFlowControlForSubscriptionName);
         });
   }
@@ -1161,11 +1159,10 @@ class GcpPubSubAutoConfigurationTests {
           assertThat(flowControlForOtherSubscriber.getMaxOutstandingRequestBytes()).isEqualTo(10L);
           assertThat(flowControlForOtherSubscriber.getLimitExceededBehavior())
               .isEqualTo(FlowController.LimitExceededBehavior.Block);
-          assertThat(gcpPubSubProperties.getSubscription()).hasSize(2);
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/subscription-name");
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/other");
+          // Change in behavior: calculated properties don't get stored
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties()).hasSize(1);
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties())
+              .containsKey(ProjectSubscriptionName.parse("projects/fake project/subscriptions/subscription-name"));
 
           // Verify that beans for selective and global flow control settings are created.
           DefaultSubscriberFactory subscriberFactory =
@@ -1186,7 +1183,7 @@ class GcpPubSubAutoConfigurationTests {
               .isEqualTo(expectedFlowControlForSubscriptionName);
           assertThat(
                   ctx.getBean(
-                      "subscriberFlowControlSettings-subscription-name", FlowControlSettings.class))
+                      "subscriberFlowControlSettings-projects/fake project/subscriptions/subscription-name", FlowControlSettings.class))
               .isEqualTo(expectedFlowControlForSubscriptionName);
           assertThat(subscriberFactory.getFlowControlSettings("other"))
               .isEqualTo(expectedFlowControlForOther);
@@ -1219,9 +1216,9 @@ class GcpPubSubAutoConfigurationTests {
           assertThat(flowControl.getMaxOutstandingRequestBytes()).isEqualTo(12L);
           assertThat(flowControl.getLimitExceededBehavior())
               .isEqualTo(FlowController.LimitExceededBehavior.Ignore);
-          assertThat(gcpPubSubProperties.getSubscription()).hasSize(1);
-          assertThat(gcpPubSubProperties.getSubscription())
-              .containsKey("projects/fake project/subscriptions/subscription-name");
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties()).hasSize(1);
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties())
+              .containsKey(ProjectSubscriptionName.parse("projects/fake project/subscriptions/subscription-name"));
 
           // Verify that bean for global flow control settings is created.
           DefaultSubscriberFactory subscriberFactory =
@@ -1279,7 +1276,7 @@ class GcpPubSubAutoConfigurationTests {
               .isEqualTo(expectedFlowControlForSubscriptionName);
           assertThat(
                   ctx.getBean(
-                      "subscriberFlowControlSettings-subscription-name", FlowControlSettings.class))
+                      "subscriberFlowControlSettings-projects/fake project/subscriptions/subscription-name", FlowControlSettings.class))
               .isEqualTo(expectedFlowControlForSubscriptionName);
           assertThat(ctx.getBean("globalSubscriberFlowControlSettings", FlowControlSettings.class))
               .isEqualTo(expectedGlobalSettings);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -1345,16 +1345,16 @@ class GcpPubSubAutoConfigurationTests {
           GcpPubSubProperties gcpPubSubProperties = ctx.getBean(GcpPubSubProperties.class);
           GcpProjectIdProvider projectIdProvider = ctx.getBean(GcpProjectIdProvider.class);
 
-          ProjectSubscriptionName psn = ProjectSubscriptionName.of(projectIdProvider.getProjectId(), "subscription-name");
+          ProjectSubscriptionName projectSubscriptionName = ProjectSubscriptionName.of(projectIdProvider.getProjectId(), "subscription-name");
           PubSubConfiguration.FlowControl flowControl =
               gcpPubSubProperties
-                  .getSubscriptionProperties(psn)
+                  .getSubscriptionProperties(projectSubscriptionName)
                   .getFlowControl();
           assertThat(flowControl.getMaxOutstandingElementCount()).isEqualTo(100L);
           assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties())
               .hasSize(1)
-              .containsKey(psn);
-          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties().get(psn).getFlowControl().getMaxOutstandingElementCount()).isEqualTo(100L);
+              .containsKey(projectSubscriptionName);
+          assertThat(gcpPubSubProperties.getFullyQualifiedSubscriberProperties().get(projectSubscriptionName).getFlowControl().getMaxOutstandingElementCount()).isEqualTo(100L);
           assertThat(output).contains("Found multiple configurations for projects/fake project/subscriptions/subscription-name; ignoring properties with key synthetic-sub-name");
         });
   }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -53,15 +53,16 @@ class PubSubAutoConfigurationIntegrationTests {
       new ApplicationContextRunner()
           .withPropertyValues(
               "spring.cloud.gcp.pubsub.subscriber.retryableCodes=INTERNAL",
-              "spring.cloud.gcp.pubsub.subscription.test-sub-1.executor-threads=3",
-              "spring.cloud.gcp.pubsub.subscription.test-sub-1.retry.total-timeout-seconds=600",
-              "spring.cloud.gcp.pubsub.subscription.test-sub-1.retry.initial-retry-delay-seconds=100",
-              "spring.cloud.gcp.pubsub.subscription.test-sub-1.retry.retry-delay-multiplier=1.3",
-              "spring.cloud.gcp.pubsub.subscription.test-sub-1.retry.max-retry-delay-seconds=600",
-              "spring.cloud.gcp.pubsub.subscription.test-sub-1.retry.max-attempts=1",
-              "spring.cloud.gcp.pubsub.subscription.test-sub-1.retry.initial-rpc-timeout-seconds=600",
-              "spring.cloud.gcp.pubsub.subscription.test-sub-1.retry.rpc-timeout-multiplier=1",
-              "spring.cloud.gcp.pubsub.subscription.test-sub-1.retry.max-rpc-timeout-seconds=600",
+              "spring.cloud.gcp.pubsub.subscription.fully-qualified-test-sub-1-with-project-abc.executor-threads=3",
+              "spring.cloud.gcp.pubsub.subscription.fully-qualified-test-sub-1-with-project-abc.fully-qualified-name=projects/" + projectIdProvider.getProjectId() + "/subscriptions/test-sub-1",
+              "spring.cloud.gcp.pubsub.subscription.fully-qualified-test-sub-1-with-project-abc.retry.total-timeout-seconds=600",
+              "spring.cloud.gcp.pubsub.subscription.fully-qualified-test-sub-1-with-project-abc.retry.initial-retry-delay-seconds=100",
+              "spring.cloud.gcp.pubsub.subscription.fully-qualified-test-sub-1-with-project-abc.retry.retry-delay-multiplier=1.3",
+              "spring.cloud.gcp.pubsub.subscription.fully-qualified-test-sub-1-with-project-abc.retry.max-retry-delay-seconds=600",
+              "spring.cloud.gcp.pubsub.subscription.fully-qualified-test-sub-1-with-project-abc.retry.max-attempts=1",
+              "spring.cloud.gcp.pubsub.subscription.fully-qualified-test-sub-1-with-project-abc.retry.initial-rpc-timeout-seconds=600",
+              "spring.cloud.gcp.pubsub.subscription.fully-qualified-test-sub-1-with-project-abc.retry.rpc-timeout-multiplier=1",
+              "spring.cloud.gcp.pubsub.subscription.fully-qualified-test-sub-1-with-project-abc.retry.max-rpc-timeout-seconds=600",
               "spring.cloud.gcp.pubsub.subscription.test-sub-2.executor-threads=1",
               "spring.cloud.gcp.pubsub.subscription.test-sub-2.max-ack-extension-period=0",
               "spring.cloud.gcp.pubsub.subscription.test-sub-2.parallel-pull-count=1",
@@ -73,7 +74,7 @@ class PubSubAutoConfigurationIntegrationTests {
                   GcpContextAutoConfiguration.class, GcpPubSubAutoConfiguration.class));
 
   @BeforeAll
-  static void enableTests() {
+  static void setUp() {
     projectIdProvider = new DefaultGcpProjectIdProvider();
   }
 
@@ -85,6 +86,9 @@ class PubSubAutoConfigurationIntegrationTests {
           PubSubAdmin pubSubAdmin = context.getBean(PubSubAdmin.class);
           String topicName = "test-topic";
           String subscriptionName = "test-sub-1";
+
+          String projectId = projectIdProvider.getProjectId();
+
           if (pubSubAdmin.getTopic(topicName) != null) {
             pubSubAdmin.deleteTopic(topicName);
           }
@@ -125,23 +129,23 @@ class PubSubAutoConfigurationIntegrationTests {
           assertThat(retry.getRpcTimeoutMultiplier()).isEqualTo(1);
           assertThat(retry.getMaxRpcTimeoutSeconds()).isEqualTo(600L);
           ThreadPoolTaskScheduler scheduler =
-              (ThreadPoolTaskScheduler) context.getBean("threadPoolScheduler_test-sub-1");
+              (ThreadPoolTaskScheduler) context.getBean("threadPoolScheduler_projects/" + projectId + "/subscriptions/test-sub-1");
           assertThat(scheduler).isNotNull();
-          assertThat(scheduler.getThreadNamePrefix()).isEqualTo("gcp-pubsub-subscriber-test-sub-1");
+          assertThat(scheduler.getThreadNamePrefix()).isEqualTo("gcp-pubsub-subscriber-projects/" + projectId + "/subscriptions/test-sub-1");
           assertThat(scheduler.isDaemon()).isTrue();
           assertThat(
                   (ThreadPoolTaskScheduler)
                       context.getBean("globalPubSubSubscriberThreadPoolScheduler"))
               .isNotNull();
-          assertThat((ExecutorProvider) context.getBean("subscriberExecutorProvider-test-sub-1"))
+          assertThat((ExecutorProvider) context.getBean("subscriberExecutorProvider-projects/" + projectId + "/subscriptions/test-sub-1"))
               .isNotNull();
           assertThat((ExecutorProvider) context.getBean("globalSubscriberExecutorProvider"))
               .isNotNull();
           assertThat(
                   gcpPubSubProperties.computeRetryableCodes(
-                      "test-sub-1", projectIdProvider.getProjectId()))
+                      "test-sub-1", projectId))
               .isEqualTo(new Code[] {Code.INTERNAL});
-          assertThat((RetrySettings) context.getBean("subscriberRetrySettings-test-sub-1"))
+          assertThat((RetrySettings) context.getBean("subscriberRetrySettings-projects/" + projectId + "/subscriptions/test-sub-1"))
               .isEqualTo(expectedRetrySettings);
 
           pubSubAdmin.deleteSubscription(subscriptionName);
@@ -188,7 +192,7 @@ class PubSubAutoConfigurationIntegrationTests {
           GcpPubSubProperties gcpPubSubProperties = context.getBean(GcpPubSubProperties.class);
           PubSubConfiguration.FlowControl flowControl =
               gcpPubSubProperties.computeSubscriberFlowControlSettings(
-                  subscriptionName, projectIdProvider.getProjectId());
+                  subscriptionName, projectId);
           FlowControlSettings flowControlSettings =
               FlowControlSettings.newBuilder()
                   .setMaxOutstandingElementCount(1L)
@@ -204,11 +208,11 @@ class PubSubAutoConfigurationIntegrationTests {
               .isEqualTo(FlowController.LimitExceededBehavior.Ignore);
           assertThat(
                   gcpPubSubProperties.computeMaxAckExtensionPeriod(
-                      subscriptionName, projectIdProvider.getProjectId()))
+                      subscriptionName, projectId))
               .isZero();
           assertThat(
                   gcpPubSubProperties.computeParallelPullCount(
-                      subscriptionName, projectIdProvider.getProjectId()))
+                      subscriptionName, projectId))
               .isEqualTo(1);
           ThreadPoolTaskScheduler scheduler =
               (ThreadPoolTaskScheduler) context.getBean("threadPoolScheduler_projects/" + projectId + "/subscriptions/test-sub-2");

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -153,8 +153,11 @@ class PubSubAutoConfigurationIntegrationTests {
   void testSubscribe() {
     this.contextRunner.run(
         context -> {
+
           PubSubAdmin pubSubAdmin = context.getBean(PubSubAdmin.class);
           PubSubTemplate pubSubTemplate = context.getBean(PubSubTemplate.class);
+
+          String projectId = projectIdProvider.getProjectId();
 
           String topicName = "test-topic";
           String subscriptionName = "test-sub-2";
@@ -193,7 +196,7 @@ class PubSubAutoConfigurationIntegrationTests {
                   .setLimitExceededBehavior(FlowController.LimitExceededBehavior.Ignore)
                   .build();
           assertThat(
-                  (FlowControlSettings) context.getBean("subscriberFlowControlSettings-test-sub-2"))
+                  (FlowControlSettings) context.getBean("subscriberFlowControlSettings-projects/" + projectId + "/subscriptions/test-sub-2"))
               .isEqualTo(flowControlSettings);
           assertThat(flowControl.getMaxOutstandingElementCount()).isEqualTo(1L);
           assertThat(flowControl.getMaxOutstandingRequestBytes()).isEqualTo(1L);
@@ -208,15 +211,15 @@ class PubSubAutoConfigurationIntegrationTests {
                       subscriptionName, projectIdProvider.getProjectId()))
               .isEqualTo(1);
           ThreadPoolTaskScheduler scheduler =
-              (ThreadPoolTaskScheduler) context.getBean("threadPoolScheduler_test-sub-2");
+              (ThreadPoolTaskScheduler) context.getBean("threadPoolScheduler_projects/" + projectId + "/subscriptions/test-sub-2");
           assertThat(scheduler).isNotNull();
-          assertThat(scheduler.getThreadNamePrefix()).isEqualTo("gcp-pubsub-subscriber-test-sub-2");
+          assertThat(scheduler.getThreadNamePrefix()).isEqualTo("gcp-pubsub-subscriber-projects/" + projectId + "/subscriptions/test-sub-2");
           assertThat(scheduler.isDaemon()).isTrue();
           assertThat(
                   (ThreadPoolTaskScheduler)
                       context.getBean("globalPubSubSubscriberThreadPoolScheduler"))
               .isNotNull();
-          assertThat((ExecutorProvider) context.getBean("subscriberExecutorProvider-test-sub-2"))
+          assertThat((ExecutorProvider) context.getBean("subscriberExecutorProvider-projects/" + projectId + "/subscriptions/test-sub-2"))
               .isNotNull();
           assertThat((ExecutorProvider) context.getBean("globalSubscriberExecutorProvider"))
               .isNotNull();

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -31,6 +31,7 @@ import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.pubsub.PubSubAdmin;
 import com.google.cloud.spring.pubsub.core.PubSubConfiguration;
 import com.google.cloud.spring.pubsub.core.PubSubTemplate;
+import com.google.pubsub.v1.ProjectSubscriptionName;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.BeforeAll;
@@ -192,7 +193,7 @@ class PubSubAutoConfigurationIntegrationTests {
           GcpPubSubProperties gcpPubSubProperties = context.getBean(GcpPubSubProperties.class);
           PubSubConfiguration.FlowControl flowControl =
               gcpPubSubProperties.computeSubscriberFlowControlSettings(
-                  subscriptionName, projectId);
+                  ProjectSubscriptionName.of(subscriptionName, projectId));
           FlowControlSettings flowControlSettings =
               FlowControlSettings.newBuilder()
                   .setMaxOutstandingElementCount(1L)

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/it/PubSubAutoConfigurationIntegrationTests.java
@@ -193,7 +193,7 @@ class PubSubAutoConfigurationIntegrationTests {
           GcpPubSubProperties gcpPubSubProperties = context.getBean(GcpPubSubProperties.class);
           PubSubConfiguration.FlowControl flowControl =
               gcpPubSubProperties.computeSubscriberFlowControlSettings(
-                  ProjectSubscriptionName.of(subscriptionName, projectId));
+                  ProjectSubscriptionName.of(projectId, subscriptionName));
           FlowControlSettings flowControlSettings =
               FlowControlSettings.newBuilder()
                   .setMaxOutstandingElementCount(1L)

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubTestBinder.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/PubSubTestBinder.java
@@ -81,6 +81,7 @@ public class PubSubTestBinder
       throw new RuntimeException("Couldn't build test binder.", ioe);
     }
     PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
+    pubSubConfiguration.initialize(projectIdProvider.getProjectId());
     DefaultSubscriberFactory subscriberFactory =
         new DefaultSubscriberFactory(projectIdProvider, pubSubConfiguration);
     subscriberFactory.setChannelProvider(transportChannelProvider);

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -133,13 +133,30 @@ public class PubSubConfiguration {
    * both global and subscription-specific properties are set. If subscription-specific settings are
    * not set then global settings are picked.
    *
+   * @param subscriptionName subscription name
+   * @param projectId project id
+   * @return flow control settings
+   * @deprecated use {@link #computeSubscriberFlowControlSettings(ProjectSubscriptionName)}
+   */
+  @Deprecated
+  public FlowControl computeSubscriberFlowControlSettings(
+      String subscriptionName, String projectId) {
+    return computeSubscriberFlowControlSettings(ProjectSubscriptionName.of(projectId, subscriptionName));
+  }
+
+  /**
+   * Computes flow control settings to use. The subscription-specific property takes precedence if
+   * both global and subscription-specific properties are set. If subscription-specific settings are
+   * not set then global settings are picked.
+   *
    * @param psn Fully qualified subscription name
    * @return flow control settings defaulting to global where not provided
    */
   public FlowControl computeSubscriberFlowControlSettings(ProjectSubscriptionName psn) {
     FlowControl flowControl = getSubscriptionProperties(psn).getFlowControl();
     FlowControl globalFlowControl = this.globalSubscriber.getFlowControl();
-    // it's possible for flowControl and globalFlowControl to be the same object
+    // It is possible for flowControl and globalFlowControl to be the same object;
+    // can just return it here if that's the case.
     if (flowControl.getMaxOutstandingRequestBytes() == null) {
       flowControl.setMaxOutstandingRequestBytes(globalFlowControl.getMaxOutstandingRequestBytes());
     }
@@ -408,7 +425,6 @@ public class PubSubConfiguration {
     public void setMaxAcknowledgementThreads(int maxAcknowledgementThreads) {
       this.maxAcknowledgementThreads = maxAcknowledgementThreads;
     }
-
   }
 
   /** Health Check settings. */

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -120,8 +120,8 @@ public class PubSubConfiguration {
       ProjectSubscriptionName projectSubscriptionName =
           PubSubSubscriptionUtils.toProjectSubscriptionName(qualifiedName, defaultProjectId);
       if (fullyQualifiedProps.containsKey(projectSubscriptionName)) {
-        logger.warn("Found multiple configurations for " + projectSubscriptionName
-            + "; ignoring properties with key " + entry.getKey());
+        logger.warn("Found multiple configurations for {}; ignoring properties with key {}",
+            projectSubscriptionName, entry.getKey());
       } else {
         fullyQualifiedProps.put(projectSubscriptionName, subscriberProperties);
       }

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -88,7 +88,7 @@ public class PubSubConfiguration {
   }
 
   /**
-   * Standardizes all subscription properties to be fully qualified.
+   * Standardizes all subscription properties to be fully qualified. Not thread-safe.
    *
    * @param defaultProjectId Project to use with short subscription names
    */
@@ -105,7 +105,12 @@ public class PubSubConfiguration {
       String qualifiedName = subProps.fullyQualifiedName == null ? entry.getKey() : subProps.fullyQualifiedName;
       ProjectSubscriptionName psn =
           PubSubSubscriptionUtils.toProjectSubscriptionName(qualifiedName, defaultProjectId);
-      fullyQualifiedProps.put(psn, subProps);
+      if (fullyQualifiedProps.containsKey(psn)) {
+        logger.warn("Found multiple configurations for " + psn
+            + "; ignoring properties with key " + entry.getKey());
+      } else {
+        fullyQualifiedProps.put(psn, subProps);
+      }
     }
 
     this.fullyQualifiedSubscriptionProperties = Collections.unmodifiableMap(fullyQualifiedProps);

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -38,10 +38,10 @@ public class PubSubConfiguration {
 
   private static final Long DEFAULT_MAX_ACK_EXTENSION_PERIOD = 0L;
 
-  /** Automatically extracted user-provided properties. Can contain mixed, short and fully qualified
+  /** Automatically extracted user-provided properties. Contains only short subscription keys
    *  user-provided properties, therefore do not use except in initialize().
    */
-  private final Map<String, Subscriber> subscription = new HashMap<>();
+  private Map<String, Subscriber> subscription = new HashMap<>();
 
   /** Properties keyed by fully qualified subscription name.
    * Initialized once; effectively a singleton.
@@ -69,22 +69,26 @@ public class PubSubConfiguration {
     return health;
   }
 
-  /**
-   * breaking change
-   * @return
-   */
+ // TODO: In the future, there should be no getters for user-provided subscription property map
 
-  // In the future, there should be no getters for user-provided subscription property map
-  public Map<String, Subscriber> getSubscription() {
+/*  *//**
+   * Spring Framework uses reflection, so will be able to get this
+   *//*
+  Map<String, Subscriber> getSubscription() {
+    System.out.println("$$$$$$$$$$$$$$$$$ ******* DO NOT CALL THIS *****************");
     return this.subscription;
-/*    //Assert.notNull(this.fullyQualifiedSubscriptionProperties, "Please call initialize() prior to retrieving properties.");
-    System.out.println("********** DO NOT CALL THIS");
-    Map<String, Subscriber> stringMap = new HashMap<>();
-    for (ProjectSubscriptionName psn : this.fullyQualifiedSubscriptionProperties.keySet()) {
-      // fully qualified string, which may be different from before
-      stringMap.put(psn.toString(), this.fullyQualifiedSubscriptionProperties.get(psn));
-    }
-    return Collections.unmodifiableMap(stringMap);*/
+  }*/
+
+  /**
+   * This method will be called by Spring Framework when binding user properties.
+   * Also potentially useful for tests.
+   * @param map map of user-defined properties.
+   */
+  public void setSubscription(Map<String, Subscriber> map) {
+    Assert.isNull(this.fullyQualifiedSubscriptionProperties,
+        "Pub/Sub properties have already been initialized; cannot update subscription properties");
+
+    this.subscription = map;
   }
 
   public Map<ProjectSubscriptionName, Subscriber> getFullyQualifiedSubscriberProperties() {
@@ -121,6 +125,8 @@ public class PubSubConfiguration {
   }
 
   public Subscriber getSubscriber(String name, String projectId) {
+    Assert.notNull(this.fullyQualifiedSubscriptionProperties, "Please call initialize() prior to retrieving properties.");
+
     ProjectSubscriptionName fullyQualifiedName =
         PubSubSubscriptionUtils.toProjectSubscriptionName(name, projectId);
 

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -94,12 +94,8 @@ public class PubSubConfiguration {
       return;
     }
 
-    // TODO: re-key properties, see PR
-    System.out.println("****** initialize(); before turning fully qualified: " + this.subscription);
-
     Map<ProjectSubscriptionName, Subscriber> fullyQualifiedProps = new HashMap<>();
     for (String subscriptionKey : this.subscription.keySet()) {
-      System.out.println("*************** In initialize: subscription name = " + subscriptionKey);
       // Subscription name is either a valid short name, or a made-up name with fully-qualified provided as a property
       Subscriber subProps = this.subscription.get(subscriptionKey);
       String realSubscriptionName = subProps.fullyQualifiedName == null ? subscriptionKey : subProps.fullyQualifiedName;
@@ -107,8 +103,6 @@ public class PubSubConfiguration {
           PubSubSubscriptionUtils.toProjectSubscriptionName(realSubscriptionName, defaultProjectId);
       fullyQualifiedProps.put(fullyQualifiedName, subProps);
     }
-
-    System.out.println("****** HELLO! New properties: " + fullyQualifiedProps);
 
     this.fullyQualifiedSubscriptionProperties = Collections.unmodifiableMap(fullyQualifiedProps);
   }

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -85,6 +85,8 @@ public class PubSubConfiguration {
 
   /**
    * Standardizes all subscription properties to be fully qualified.
+   *
+   * @param defaultProjectId Project to use with short subscription names
    */
   public void initialize(String defaultProjectId) {
     if (this.fullyQualifiedSubscriptionProperties != null) {
@@ -112,11 +114,10 @@ public class PubSubConfiguration {
   }
 
   /**
-   * @Deprecated use {@link #getSubscriptionProperties(ProjectSubscriptionName)} instead.
-   *
    * @param name short subscription name
    * @param projectId subscription project name
    * @return user-provided subscription properties
+   * @deprecated use {@link #getSubscriptionProperties(ProjectSubscriptionName)} instead.
    */
   @Deprecated
   public Subscriber getSubscriber(String name, String projectId) {

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
@@ -96,9 +96,17 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
    */
   @Deprecated
   public DefaultSubscriberFactory(GcpProjectIdProvider projectIdProvider) {
-    this(projectIdProvider, new PubSubConfiguration());
+    this(projectIdProvider, getBlankConfiguration(projectIdProvider));
   }
 
+  private static PubSubConfiguration getBlankConfiguration(GcpProjectIdProvider projectIdProvider) {
+    if (projectIdProvider == null) {
+      return null;
+    }
+    PubSubConfiguration config = new PubSubConfiguration();
+    config.initialize(projectIdProvider.getProjectId());
+    return config;
+  }
   /**
    * Default {@link DefaultSubscriberFactory} constructor.
    *

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
@@ -454,10 +454,10 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
     if (this.executorProvider != null) {
       return this.executorProvider;
     }
-    ProjectSubscriptionName psn =
+    ProjectSubscriptionName projectSubscriptionName =
         PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, projectId);
-    if (this.executorProviderMap.containsKey(psn)) {
-      return this.executorProviderMap.get(psn);
+    if (this.executorProviderMap.containsKey(projectSubscriptionName)) {
+      return this.executorProviderMap.get(projectSubscriptionName);
     }
     return this.globalExecutorProvider;
   }
@@ -474,10 +474,10 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
     if (this.subscriberStubRetrySettings != null) {
       return this.subscriberStubRetrySettings;
     }
-    ProjectSubscriptionName psn =
+    ProjectSubscriptionName projectSubscriptionName =
         PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, projectId);
-    if (retrySettingsMap.containsKey(psn)) {
-      return this.retrySettingsMap.get(psn);
+    if (retrySettingsMap.containsKey(projectSubscriptionName)) {
+      return this.retrySettingsMap.get(projectSubscriptionName);
     }
     return this.globalRetrySettings;
   }
@@ -491,13 +491,13 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
    * @return flow control settings for subscriber
    */
   public FlowControlSettings getFlowControlSettings(String subscriptionName) {
-    ProjectSubscriptionName psn =
+    ProjectSubscriptionName projectSubscriptionName =
         PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, projectId);
     if (this.flowControlSettings != null) {
       return this.flowControlSettings;
     }
-    if (flowControlSettingsMap.containsKey(psn)) {
-      return this.flowControlSettingsMap.get(psn);
+    if (flowControlSettingsMap.containsKey(projectSubscriptionName)) {
+      return this.flowControlSettingsMap.get(projectSubscriptionName);
     }
     return this.globalFlowControlSettings;
   }

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
@@ -36,8 +36,9 @@ import com.google.cloud.spring.pubsub.core.health.HealthTrackerRegistry;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PullRequest;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import org.springframework.util.Assert;
 import org.threeten.bp.Duration;
 
@@ -72,16 +73,16 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 
   private PubSubConfiguration pubSubConfiguration;
 
-  private ConcurrentMap<String, FlowControlSettings> flowControlSettingsMap =
-      new ConcurrentHashMap<>();
+  private Map<ProjectSubscriptionName, FlowControlSettings> flowControlSettingsMap =
+      new HashMap<>();
 
-  private ConcurrentMap<String, RetrySettings> retrySettingsMap = new ConcurrentHashMap<>();
+  private Map<ProjectSubscriptionName, RetrySettings> retrySettingsMap = new ConcurrentHashMap<>();
 
   private FlowControlSettings globalFlowControlSettings;
 
   private RetrySettings globalRetrySettings;
 
-  private ConcurrentMap<String, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
+  private Map<ProjectSubscriptionName, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
 
   private ExecutorProvider globalExecutorProvider;
 
@@ -107,6 +108,7 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
     config.initialize(projectIdProvider.getProjectId());
     return config;
   }
+
   /**
    * Default {@link DefaultSubscriberFactory} constructor.
    *
@@ -452,10 +454,10 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
     if (this.executorProvider != null) {
       return this.executorProvider;
     }
-    String fullyQualifiedName =
-        PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, projectId).toString();
-    if (this.executorProviderMap.containsKey(fullyQualifiedName)) {
-      return this.executorProviderMap.get(fullyQualifiedName);
+    ProjectSubscriptionName psn =
+        PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, projectId);
+    if (this.executorProviderMap.containsKey(psn)) {
+      return this.executorProviderMap.get(psn);
     }
     return this.globalExecutorProvider;
   }
@@ -472,10 +474,10 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
     if (this.subscriberStubRetrySettings != null) {
       return this.subscriberStubRetrySettings;
     }
-    String fullyQualifiedName =
-        PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, projectId).toString();
-    if (retrySettingsMap.containsKey(fullyQualifiedName)) {
-      return this.retrySettingsMap.get(fullyQualifiedName);
+    ProjectSubscriptionName psn =
+        PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, projectId);
+    if (retrySettingsMap.containsKey(psn)) {
+      return this.retrySettingsMap.get(psn);
     }
     return this.globalRetrySettings;
   }
@@ -489,13 +491,13 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
    * @return flow control settings for subscriber
    */
   public FlowControlSettings getFlowControlSettings(String subscriptionName) {
-    String fullyQualifiedName =
-        PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, projectId).toString();
+    ProjectSubscriptionName psn =
+        PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, projectId);
     if (this.flowControlSettings != null) {
       return this.flowControlSettings;
     }
-    if (flowControlSettingsMap.containsKey(fullyQualifiedName)) {
-      return this.flowControlSettingsMap.get(fullyQualifiedName);
+    if (flowControlSettingsMap.containsKey(psn)) {
+      return this.flowControlSettingsMap.get(psn);
     }
     return this.globalFlowControlSettings;
   }
@@ -529,7 +531,7 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
     return this.pubSubConfiguration.computeRetryableCodes(subscriptionName, projectId);
   }
 
-  public void setExecutorProviderMap(ConcurrentMap<String, ExecutorProvider> executorProviderMap) {
+  public void setExecutorProviderMap(Map<ProjectSubscriptionName, ExecutorProvider> executorProviderMap) {
     this.executorProviderMap = executorProviderMap;
   }
 
@@ -542,7 +544,7 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
   }
 
   public void setFlowControlSettingsMap(
-      ConcurrentMap<String, FlowControlSettings> flowControlSettingsMap) {
+      Map<ProjectSubscriptionName, FlowControlSettings> flowControlSettingsMap) {
     this.flowControlSettingsMap = flowControlSettingsMap;
   }
 
@@ -550,7 +552,7 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
     this.globalFlowControlSettings = flowControlSettings;
   }
 
-  public void setRetrySettingsMap(ConcurrentMap<String, RetrySettings> retrySettingsMap) {
+  public void setRetrySettingsMap(Map<ProjectSubscriptionName, RetrySettings> retrySettingsMap) {
     this.retrySettingsMap = retrySettingsMap;
   }
 

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
@@ -408,7 +408,7 @@ class PubSubConfigurationTests {
                 .getSubscriber("subscription-name", "projectId")
                 .getExecutorThreads())
         .isNull();
-    assertThat(pubSubConfiguration.getFullyQualifiedSubscriberProperties()).hasSize(0);
+    assertThat(pubSubConfiguration.getFullyQualifiedSubscriberProperties()).isEmpty();
   }
 
   @Test

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
@@ -142,12 +142,13 @@ class PubSubConfigurationTests {
     selectiveFlowControl.setMaxOutstandingElementCount(1L);
     selectiveFlowControl.setMaxOutstandingRequestBytes(2L);
 
+    ProjectSubscriptionName psn = ProjectSubscriptionName.parse("projects/projectId/subscriptions/subscription-name");
     getUserSubscriptionMap(pubSubConfiguration)
         .put("projects/projectId/subscriptions/subscription-name", subscriber);
     pubSubConfiguration.initialize("projectId");
 
     PubSubConfiguration.FlowControl result =
-        pubSubConfiguration.computeSubscriberFlowControlSettings("subscription-name", "projectId");
+        pubSubConfiguration.computeSubscriberFlowControlSettings(psn);
 
     assertThat(result.getLimitExceededBehavior())
         .isEqualTo(FlowController.LimitExceededBehavior.Ignore);
@@ -176,8 +177,9 @@ class PubSubConfigurationTests {
 
     pubSubConfiguration.initialize("projectId");
 
+    ProjectSubscriptionName psn = ProjectSubscriptionName.of("subscription-name", "projectId");
     PubSubConfiguration.FlowControl result =
-        pubSubConfiguration.computeSubscriberFlowControlSettings("subscription-name", "projectId");
+        pubSubConfiguration.computeSubscriberFlowControlSettings(psn);
 
     assertThat(result.getLimitExceededBehavior())
         .isEqualTo(FlowController.LimitExceededBehavior.Ignore);

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
@@ -22,6 +22,7 @@ import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.cloud.spring.pubsub.core.PubSubConfiguration.Subscriber;
 import com.google.pubsub.v1.ProjectSubscriptionName;
+import java.util.Collections;
 import java.util.Map;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.Test;
@@ -142,9 +143,10 @@ class PubSubConfigurationTests {
     selectiveFlowControl.setMaxOutstandingElementCount(1L);
     selectiveFlowControl.setMaxOutstandingRequestBytes(2L);
 
-    ProjectSubscriptionName psn = ProjectSubscriptionName.parse("projects/projectId/subscriptions/subscription-name");
-    getUserSubscriptionMap(pubSubConfiguration)
-        .put("projects/projectId/subscriptions/subscription-name", subscriber);
+    ProjectSubscriptionName psn =
+        ProjectSubscriptionName.parse("projects/projectId/subscriptions/subscription-name");
+    pubSubConfiguration.setSubscription(
+        Collections.singletonMap("projects/projectId/subscriptions/subscription-name", subscriber));
     pubSubConfiguration.initialize("projectId");
 
     PubSubConfiguration.FlowControl result =
@@ -154,15 +156,6 @@ class PubSubConfigurationTests {
         .isEqualTo(FlowController.LimitExceededBehavior.Ignore);
     assertThat(result.getMaxOutstandingElementCount()).isEqualTo(1L);
     assertThat(result.getMaxOutstandingRequestBytes()).isEqualTo(2L);
-  }
-
-  private Map<String, Subscriber> getUserSubscriptionMap(PubSubConfiguration config) {
-    try {
-      return (Map<String, Subscriber>) FieldUtils.readField(config, "subscription", true);
-    } catch (IllegalAccessException e) {
-      System.out.println("Failed to read private field PubSubConfiguration.subscription");
-      throw new RuntimeException(e);
-    }
   }
 
   @Test
@@ -192,8 +185,8 @@ class PubSubConfigurationTests {
     PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
     PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
     subscriber.setParallelPullCount(2);
-    getUserSubscriptionMap(pubSubConfiguration)
-        .put("projects/projectId/subscriptions/subscription-name", subscriber);
+    pubSubConfiguration.setSubscription(
+        Collections.singletonMap("projects/projectId/subscriptions/subscription-name", subscriber));
 
     pubSubConfiguration.initialize("projectId");
 
@@ -219,8 +212,8 @@ class PubSubConfigurationTests {
     PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
     PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
     subscriber.setPullEndpoint("endpoint");
-    getUserSubscriptionMap(pubSubConfiguration)
-        .put("projects/projectId/subscriptions/subscription-name", subscriber);
+    pubSubConfiguration.setSubscription(
+        Collections.singletonMap("projects/projectId/subscriptions/subscription-name", subscriber));
 
     pubSubConfiguration.initialize("projectId");
 
@@ -246,8 +239,8 @@ class PubSubConfigurationTests {
     PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
     PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
     subscriber.setMaxAckExtensionPeriod(1L);
-    getUserSubscriptionMap(pubSubConfiguration)
-        .put("projects/projectId/subscriptions/subscription-name", subscriber);
+    pubSubConfiguration.setSubscription(
+        Collections.singletonMap("projects/projectId/subscriptions/subscription-name", subscriber));
 
     pubSubConfiguration.initialize("projectId");
 
@@ -326,8 +319,8 @@ class PubSubConfigurationTests {
     retry.setRpcTimeoutMultiplier(14.0);
     retry.setMaxRpcTimeoutSeconds(9L);
 
-    getUserSubscriptionMap(pubSubConfiguration)
-        .put("projects/projectId/subscriptions/subscription-name", subscriber);
+    pubSubConfiguration.setSubscription(
+        Collections.singletonMap("projects/projectId/subscriptions/subscription-name", subscriber));
 
     pubSubConfiguration.initialize("projectId");
 
@@ -393,8 +386,8 @@ class PubSubConfigurationTests {
     PubSubConfiguration pubSubConfiguration = new PubSubConfiguration();
     PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
     subscriber.setRetryableCodes(new Code[] {Code.INTERNAL});
-    getUserSubscriptionMap(pubSubConfiguration)
-        .put("projects/projectId/subscriptions/subscription-name", subscriber);
+    pubSubConfiguration.setSubscription(
+        Collections.singletonMap("projects/projectId/subscriptions/subscription-name", subscriber));
     pubSubConfiguration.initialize("projectId");
 
     assertThat(pubSubConfiguration.computeRetryableCodes("subscription-name", "projectId"))
@@ -424,7 +417,8 @@ class PubSubConfigurationTests {
     PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
     subscriber.setExecutorThreads(8);
 
-    getUserSubscriptionMap(pubSubConfiguration).put("subscription-name", subscriber);
+    pubSubConfiguration.setSubscription(
+        Collections.singletonMap("subscription-name", subscriber));
 
     pubSubConfiguration.initialize("projectId");
 
@@ -450,8 +444,8 @@ class PubSubConfigurationTests {
     PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
     subscriber.setExecutorThreads(8);
 
-    getUserSubscriptionMap(pubSubConfiguration)
-        .put("projects/projectId/subscriptions/subscription-name", subscriber);
+    pubSubConfiguration.setSubscription(
+        Collections.singletonMap("projects/projectId/subscriptions/subscription-name", subscriber));
 
     pubSubConfiguration.initialize("projectId");
 
@@ -475,8 +469,8 @@ class PubSubConfigurationTests {
     PubSubConfiguration.Subscriber subscriber = new PubSubConfiguration.Subscriber();
     subscriber.setExecutorThreads(8);
 
-    getUserSubscriptionMap(pubSubConfiguration)
-        .put("projects/otherProjectId/subscriptions/subscription-name", subscriber);
+    pubSubConfiguration.setSubscription(Collections.singletonMap(
+        "projects/otherProjectId/subscriptions/subscription-name", subscriber));
 
     pubSubConfiguration.initialize("projectId");
 

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/PubSubConfigurationTests.java
@@ -177,7 +177,7 @@ class PubSubConfigurationTests {
 
     pubSubConfiguration.initialize("projectId");
 
-    ProjectSubscriptionName psn = ProjectSubscriptionName.of("subscription-name", "projectId");
+    ProjectSubscriptionName psn = ProjectSubscriptionName.of("projectId", "subscription-name");
     PubSubConfiguration.FlowControl result =
         pubSubConfiguration.computeSubscriberFlowControlSettings(psn);
 

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -74,6 +74,14 @@ class DefaultSubscriberFactoryTests {
 
   @Mock private HealthTrackerRegistry healthTrackerRegistry;
 
+  private PubSubConfiguration pubSubConfig;
+
+  @BeforeEach
+  void setUp() {
+    this.pubSubConfig = new PubSubConfiguration();
+    this.pubSubConfig.initialize("some-project");
+  }
+
   @Test
   void testNewSubscriber() {
     DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "angeldust");
@@ -89,7 +97,7 @@ class DefaultSubscriberFactoryTests {
   void testNewSubscriber_constructorWithPubSubConfiguration() {
     GcpProjectIdProvider projectIdProvider = () -> "angeldust";
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
+        new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
     factory.setCredentialsProvider(this.credentialsProvider);
 
     Subscriber subscriber = factory.createSubscriber("midnight cowboy", (message, consumer) -> {});
@@ -252,7 +260,7 @@ class DefaultSubscriberFactoryTests {
   void testGetRetrySettings_notPresentInMap_pickGlobal() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
+        new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
     RetrySettings expectedRetrySettings =
         RetrySettings.newBuilder()
             .setTotalTimeout(Duration.ofSeconds(10L))
@@ -292,7 +300,7 @@ class DefaultSubscriberFactoryTests {
             .setMaxRpcTimeout(Duration.ofSeconds(10L))
             .build();
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(() -> "project", new PubSubConfiguration());
+        new DefaultSubscriberFactory(() -> "project", this.pubSubConfig);
     factory.setSubscriberStubRetrySettings(expectedRetrySettings);
 
     SubscriberStubSettings subscriberStubSettings = factory.buildGlobalSubscriberStubSettings();
@@ -450,7 +458,7 @@ class DefaultSubscriberFactoryTests {
   void testGetMaxAckExtensionPeriod_newConfiguration() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
+        new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
 
     assertThat(factory.getMaxAckExtensionPeriod("subscription-name"))
         .isEqualTo(Duration.ofSeconds(0L));
@@ -482,7 +490,7 @@ class DefaultSubscriberFactoryTests {
   void testGetParallelPullCount_newConfiguration() {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
+        new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
 
     assertThat(factory.getPullCount("subscription-name")).isNull();
   }
@@ -512,7 +520,7 @@ class DefaultSubscriberFactoryTests {
   @Test
   void testGetPullEndpoint_newConfiguration() {
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(() -> "project", new PubSubConfiguration());
+        new DefaultSubscriberFactory(() -> "project", this.pubSubConfig);
 
     assertThat(factory.getPullEndpoint("subscription-name")).isNull();
   }
@@ -521,7 +529,7 @@ class DefaultSubscriberFactoryTests {
   void testBuildGlobalSubscriberStubSettings_pullEndpoint_pickUserProvidedBean()
       throws IOException {
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(() -> "project", new PubSubConfiguration());
+        new DefaultSubscriberFactory(() -> "project", this.pubSubConfig);
     factory.setPullEndpoint("my-endpoint");
     SubscriberStubSettings globalSubscriberSettings = factory.buildGlobalSubscriberStubSettings();
     assertThat(globalSubscriberSettings.getEndpoint()).isEqualTo("my-endpoint");
@@ -544,7 +552,7 @@ class DefaultSubscriberFactoryTests {
       throws IllegalAccessException, IOException {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
+        new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
     factory.setRetryableCodes(new Code[] {Code.INTERNAL});
 
     assertThat(FieldUtils.readField(factory, "retryableCodes", true))
@@ -575,7 +583,7 @@ class DefaultSubscriberFactoryTests {
       throws IOException, IllegalAccessException {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
+        new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
     factory.setRetryableCodes(new Code[] {Code.INTERNAL});
 
     assertThat(FieldUtils.readField(factory, "retryableCodes", true))
@@ -607,7 +615,7 @@ class DefaultSubscriberFactoryTests {
 
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
+        new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
     factory.setChannelProvider(FixedTransportChannelProvider.create(this.mockTransportChannel));
     factory.setCredentialsProvider(() -> NoCredentials.getInstance());
 
@@ -624,7 +632,7 @@ class DefaultSubscriberFactoryTests {
 
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
+        new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
     factory.setChannelProvider(FixedTransportChannelProvider.create(this.mockTransportChannel));
     factory.setCredentialsProvider(() -> NoCredentials.getInstance());
 
@@ -636,7 +644,7 @@ class DefaultSubscriberFactoryTests {
   void createSubscriberStubFailsOnBadCredentials() throws IOException {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(projectIdProvider, new PubSubConfiguration());
+        new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
     factory.setChannelProvider(FixedTransportChannelProvider.create(this.mockTransportChannel));
 
     CredentialsProvider mockCredentialsProvider = mock(CredentialsProvider.class);

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -163,9 +163,9 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
-    ConcurrentHashMap<String, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
+    ConcurrentHashMap<ProjectSubscriptionName, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
     executorProviderMap.put(
-        "projects/project/subscriptions/subscription-name", mockExecutorProvider);
+        ProjectSubscriptionName.parse("projects/project/subscriptions/subscription-name"), mockExecutorProvider);
     factory.setExecutorProviderMap(executorProviderMap);
 
     assertThat(factory.getExecutorProvider("subscription-name")).isSameAs(mockExecutorProvider);
@@ -176,9 +176,9 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
-    ConcurrentHashMap<String, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
+    ConcurrentHashMap<ProjectSubscriptionName, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
     executorProviderMap.put(
-        "projects/project/subscriptions/subscription-name", mockExecutorProvider);
+        ProjectSubscriptionName.parse("projects/project/subscriptions/subscription-name"), mockExecutorProvider);
     factory.setExecutorProviderMap(executorProviderMap);
     factory.setExecutorProvider(mockGlobalExecutorProvider);
 
@@ -240,8 +240,8 @@ class DefaultSubscriberFactoryTests {
             .setRpcTimeoutMultiplier(10)
             .setMaxRpcTimeout(Duration.ofSeconds(10))
             .build();
-    ConcurrentHashMap<String, RetrySettings> settingsMap = new ConcurrentHashMap<>();
-    settingsMap.put("projects/project/subscriptions/mySubscription", expectedRetrySettings);
+    ConcurrentHashMap<ProjectSubscriptionName, RetrySettings> settingsMap = new ConcurrentHashMap<>();
+    settingsMap.put(ProjectSubscriptionName.parse("projects/project/subscriptions/mySubscription"), expectedRetrySettings);
     factory.setRetrySettingsMap(settingsMap);
 
     RetrySettings actualRetrySettings = factory.getRetrySettings("mySubscription");
@@ -401,10 +401,10 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
-    ConcurrentHashMap<String, FlowControlSettings> settingsMap = new ConcurrentHashMap<>();
+    ConcurrentHashMap<ProjectSubscriptionName, FlowControlSettings> settingsMap = new ConcurrentHashMap<>();
     FlowControlSettings expectedFlowSettings =
         FlowControlSettings.newBuilder().setMaxOutstandingRequestBytes(10L).build();
-    settingsMap.put("projects/project/subscriptions/defaultSubscription1", expectedFlowSettings);
+    settingsMap.put(ProjectSubscriptionName.parse("projects/project/subscriptions/defaultSubscription1"), expectedFlowSettings);
     factory.setFlowControlSettingsMap(settingsMap);
 
     FlowControlSettings actualFlowSettings = factory.getFlowControlSettings("defaultSubscription1");


### PR DESCRIPTION
TLDR: 
- immutable maps
- type-safe and unambiguous `ProjectSubscriptionName` map keys
- switched map types to generic `Map` interface

Details:
- In the past, settings for subscriptions not explicitly specified by the user were cached in the map as a reference to global settings. Now they are not; instead global subscriber is returned on-demand whenever properties are requested for an heretofore unknown subscription. This caused a couple of tests to change in behavior -- instead of testing for 2 entries in the map, they are now testing for only 1.
- An instance of `PubSubConfiguration` effectively can't be used until `.initialize()` is called, allowing tying settings to fully qualified subscription names, using the passed-in project ID as a default.
-  `PubSubConfiguration` no longer allows retrieval of user-provided properties in the `subscription` map. Instead, an immutable map containing equivalent fully-qualified subscription keys can be retrieved with `.getFullyQualifiedSubscriberProperties()`. Both Spring bean wiring and our unit tests now use the `setSubscription()` setter to inject "user provided" properties.
- NEW FEATURE: users can now configure the fully-qualified subscription name with `spring.cloud.gcp.pubsub.subscription.fake-short-name.fully-qualified-name` property.


What did not change?
- I did not update many of the `compute*` methods to accept a fully qualified `ProjectSubscriptionName` because they are called from a place where only a string subscription name (either short or fully qualified) is available.
- Almost no new tests; the old tests covered all cases. 

Fixes #1005.