### PR TITLE
remove references to 3.x docs and javadocs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,9 +9,8 @@ image:https://sonarcloud.io/api/project_badges/measure?project=GoogleCloudPlatfo
 This project makes it easy for Spring users to run their applications on Google Cloud Platform.
 You can check our project website https://spring.io/projects/spring-cloud-gcp[here].
 
-For a deep dive into the project, refer to the Spring Cloud GCP Reference documentation below or the https://googleapis.dev/java/spring-cloud-gcp/latest/index.html[latest Javadocs].
+For a deep dive into the project, refer to the Spring Cloud GCP Reference documentation below or the https://googleapis.dev/java/spring-cloud-gcp/2.0.10/index.html[Javadocs 2.0.10].
 
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/reference/html/index.html[Spring Cloud GCP Latest]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/2.0.10/reference/html/index.html[Spring Cloud GCP 2.0.10]
 
 If you prefer to learn by doing, try taking a look at the https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples[Spring Cloud GCP sample applications] or the https://codelabs.developers.google.com/spring[Spring on GCP codelabs].


### PR DESCRIPTION
We are currently linking to 3.3.0-SNAPSHOT from 2.x branch readme.