### PR TITLE
Removes new vision flake

### DIFF
--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
@@ -35,7 +35,7 @@ public class CloudVisionTemplateIntegrationTests {
 
     List<String> extractedTexts = cloudVisionTemplate.extractTextFromPdf(dummyPdf);
 
-    assertThat(extractedTexts).hasSize(1).contains("Dummy PDF File\n");
+    assertThat(extractedTexts).hasSize(1).contains("Dummy PDF File");
   }
 
   @Test
@@ -46,7 +46,7 @@ public class CloudVisionTemplateIntegrationTests {
 
     assertThat(extractedTexts)
         .hasSize(2)
-        .contains("Dummy PDF File Page 1\n")
-        .contains("Dummy PDF File Page 2\n");
+        .contains("Dummy PDF File Page 1")
+        .contains("Dummy PDF File Page 2");
   }
 }


### PR DESCRIPTION
Vision seems to have stopped adding the trailing newline to their OCR'ed output. Vision flakes of yesterday have turned into a fairly persistent integration test failure today.