### PR TITLE
Turn off UnicodeInCode errorprone rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@
 								<fork>true</fork>
 								<compilerArgs>
 									<arg>-XDcompilePolicy=simple</arg>
-									<arg>-Xplugin:ErrorProne</arg>
+									<arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF</arg>
 									<!-- See: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/92 -->
 									<arg>-parameters</arg>
 									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>

--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
@@ -42,7 +42,6 @@ public class CloudVisionTemplateIntegrationTests {
   public void testExtractTextFromMultiPagePdf() {
     Resource dummyPdf = new ClassPathResource("documents/multi-page-dummy.pdf");
 
-    String юникод = "haha parse this";
     List<String> extractedTexts = cloudVisionTemplate.extractTextFromPdf(dummyPdf);
 
     assertThat(extractedTexts)

--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
@@ -42,6 +42,7 @@ public class CloudVisionTemplateIntegrationTests {
   public void testExtractTextFromMultiPagePdf() {
     Resource dummyPdf = new ClassPathResource("documents/multi-page-dummy.pdf");
 
+    String юникод = "haha parse this";
     List<String> extractedTexts = cloudVisionTemplate.extractTextFromPdf(dummyPdf);
 
     assertThat(extractedTexts)


### PR DESCRIPTION
Because of an [intellij bug](https://youtrack.jetbrains.com/issue/IDEA-288257), local development can be irritating nowadays because of random issues with last character of package files getting changed to \0. 
This turns off the unicode checking rule for Java 9+, which will take care of our local development flow. 

I've tested adding non-English-ascii unicode, and it does not even get past checkstyle, so it won't get to compilation/errorprone. So this change won't relax the code standards.