### PR TITLE
Logstash 7.2 fix

### DIFF
--- a/spring-cloud-gcp-logging/pom.xml
+++ b/spring-cloud-gcp-logging/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<properties>
-		<logstash.version>7.0.1</logstash.version>
+		<logstash.version>7.2</logstash.version>
 	</properties>
 
 	<artifactId>spring-cloud-gcp-logging</artifactId>

--- a/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/extensions/LogstashLoggingEventEnhancer.java
+++ b/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/extensions/LogstashLoggingEventEnhancer.java
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.logback.LoggingEventEnhancer;
 import com.google.cloud.spring.logging.JsonLoggingEventEnhancer;
+import com.google.common.base.Splitter;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -42,13 +43,19 @@ public class LogstashLoggingEventEnhancer
   public void enhanceLogEntry(LogEntry.Builder builder, ILoggingEvent event) {
     addLogstashMarkerIfNecessary(
         event.getMarker(),
-        marker -> builder.addLabel(marker.getFieldName(), marker.getFieldValue().toString()));
+        marker -> {
+          String markerValue = Splitter.on("=").trimResults().splitToList(marker.toStringSelf()).get(1);
+          builder.addLabel(marker.getFieldName(), markerValue);
+        });
   }
 
   @Override
   public void enhanceJsonLogEntry(Map<String, Object> jsonMap, ILoggingEvent event) {
     addLogstashMarkerIfNecessary(
-        event.getMarker(), marker -> jsonMap.put(marker.getFieldName(), marker.getFieldValue()));
+        event.getMarker(), marker -> {
+          String markerValue = Splitter.on("=").trimResults().splitToList(marker.toStringSelf()).get(1);
+          jsonMap.put(marker.getFieldName(), markerValue);
+        });
   }
 
   private void addLogstashMarkerIfNecessary(


### PR DESCRIPTION
About logstash-logback-encoder 7.2 compile failures (#1135 ), I made a quick fix that should make it compatible. But it feels dependent on the `messageFormatPattern` and not robust to changes. I don’t see any other way to access this field in 7.2 though. 
logstash-logback-encoder made changes to[ hide accessibility for  `getFieldValue()`](https://github.com/logfellow/logstash-logback-encoder/blob/main/src/main/java/net/logstash/logback/marker/ObjectAppendingMarker.java#L97) in [this PR](https://github.com/logfellow/logstash-logback-encoder/pull/720).


