### PR TITLE
Customize thread name prefixes for subscription specific TaskSchedulers

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -109,6 +109,9 @@ Maximum number of outstanding bytes to keep in memory before enforcing flow cont
 The behavior when the specified limits are exceeded. | No | Block
 |===
 
+NOTE: By default, subscription-specific threads are named after fully-qualified subscription name, ex: `gcp-pubsub-subscriber-projects/project-id/subscriptions/subscription-name`.
+This can be customized, by registering a `SelectiveSchedulerThreadNameProvider` bean.
+
 ==== GRPC Connection Settings
 
 The Pub/Sub API uses the https://cloud.google.com/pubsub/docs/reference/service_apis_overview#grpc_api[GRPC] protocol to send API requests to the Pub/Sub service.

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/SelectiveSchedulerThreadNameProvider.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/SelectiveSchedulerThreadNameProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.pubsub;
+
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * Provides an interface to customize thread name of subscription-specific
+ * {@link ThreadPoolTaskScheduler}
+ */
+@FunctionalInterface
+public interface SelectiveSchedulerThreadNameProvider {
+
+  String getThreadName(ProjectSubscriptionName subscriptionName);
+}


### PR DESCRIPTION
Currently thread names for subscription specific Task Schedulers are lengthy as they comprise of 
`gcp-pubsub-subscriber-` + fully qualified subscription name, ex:
`gcp-pubsub-subscriber-projects/fake project/subscriptions/subscription-name1`

This may result in a lengthy log statement, if thread name is a part of it.

This MR allows customization of subscription specific Task Scheduler's thread names.


