### PR TITLE
Fix for spanner it test precondition setup

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/SpannerTestExecutionListener.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/SpannerTestExecutionListener.java
@@ -28,9 +28,11 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 
+@EnabledIfSystemProperty(named = "it.spanner", matches = "true")
 public class SpannerTestExecutionListener implements TestExecutionListener {
 
   private static final Log LOGGER = LogFactory.getLog(SpannerTestExecutionListener.class);
@@ -41,11 +43,6 @@ public class SpannerTestExecutionListener implements TestExecutionListener {
 
   @Override
   public void beforeTestClass(TestContext testContext) throws Exception {
-    // This runs before the JUnit @BeforeClass method, so this property needs to be checked here,
-    // too.
-    if (!"true".equalsIgnoreCase(System.getProperty("it.spanner"))) {
-      return;
-    }
 
     spannerDatabaseAdminTemplate =
         testContext.getApplicationContext().getBean(SpannerDatabaseAdminTemplate.class);
@@ -55,9 +52,6 @@ public class SpannerTestExecutionListener implements TestExecutionListener {
 
   @Override
   public void afterTestClass(TestContext testContext) throws Exception {
-    if (!"true".equalsIgnoreCase(System.getProperty("it.spanner"))) {
-      return;
-    }
 
     SpannerDatabaseAdminTemplate spannerDatabaseAdminTemplate =
         testContext.getApplicationContext().getBean(SpannerDatabaseAdminTemplate.class);

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/SpannerTestExecutionListener.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/SpannerTestExecutionListener.java
@@ -28,11 +28,9 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 
-@EnabledIfSystemProperty(named = "it.spanner", matches = "true")
 public class SpannerTestExecutionListener implements TestExecutionListener {
 
   private static final Log LOGGER = LogFactory.getLog(SpannerTestExecutionListener.class);


### PR DESCRIPTION
Switch to @EnabledIfSystemProperty to be consistent with other test classes that SpannerTemplateIntegrationTests.java depend on. This makes the behavior consistent running test in Intellij so no VM option needed.