### PR TITLE
feat: add support for ARRAY<JSON> type in Spring Data Spanner

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -483,7 +483,7 @@ Natively supported types:
 
 ==== JSON fields
 
-Spanner supports `JSON` type for columns. `JSON` columns are mapped to custom POJOs annotated with `@Column(spannerType = TypeCode.JSON)`. Read, write and query with custom SQL query are supported for JSON annotated fields.
+Spanner supports `JSON` and `ARRAY<JSON>` type for columns. Such property needs to be annotated with `@Column(spannerType = TypeCode.JSON)`. `JSON` columns are mapped to custom POJOs and `ARRAY<JSON>` columns are mapped to List of custom POJOs. Read, write and query with custom SQL query are supported for JSON annotated fields.
 
 NOTE: The default Gson instance used to convert to and from JSON representation can be customized by providing a bean of type `Gson`.
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -326,7 +326,7 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 
     if (spannerPersistentProperty.getAnnotatedColumnItemType() == Type.Code.JSON) {
       // if column annotated with JSON, convert directly
-      valueBinder.toJsonArray(this.covertIterableJsonToValue(value));
+      valueBinder.toJsonArray(this.convertIterableJsonToValue(value));
       valueSet = true;
     } else if (spannerPersistentProperty.getAnnotatedColumnItemType() != null) {
       // use the annotated column type if possible.
@@ -376,7 +376,7 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
     return Value.json(jsonString);
   }
 
-  private Iterable<String> covertIterableJsonToValue(Iterable<Object> value) {
+  private Iterable<String> convertIterableJsonToValue(Iterable<Object> value) {
     List<String> result = new ArrayList<>();
     if (value == null) {
       return null;

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -30,10 +30,12 @@ import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentEntity;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentProperty;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -308,7 +310,7 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 
   // @formatter:off
 
-  private static boolean attemptSetIterableValue(
+  private boolean attemptSetIterableValue(
       Iterable<Object> value,
       ValueBinder<WriteBuilder> valueBinder,
       SpannerPersistentProperty spannerPersistentProperty,
@@ -321,8 +323,13 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 
     boolean valueSet = false;
 
-    // use the annotated column type if possible.
-    if (spannerPersistentProperty.getAnnotatedColumnItemType() != null) {
+
+    if (spannerPersistentProperty.getAnnotatedColumnItemType() == Type.Code.JSON) {
+      // if column annotated with JSON, convert directly
+      valueBinder.toJsonArray(this.covertIterableJsonToValue(value));
+      valueSet = true;
+    } else if (spannerPersistentProperty.getAnnotatedColumnItemType() != null) {
+      // use the annotated column type if possible.
       valueSet =
           attemptSetIterablePropertyWithTypeConversion(
               value,
@@ -361,12 +368,18 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
     return true;
   }
 
-  private Value covertJsonToValue(Object value) {
+  private Value convertJsonToValue(Object value) {
     if (value == null) {
       return Value.json(null);
     }
     String jsonString = this.spannerMappingContext.getGson().toJson(value);
     return Value.json(jsonString);
+  }
+
+  private Iterable<String> covertIterableJsonToValue(Iterable<Object> value) {
+    List<String> result = new ArrayList<>();
+    value.forEach(item -> result.add(this.spannerMappingContext.getGson().toJson(item)));
+    return result;
   }
 
   /**
@@ -429,7 +442,7 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
                 this.writeConverter);
       } else if (property.getAnnotatedColumnItemType() == Type.Code.JSON) {
         // annotated json column, bind directly
-        valueBinder.to(this.covertJsonToValue(propertyValue));
+        valueBinder.to(this.convertJsonToValue(propertyValue));
         valueSet = true;
       } else if (property.getAnnotatedColumnItemType() != null) {
         // use the user's annotated column type if possible

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -378,6 +378,9 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 
   private Iterable<String> covertIterableJsonToValue(Iterable<Object> value) {
     List<String> result = new ArrayList<>();
+    if (value == null) {
+      return null;
+    }
     value.forEach(item -> result.add(this.spannerMappingContext.getGson().toJson(item)));
     return result;
   }

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
@@ -166,7 +166,14 @@ public class StructAccessor {
     return result;
   }
 
-  public <T> List<T> getListJsonValue(int colIndex, Class<T> colType) {
+  public  <T> Object getJsonValue(int colIndex, Class<T> colType) {
+    if (this.struct.getColumnType(colIndex).getCode() != Code.ARRAY) {
+      return getSingleJsonValue(colIndex, colType);
+    }
+    return getListJsonValue(colIndex, colType);
+  }
+
+  private  <T> List<T> getListJsonValue(int colIndex, Class<T> colType) {
     if (this.struct.getColumnType(colIndex).getCode() != Code.ARRAY) {
       throw new SpannerDataException("Column is not an ARRAY type: " + colIndex);
     }
@@ -209,7 +216,7 @@ public class StructAccessor {
     return gson.fromJson(jsonString, colType);
   }
 
-  public <T> T getSingleJsonValue(int colIndex, Class<T> colType) {
+  private  <T> T getSingleJsonValue(int colIndex, Class<T> colType) {
     if (this.struct.getColumnType(colIndex).getCode() != Code.JSON) {
       throw new SpannerDataException("Column of index " + colIndex + " not an JSON type.");
     }

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
@@ -27,6 +27,7 @@ import com.google.cloud.spring.core.util.MapBuilder;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerDataException;
 import com.google.gson.Gson;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -151,6 +152,30 @@ public class StructAccessor {
     Class clazz = SpannerTypeMapper.getSimpleJavaClassFor(innerTypeCode);
     BiFunction<Struct, String, List> readMethod = readIterableMapping.get(clazz);
     return readMethod.apply(this.struct, colName);
+  }
+
+  <T> List<T> getListJsonValue(String colName, Class<T> colType) {
+    if (this.struct.getColumnType(colName).getCode() != Code.ARRAY) {
+      throw new SpannerDataException("Column is not an ARRAY type: " + colName);
+    }
+    List<String> jsonStringList = this.struct.getJsonList(colName);
+    List<T> result = new ArrayList<>();
+    jsonStringList.forEach(item -> {
+      result.add(gson.fromJson(item, colType));
+    });
+    return result;
+  }
+
+  public <T> List<T> getListJsonValue(int colIndex, Class<T> colType) {
+    if (this.struct.getColumnType(colIndex).getCode() != Code.ARRAY) {
+      throw new SpannerDataException("Column is not an ARRAY type: " + colIndex);
+    }
+    List<String> jsonStringList = this.struct.getJsonList(colIndex);
+    List<T> result = new ArrayList<>();
+    jsonStringList.forEach(item -> {
+      result.add(gson.fromJson(item, colType));
+    });
+    return result;
   }
 
   boolean hasColumn(String columnName) {

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
@@ -216,7 +216,8 @@ public class StructAccessor {
     return gson.fromJson(jsonString, colType);
   }
 
-  private  <T> T getSingleJsonValue(int colIndex, Class<T> colType) {
+  //TODO: change this to private in next major release
+  public  <T> T getSingleJsonValue(int colIndex, Class<T> colType) {
     if (this.struct.getColumnType(colIndex).getCode() != Code.JSON) {
       throw new SpannerDataException("Column of index " + colIndex + " not an JSON type.");
     }

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
@@ -100,6 +100,7 @@ public class StructAccessor {
           .build();
 
   // @formatter:on
+  private static final String EXCEPTION_NARRATIVE_COL_NOT_ARRAY = "Column is not an ARRAY type: ";
 
   private Struct struct;
 
@@ -146,7 +147,7 @@ public class StructAccessor {
 
   List getListValue(String colName) {
     if (this.struct.getColumnType(colName).getCode() != Code.ARRAY) {
-      throw new SpannerDataException("Column is not an ARRAY type: " + colName);
+      throw new SpannerDataException(EXCEPTION_NARRATIVE_COL_NOT_ARRAY + colName);
     }
     Type.Code innerTypeCode = this.struct.getColumnType(colName).getArrayElementType().getCode();
     Class clazz = SpannerTypeMapper.getSimpleJavaClassFor(innerTypeCode);
@@ -156,13 +157,12 @@ public class StructAccessor {
 
   <T> List<T> getListJsonValue(String colName, Class<T> colType) {
     if (this.struct.getColumnType(colName).getCode() != Code.ARRAY) {
-      throw new SpannerDataException("Column is not an ARRAY type: " + colName);
+      throw new SpannerDataException(EXCEPTION_NARRATIVE_COL_NOT_ARRAY + colName);
     }
     List<String> jsonStringList = this.struct.getJsonList(colName);
     List<T> result = new ArrayList<>();
-    jsonStringList.forEach(item -> {
-      result.add(gson.fromJson(item, colType));
-    });
+    jsonStringList.forEach(item ->
+        result.add(gson.fromJson(item, colType)));
     return result;
   }
 
@@ -175,13 +175,12 @@ public class StructAccessor {
 
   private  <T> List<T> getListJsonValue(int colIndex, Class<T> colType) {
     if (this.struct.getColumnType(colIndex).getCode() != Code.ARRAY) {
-      throw new SpannerDataException("Column is not an ARRAY type: " + colIndex);
+      throw new SpannerDataException(EXCEPTION_NARRATIVE_COL_NOT_ARRAY + colIndex);
     }
     List<String> jsonStringList = this.struct.getJsonList(colIndex);
     List<T> result = new ArrayList<>();
-    jsonStringList.forEach(item -> {
-      result.add(gson.fromJson(item, colType));
-    });
+    jsonStringList.forEach(item ->
+        result.add(gson.fromJson(item, colType)));
     return result;
   }
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
@@ -100,7 +100,7 @@ public class StructAccessor {
           .build();
 
   // @formatter:on
-  private static final String EXCEPTION_NARRATIVE_COL_NOT_ARRAY = "Column is not an ARRAY type: ";
+  private static final String EXCEPTION_COL_NOT_ARRAY = "Column is not an ARRAY type: ";
 
   private Struct struct;
 
@@ -147,7 +147,7 @@ public class StructAccessor {
 
   List getListValue(String colName) {
     if (this.struct.getColumnType(colName).getCode() != Code.ARRAY) {
-      throw new SpannerDataException(EXCEPTION_NARRATIVE_COL_NOT_ARRAY + colName);
+      throw new SpannerDataException(EXCEPTION_COL_NOT_ARRAY + colName);
     }
     Type.Code innerTypeCode = this.struct.getColumnType(colName).getArrayElementType().getCode();
     Class clazz = SpannerTypeMapper.getSimpleJavaClassFor(innerTypeCode);
@@ -157,7 +157,7 @@ public class StructAccessor {
 
   <T> List<T> getListJsonValue(String colName, Class<T> colType) {
     if (this.struct.getColumnType(colName).getCode() != Code.ARRAY) {
-      throw new SpannerDataException(EXCEPTION_NARRATIVE_COL_NOT_ARRAY + colName);
+      throw new SpannerDataException(EXCEPTION_COL_NOT_ARRAY + colName);
     }
     List<String> jsonStringList = this.struct.getJsonList(colName);
     List<T> result = new ArrayList<>();
@@ -175,7 +175,7 @@ public class StructAccessor {
 
   private  <T> List<T> getListJsonValue(int colIndex, Class<T> colType) {
     if (this.struct.getColumnType(colIndex).getCode() != Code.ARRAY) {
-      throw new SpannerDataException(EXCEPTION_NARRATIVE_COL_NOT_ARRAY + colIndex);
+      throw new SpannerDataException(EXCEPTION_COL_NOT_ARRAY + colIndex);
     }
     List<String> jsonStringList = this.struct.getJsonList(colIndex);
     List<T> result = new ArrayList<>();

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructPropertyValueProvider.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructPropertyValueProvider.java
@@ -125,6 +125,12 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
   private <T> Iterable<T> readIterableWithConversion(
       SpannerPersistentProperty spannerPersistentProperty) {
     String colName = spannerPersistentProperty.getColumnName();
+    Type.Code spannerColumnType = spannerPersistentProperty.getAnnotatedColumnItemType();
+    if (spannerColumnType == Type.Code.JSON) {
+      List<T> value = (List<T>) this.structAccessor.getListJsonValue(colName,
+          spannerPersistentProperty.getColumnInnerType());
+      return value;
+    }
     List<?> listValue = this.structAccessor.getListValue(colName);
     return listValue.stream()
         .map(item -> convertOrRead((Class<T>) spannerPersistentProperty.getColumnInnerType(), item))

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructPropertyValueProvider.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructPropertyValueProvider.java
@@ -127,9 +127,8 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
     String colName = spannerPersistentProperty.getColumnName();
     Type.Code spannerColumnType = spannerPersistentProperty.getAnnotatedColumnItemType();
     if (spannerColumnType == Type.Code.JSON) {
-      List<T> value = (List<T>) this.structAccessor.getListJsonValue(colName,
+      return (List<T>) this.structAccessor.getListJsonValue(colName,
           spannerPersistentProperty.getColumnInnerType());
-      return value;
     }
     List<?> listValue = this.structAccessor.getListValue(colName);
     return listValue.stream()

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImpl.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImpl.java
@@ -91,6 +91,8 @@ public class SpannerPersistentEntityImpl<T>
 
   private final Set<Class<?>> jsonProperties = new HashSet<>();
 
+  private final Set<Class<?>> arrayJsonProperties = new HashSet<>();
+
   /**
    * Creates a {@link SpannerPersistentEntityImpl}.
    *
@@ -188,7 +190,9 @@ public class SpannerPersistentEntityImpl<T>
           });
     }
 
-    if (property.getAnnotatedColumnItemType() == Type.Code.JSON) {
+    if (property.getAnnotatedColumnItemType() == Type.Code.JSON && property.isCollectionLike()) {
+      this.arrayJsonProperties.add(property.getColumnInnerType());
+    } else if (property.getAnnotatedColumnItemType() == Type.Code.JSON) {
       this.jsonProperties.add(property.getType());
     }
   }
@@ -421,6 +425,15 @@ public class SpannerPersistentEntityImpl<T>
   // Lookup whether a particular class is a JSON entity property
   public boolean isJsonProperty(Class<?> type) {
     return this.jsonProperties.contains(type);
+  }
+
+  /**
+   * Lookup whether a class is an innertype of a JSONARRAY entity property
+   * @param type
+   * @return
+   */
+  public boolean isArrayJsonProperty(Class<?> type) {
+    return this.arrayJsonProperties.contains(type);
   }
 
   public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImpl.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImpl.java
@@ -91,8 +91,6 @@ public class SpannerPersistentEntityImpl<T>
 
   private final Set<Class<?>> jsonProperties = new HashSet<>();
 
-  private final Set<Class<?>> arrayJsonProperties = new HashSet<>();
-
   /**
    * Creates a {@link SpannerPersistentEntityImpl}.
    *
@@ -191,7 +189,7 @@ public class SpannerPersistentEntityImpl<T>
     }
 
     if (property.getAnnotatedColumnItemType() == Type.Code.JSON && property.isCollectionLike()) {
-      this.arrayJsonProperties.add(property.getColumnInnerType());
+      this.jsonProperties.add(property.getColumnInnerType());
     } else if (property.getAnnotatedColumnItemType() == Type.Code.JSON) {
       this.jsonProperties.add(property.getType());
     }
@@ -423,17 +421,9 @@ public class SpannerPersistentEntityImpl<T>
   }
 
   // Lookup whether a particular class is a JSON entity property
+  // or is an inner type of a ARRAY<JSON> property
   public boolean isJsonProperty(Class<?> type) {
     return this.jsonProperties.contains(type);
-  }
-
-  /**
-   * Lookup whether a class is an innertype of a JSONARRAY entity property
-   * @param type
-   * @return
-   */
-  public boolean isArrayJsonProperty(Class<?> type) {
-    return this.arrayJsonProperties.contains(type);
   }
 
   public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQuery.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQuery.java
@@ -47,7 +47,6 @@ import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
-import org.springframework.data.util.Pair;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ParserContext;

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
@@ -161,6 +161,9 @@ class SpannerSchemaUtilsTests {
   void createDdlForJson() {
     assertColumnDdl(
         JsonColumn.class, null, "jsonCol", Type.Code.JSON, OptionalLong.empty(), "jsonCol JSON");
+    assertColumnDdl(
+        List.class, JsonColumn.class, "arrayJsonCol", Type.Code.JSON, OptionalLong.empty(),
+        "arrayJsonCol ARRAY<JSON>");
   }
 
   private void assertColumnDdl(

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
@@ -393,4 +393,35 @@ class ConverterAwareMappingSpannerEntityReaderTests {
     assertThat(result.params.p1).isEqualTo("address line");
     assertThat(result.params.p2).isEqualTo("5");
   }
+
+  @Test
+  void readArrayJsonFieldTest() {
+    Struct row = mock(Struct.class);
+    when(row.getString("id")).thenReturn("1234");
+    when(row.getType())
+        .thenReturn(
+            Type.struct(
+                Arrays.asList(
+                    Type.StructField.of("id", Type.string()),
+                    Type.StructField.of("paramsList", Type.array(Type.json())))));
+    when(row.getColumnType("id")).thenReturn(Type.string());
+
+    when(row.getColumnType("paramsList")).thenReturn(Type.array(Type.json()));
+    when(row.getJsonList("paramsList")).thenReturn(
+        Arrays.asList("{\"p1\":\"address line\",\"p2\":\"5\"}",
+            "{\"p1\":\"address line 2\",\"p2\":\"6\"}", null));
+
+    TestEntities.TestEntityJsonArray result =
+        this.spannerEntityReader.read(TestEntities.TestEntityJsonArray.class, row);
+
+    assertThat(result.id).isEqualTo("1234");
+
+    assertThat(result.paramsList.get(0).p1).isEqualTo("address line");
+    assertThat(result.paramsList.get(0).p2).isEqualTo("5");
+
+    assertThat(result.paramsList.get(1).p1).isEqualTo("address line 2");
+    assertThat(result.paramsList.get(1).p2).isEqualTo("6");
+
+    assertThat(result.paramsList.get(2)).isNull();
+  }
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
@@ -364,6 +364,47 @@ class ConverterAwareMappingSpannerEntityWriterTests {
   }
 
   @Test
+  void writeJsonArrayTest() {
+    TestEntities.Params parameters = new TestEntities.Params("some value", "some other value");
+    TestEntities.TestEntityJsonArray testEntity = new TestEntities.TestEntityJsonArray("id1", Arrays.asList(parameters, parameters));
+
+    WriteBuilder writeBuilder = mock(WriteBuilder.class);
+    ValueBinder<WriteBuilder> valueBinder = mock(ValueBinder.class);
+
+    when(writeBuilder.set("id")).thenReturn(valueBinder);
+    when(writeBuilder.set("paramsList")).thenReturn(valueBinder);
+
+    this.spannerEntityWriter.write(testEntity, writeBuilder::set);
+
+    List<String> stringList = new ArrayList<>();
+    stringList.add("{\"p1\":\"some value\",\"p2\":\"some other value\"}");
+    stringList.add("{\"p1\":\"some value\",\"p2\":\"some other value\"}");
+
+    verify(valueBinder).to(testEntity.id);
+    verify(valueBinder).toJsonArray(stringList);
+  }
+
+  @Test
+  void writeNullEmptyJsonArrayTest() {
+    TestEntities.TestEntityJsonArray testNull = new TestEntities.TestEntityJsonArray("id1", null);
+    TestEntities.TestEntityJsonArray testEmpty = new TestEntities.TestEntityJsonArray("id2", new ArrayList<>());
+
+    WriteBuilder writeBuilder = mock(WriteBuilder.class);
+    ValueBinder<WriteBuilder> valueBinder = mock(ValueBinder.class);
+
+    when(writeBuilder.set("id")).thenReturn(valueBinder);
+    when(writeBuilder.set("paramsList")).thenReturn(valueBinder);
+
+    this.spannerEntityWriter.write(testNull, writeBuilder::set);
+    this.spannerEntityWriter.write(testEmpty, writeBuilder::set);
+
+    verify(valueBinder).to(testNull.id);
+    verify(valueBinder).toJsonArray(isNull());
+    verify(valueBinder).to(testEmpty.id);
+    verify(valueBinder).toJsonArray(new ArrayList<>());
+  }
+
+  @Test
   void writeUnsupportedTypeIterableTest() {
 
     FaultyTestEntity2 ft = new FaultyTestEntity2();

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
@@ -243,7 +243,7 @@ class TestEntities {
   }
 
   /** A test class with Json field. */
-  @Table(name = "custom_test_table")
+  @Table(name = "json_test_table")
   static class TestEntityJson {
     @PrimaryKey String id;
 
@@ -253,6 +253,20 @@ class TestEntities {
     TestEntityJson(String id, Params params) {
       this.id = id;
       this.params = params;
+    }
+  }
+
+  /** A test class with Json Array field. */
+  @Table(name = "jsonarray_test_table2")
+  static class TestEntityJsonArray {
+    @PrimaryKey String id;
+
+    @Column(spannerType = TypeCode.JSON)
+    List<Params> paramsList;
+
+    TestEntityJsonArray(String id, List<Params> paramsList) {
+      this.id = id;
+      this.paramsList = paramsList;
     }
   }
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentEntityImplTests.java
@@ -348,6 +348,12 @@ class SpannerPersistentEntityImplTests {
 
     assertThat(entityWithNoJsonField.isJsonProperty(String.class)).isFalse();
     assertThat(entityWithNoJsonField.isJsonProperty(long.class)).isFalse();
+
+    SpannerPersistentEntityImpl<EntityWithArrayJsonField> entityWithArrayJsonField =
+        (SpannerPersistentEntityImpl<EntityWithArrayJsonField>)
+            this.spannerMappingContext.getPersistentEntity(EntityWithArrayJsonField.class);
+    assertThat(entityWithArrayJsonField.isJsonProperty(JsonEntity.class)).isTrue();
+    assertThat(entityWithArrayJsonField.isJsonProperty(String.class)).isFalse();
   }
 
   private static class ParentInRelationship {
@@ -510,6 +516,13 @@ class SpannerPersistentEntityImplTests {
 
     @Column(spannerType = TypeCode.JSON)
     JsonEntity jsonField;
+  }
+
+  private static class EntityWithArrayJsonField {
+    @PrimaryKey String id;
+
+    @Column(spannerType = TypeCode.JSON)
+    List<JsonEntity> jsonListField;
   }
 
   private static class JsonEntity {}

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -571,6 +571,32 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   }
 
   @Test
+  void testWithArrayJsonField() {
+    Details details1 = new Details("abc", "def");
+    Details details2 = new Details("123", "234");
+    Trade trade1 = Trade.makeTrade();
+    trade1.setAdditionalDetails(Arrays.asList(details1, details2));
+    Trade trade2 = Trade.makeTrade();
+    trade2.setAdditionalDetails(null);
+    Trade trade3 = Trade.makeTrade();
+    trade3.setOptionalDetails(details1);
+
+    this.tradeRepository.save(trade1);
+    this.tradeRepository.save(trade2);
+    this.tradeRepository.save(trade3);
+
+    assertThat(this.tradeRepository.findAll()).contains(trade1, trade2, trade3);
+
+    String traderId = trade1.getTraderId();
+    List<List<Details>> detailsList = this.tradeRepository.getAdditionalDetailsById(traderId);
+    assertThat(detailsList.get(0)).containsExactly(details1, details2);
+
+    String traderId3 = trade3.getTraderId();
+    Optional<Details> optionalDetails = this.tradeRepository.getOptionalDetailsById(traderId3);
+    assertThat(optionalDetails).isEqualTo(Optional.of(details1));
+  }
+
+  @Test
   void testTransaction() {
     this.tradeRepositoryTransactionalService.testTransactionalAnnotation(2);
     assertThat(this.tradeRepository.count()).isEqualTo(1L);

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/Trade.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/Trade.java
@@ -78,6 +78,9 @@ public class Trade {
   @Column(spannerType = TypeCode.JSON)
   private Details backupDetails;
 
+  @Column(spannerType = TypeCode.JSON)
+  private List<Details> additionalDetails;
+
   /**
    * Partial constructor. Intentionally tests a field that is left null sometimes.
    *
@@ -316,6 +319,15 @@ public class Trade {
 
   public void setOptionalDetails(Details optionalDetails) {
     this.optionalDetails = optionalDetails;
+  }
+
+  public List<Details> getAdditionalDetails() {
+    return additionalDetails;
+  }
+
+  public void setAdditionalDetails(
+      List<Details> additionalDetails) {
+    this.additionalDetails = additionalDetails;
   }
 
   public void setBackupDetails(Details backupDetails) {

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/TradeRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/TradeRepository.java
@@ -142,6 +142,11 @@ public interface TradeRepository extends SpannerRepository<Trade, Key> {
           + " where trader_id = @trader_id")
   Optional<Details> getOptionalDetailsById(@Param("trader_id") String traderId);
 
+  @Query(
+      "SELECT additionalDetails from :com.google.cloud.spring.data.spanner.test.domain.Trade:"
+          + " where trader_id = @trader_id")
+  List<List<Details>> getAdditionalDetailsById(@Param("trader_id") String traderId);
+
   @NonNull
   Trade getByAction(String s);
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/main/java/com/example/SpannerRepositoryExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/main/java/com/example/SpannerRepositoryExample.java
@@ -113,7 +113,7 @@ public class SpannerRepositoryExample {
     LOGGER.info("Try http://localhost:8080/trades in the browser to see all trades.");
 
     LOGGER.info(
-        "JSON field should be annotated with \"@Column(spannerType = TypeCode.JSON)\" in data"
+        "JSON or ARRAY<JSON> field should be annotated with \"@Column(spannerType = TypeCode.JSON)\" in data"
             + " class.");
 
     Trader trader1 =
@@ -123,10 +123,15 @@ public class SpannerRepositoryExample {
     Trader trader3 =
         new Trader("demo_trader_json3", "Scott", "Smith", new Address(8L, "fake address 3", false));
     trader3.setHomeAddress(new Address(8L, "fake address 3 in unused detail", false));
+    Trader trader4 =
+        new Trader("demo_trader_json4", "John", "Doe",
+            Arrays.asList(new Address(666L, "fake address 4", false),
+                new Address(777L, "fake address 5", false)));
 
     this.traderRepository.save(trader1);
     this.traderRepository.save(trader2);
     this.traderRepository.save(trader3);
+    this.traderRepository.save(trader4);
 
     LOGGER.info(
         "Find trader by Id and print out JSON field 'workAddress' as string: "
@@ -135,6 +140,10 @@ public class SpannerRepositoryExample {
     LOGGER.info(
         "Find trader by Id and print out JSON field 'unusedDetails' as string: "
             + this.traderRepository.findById("demo_trader_json3").get().getHomeAddress());
+
+    LOGGER.info(
+        "Find trader by Id and print out ARRAY<JSON> field 'addressList' as string: "
+            + this.traderRepository.findById("demo_trader_json4").get().getAddressList().toString());
 
     long count = this.traderRepository.getCountActive("true");
     LOGGER.info("A query method can query on the properties of JSON values");

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/main/java/com/example/Trader.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/main/java/com/example/Trader.java
@@ -56,6 +56,9 @@ public class Trader {
   @Column(name = "home_address", spannerType = TypeCode.JSON)
   private Address homeAddress;
 
+  @Column(name = "address_list", spannerType = TypeCode.JSON)
+  private List<Address> addressList;
+
   public Trader() {}
 
   public Trader(String traderId, String firstName, String lastName) {
@@ -69,6 +72,14 @@ public class Trader {
     this.firstName = firstName;
     this.lastName = lastName;
     this.workAddress = workAddress;
+  }
+
+  public Trader(String traderId, String firstName, String lastName,
+      List<Address> addressList) {
+    this.traderId = traderId;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.addressList = addressList;
   }
 
   public Trader(
@@ -126,6 +137,10 @@ public class Trader {
 
   public Address getHomeAddress() {
     return homeAddress;
+  }
+
+  public List<Address> getAddressList() {
+    return addressList;
   }
 
   @Override

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/test/java/com/example/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/test/java/com/example/SpannerRepositoryIntegrationTests.java
@@ -24,6 +24,7 @@ import java.sql.Timestamp;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -135,7 +136,8 @@ class SpannerRepositoryIntegrationTests {
             "demo_trader3",
             "demo_trader_json1",
             "demo_trader_json2",
-            "demo_trader_json3");
+            "demo_trader_json3",
+            "demo_trader_json4");
 
     assertThat(this.tradeRepository.findAll()).hasSize(8);
 
@@ -167,14 +169,17 @@ class SpannerRepositoryIntegrationTests {
   }
 
   @Test
-  void testJsonFieldReadWrite() {
+  void testJsonAndArrayJsonFieldReadWrite() {
 
-    Address workAddress = new Address(5L, "address line", true);
-    Trader trader = new Trader("demo_trader1", "John", "Doe", workAddress);
+    Address address = new Address(5L, "address line", true);
+    Trader trader = new Trader("demo_trader1", "John", "Doe",
+        Arrays.asList(address, address, address));
+    trader.setHomeAddress(address);
     this.traderRepository.save(trader);
 
     Trader traderFound = this.traderRepository.findById("demo_trader1").get();
     assertThat(traderFound.getTraderId()).isEqualTo(trader.getTraderId());
-    assertThat(traderFound.getWorkAddress()).isEqualTo(workAddress);
+    assertThat(traderFound.getHomeAddress()).isEqualTo(address);
+    assertThat(traderFound.getAddressList()).contains(address, address, address);
   }
 }


### PR DESCRIPTION
support ARRAY<JSON> spanner type. 
- read: `StructAccessor.java` and `StructPropertyValueProvider.java`
- write: `ConverterAwareMappingSpannerEntityWriter.java`
- sql query when return type is ARRAY<JSON> field.
    - `SqlSpannerQuery.java` and `SpannerPersistentEntityImpl.java`
- test and sample

closes #651.