### PR TITLE
Update trace propagation order to reflect reality

### DIFF
--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -42,7 +42,14 @@ This integration enables Brave to use the https://github.com/openzipkin/zipkin-g
 
 A propagation is responsible for extracting trace context from an entity (e.g., an HTTP servlet request) and injecting trace context into an entity.
 A canonical example of the propagation usage is a web server that receives an HTTP request, which triggers other HTTP requests from the server before returning an HTTP response to the original caller.
-In the case of `StackdriverTracePropagation`, first it looks for trace context in the `x-cloud-trace-context` key (e.g., an HTTP request header).
+
+In the case of `StackdriverTracePropagation`, first it looks for trace context in the https://github.com/openzipkin/b3-propagation[X-B3 headers] (`X-B3-TraceId`, `X-B3-SpanId`).
+If those are not found, `StackdriverTracePropagation` will fall back on `x-cloud-trace-context` key (e.g., an HTTP request header).
+
+If you need different propagation behavior (e.g. relying primarily on `x-cloud-trace-context` in a mixed Spring / non-Spring application environment), Spring Cloud Sleuth allows such customization through the https://docs.spring.io/spring-cloud-sleuth/docs/current/reference/html/howto.html#how-to-change-context-propagation[`CUSTOM` propagation type].
+
+[TIP]
+====
 The value of the `x-cloud-trace-context` key can be formatted in three different ways:
 
 * `x-cloud-trace-context: TRACE_ID`
@@ -56,8 +63,8 @@ Since Cloud Trace doesn't support span joins, a new span ID is always generated,
 
 `TRACE_TRUE` can either be `0` if the entity should be untraced, or `1` if it should be traced.
 This field forces the decision of whether or not to trace the request; if omitted then the decision is deferred to the sampler.
+====
 
-If a `x-cloud-trace-context` key isn't found, `StackdriverTracePropagation` falls back to tracing with the https://github.com/openzipkin/b3-propagation[X-B3 headers].
 
 === Spring Boot Starter for Cloud Trace
 


### PR DESCRIPTION
`StackdriverTracePropagation` has been Brave-centric for years now, but Spring Cloud GCP docs did not keep up. 

Soon, we are going to have to think about how to handle two large ecosystem changes: Spring Cloud Sleuth responsibilities shifting to Micrometer and OpenCensus becoming industry standard. But for now, up to date docs will do.

Fixes #1154.