### PR TITLE
fix: SpannerStatementQueryExecutor query generation for IsNotNull conditions

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryExecutor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryExecutor.java
@@ -689,7 +689,7 @@ public final class SpannerStatementQueryExecutor {
                           andString += "<" + insertedTag;
                           break;
                         case IS_NOT_NULL:
-                          andString += "<>NULL";
+                          andString += " IS NOT NULL";
                           break;
                         case LESS_THAN_EQUAL:
                           andString += "<=" + insertedTag;

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -614,6 +614,17 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
     assertThat(foundTrades).isEmpty();
   }
 
+  @Test
+  void findAllByActionIsNotNull() {
+    insertTrades("trader1", "SELL", 2);
+    insertTrades("trader2", null, 3);
+
+    assertThat(this.tradeRepository.count()).isEqualTo(5L);
+
+    List<Trade> tradesWithActionNotNull = this.tradeRepository.findAllByActionIsNotNull("not used");
+    assertThat(tradesWithActionNotNull).hasSize(2);
+  }
+
   private List<Trade> insertTrades(String traderId, String action, int numTrades) {
     List<Trade> trades = new ArrayList<>();
     for (int i = 0; i < numTrades; i++) {

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
@@ -120,7 +120,7 @@ class SpannerStatementQueryTests {
               String expectedQuery =
                   "SELECT DISTINCT shares, trader_id, ticker, price, action, id, value FROM trades"
                       + " WHERE ( LOWER(action)=LOWER(@tag0) AND ticker=@tag1 ) OR ("
-                      + " trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND id<>NULL AND"
+                      + " trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND id IS NOT NULL AND"
                       + " trader_id=NULL AND trader_id LIKE @tag7 AND price=TRUE AND price=FALSE"
                       + " AND price>@tag10 AND price<=@tag11 AND price IN UNNEST(@tag12) AND"
                       + " value<@tag13 ) ORDER BY id DESC LIMIT 3";
@@ -231,7 +231,7 @@ class SpannerStatementQueryTests {
               String expectedSql =
                   "SELECT EXISTS(SELECT DISTINCT shares, trader_id, ticker, price, action, id,"
                       + " value FROM trades WHERE ( LOWER(action)=LOWER(@tag0) AND ticker=@tag1 )"
-                      + " OR ( trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND id<>NULL AND"
+                      + " OR ( trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND id IS NOT NULL AND"
                       + " trader_id=NULL AND trader_id LIKE @tag7 AND price=TRUE AND price=FALSE"
                       + " AND price>@tag10 AND price<=@tag11 ) ORDER BY id DESC LIMIT 1)";
               assertThat(statement.getSql()).isEqualTo(expectedSql);

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
@@ -382,7 +382,7 @@ class SqlSpannerQueryTests {
             + " WHERE price=#{#tag3 * -1} AND price<>#{#tag3 * -1} OR "
             + "price<>#{#tag4 * -1} AND "
             + "( action=@tag0 AND ticker=@tag1 ) OR "
-            + "( trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND id<>NULL AND "
+            + "( trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND id IS NOT NULL AND "
             + "trader_id=NULL AND trader_id LIKE %@tag5 AND price=TRUE AND price=FALSE AND "
             + "struct_val = @tag8 AND struct_val = @tag9 "
             + "price>@tag6 AND price<=@tag7 and price in unnest(@tag10)) ORDER BY id DESC LIMIT 3;";
@@ -396,7 +396,7 @@ class SqlSpannerQueryTests {
             + " children FROM (SELECT DISTINCT * FROM trades@{index=fakeindex} WHERE"
             + " price=@SpELtag1 AND price<>@SpELtag1 OR price<>@SpELtag2 AND ( action=@tag0 AND"
             + " ticker=@tag1 ) OR ( trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND"
-            + " id<>NULL AND trader_id=NULL AND trader_id LIKE %@tag5 AND price=TRUE AND"
+            + " id IS NOT NULL AND trader_id=NULL AND trader_id LIKE %@tag5 AND price=TRUE AND"
             + " price=FALSE AND struct_val = @tag8 AND struct_val = @tag9 price>@tag6 AND"
             + " price<=@tag7 and price in unnest(@tag10)) ORDER BY id DESC LIMIT 3) trades ORDER BY"
             + " COLA ASC , COLB DESC LIMIT 10 OFFSET 30";

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/TradeRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/TradeRepository.java
@@ -113,6 +113,8 @@ public interface TradeRepository extends SpannerRepository<Trade, Key> {
 
   List<Trade> findBySymbolNotContains(String symbolFragment);
 
+  List<Trade> findAllByActionIsNotNull(String actionNotUsed);
+
   @Query(
       "SELECT * FROM :com.google.cloud.spring.data.spanner.test.domain.Trade:"
           + " WHERE STRUCT(symbol,action) = @pairTag ORDER BY LOWER(action) DESC")


### PR DESCRIPTION
fixes #1168.

When including `IsNotNull` conditions in query methods by convention, Spanner query fails with  error `Query failed: Operands of <> cannot be literal NULL` with `property<>NULL` syntax. Changing to `property IS NOT NULL` instead.