### PR TITLE
Remove exclamation points from tests

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepository.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/SimpleDatastoreRepository.java
@@ -256,8 +256,8 @@ public class SimpleDatastoreRepository<T, I> implements DatastoreRepository<T, I
   @Override
   public <S extends T, R> R findBy(
       Example<S> example, Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction) {
-    Assert.notNull(example, "Example must not be null!");
-    Assert.notNull(queryFunction, "Query function must not be null!");
+    Assert.notNull(example, "Example must not be null");
+    Assert.notNull(queryFunction, "Query function must not be null");
 
     return queryFunction.apply(new DatastoreFluentQueryByExample<>(example));
   }

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
@@ -402,7 +402,7 @@ class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests {
 
     assertThatThrownBy(() -> this.testEntityRepository.findByColor("green"))
         .isInstanceOf(EmptyResultDataAccessException.class)
-        .hasMessageMatching("Result must not be null!");
+        .hasMessageMatching("Result must not be null");
 
     assertThat(
             this.testEntityRepository.findByShape(Shape.SQUARE).stream()

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -543,7 +543,7 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
   void testNonNull() {
     assertThatThrownBy(() -> this.tradeRepository.getByAction("non-existing-action"))
         .isInstanceOf(EmptyResultDataAccessException.class)
-        .hasMessageMatching("Result must not be null!");
+        .hasMessageMatching("Result must not be null");
   }
 
   @Test


### PR DESCRIPTION
Spring Data [removed](https://github.com/spring-projects/spring-data-commons/issues/2603) non-load-bearing punctuation from their exceptions.

We have a couple of spots where we verify exception wording, and I've removed another two places just for consistency. Note that this only affects the tests, and not the code throwing those exceptions.