### PR TITLE
fix: update broken link in doc.

### DIFF
--- a/docs/src/main/asciidoc/core.adoc
+++ b/docs/src/main/asciidoc/core.adoc
@@ -53,7 +53,7 @@ spring.cloud.gcp.project-id=my-gcp-project-id
 ----
 
 Otherwise, the project ID is discovered based on an
-https://googlecloudplatform.github.io/google-cloud-java/google-cloud-clients/apidocs/com/google/cloud/ServiceOptions.html#getDefaultProjectId--[ordered list of rules]:
+https://cloud.google.com/java/docs/reference/google-cloud-core/latest/com.google.cloud.ServiceOptions#com_google_cloud_ServiceOptions_getDefaultProjectId__[ordered list of rules]:
 
 1. The project ID specified by the `GOOGLE_CLOUD_PROJECT` environment variable
 2. The Google App Engine project ID

--- a/docs/src/main/md/core.md
+++ b/docs/src/main/md/core.md
@@ -51,7 +51,7 @@ spring.cloud.gcp.project-id=my-gcp-project-id
 ```
 
 Otherwise, the project ID is discovered based on an [ordered list of
-rules](https://googlecloudplatform.github.io/google-cloud-java/google-cloud-clients/apidocs/com/google/cloud/ServiceOptions.html#getDefaultProjectId--):
+rules](https://cloud.google.com/java/docs/reference/google-cloud-core/latest/com.google.cloud.ServiceOptions#com_google_cloud_ServiceOptions_getDefaultProjectId__):
 
 1.  The project ID specified by the `GOOGLE_CLOUD_PROJECT` environment
     variable


### PR DESCRIPTION
the old link for `ServiceOptions.getDefaultProjectId()` does not exist anymore, updated the link to client lib references.