### PR TITLE
feat: support  for `spring.config.import` GCP Secret Manager

### DIFF
--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -137,9 +137,9 @@ Secret Manager boostrap phrase.
 spring.cloud.gcp.secretmanager.legacy=false
 ----
 
-2. After running the application, updates your secret stored in the Secret Manager.
+2. After running the application, update your secret stored in the Secret Manager.
 
-3. To refresh the secret, send the following command to your server from which hosting the application:
+3. To refresh the secret, send the following command to your application sever:
 +
 [source]
 ----

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -108,6 +108,43 @@ private SecretManagerTemplate secretManagerTemplate;
 
 Please consult https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/main/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerOperations.java[`SecretManagerOperations`] for information on what operations are available for the Secret Manager template.
 
+=== Refresh secrets without restarting the application
+
+1. Before running your application, change the project's configuration files as follows:
++
+import the actuator starter dependency to your project,
++
+[source]
+----
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+</dependency>
+----
+add the following property to your project's `application.properties`,
++
+[source]
+----
+management.endpoints.web.exposure.include=refresh
+----
++
+finally, add the following property to your project's `bootstrap.properties` to enable https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4[Spring Boot's Config Data API].
++
+[source]
+----
+spring.cloud.gcp.secretmanager.legacy=false
+----
+
+2. After running the application, change your secrets using https://console.cloud.google.com/security/secret-manager[Secret Manager Cloud Console UI].
+
+3. To refresh the secret, send the following command to your server from which hosting the application:
++
+[source]
+----
+curl -X POST http://[host]:[port]/actuator/refresh
+----
+Note that only `@ConfigurationProperties` annotated with `@RefreshScope` got the updated value.
+
 === Sample
 
 A https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample[Secret Manager Sample Application] is provided which demonstrates basic property source loading and usage of the template class.

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -121,21 +121,23 @@ import the actuator starter dependency to your project,
     <artifactId>spring-boot-starter-actuator</artifactId>
 </dependency>
 ----
-add the following property to your project's `application.properties`,
+add the following properties to your project's `application.properties`. The latter is used to enable https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4[Spring Boot's Config Data API].
 +
 [source]
 ----
 management.endpoints.web.exposure.include=refresh
+spring.config.import=sm://
 ----
 +
-finally, add the following property to your project's `bootstrap.properties` to enable https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4[Spring Boot's Config Data API].
+finally, add the following property to your project's `bootstrap.properties` to disable
+Secret Manager boostrap phrase.
 +
 [source]
 ----
 spring.cloud.gcp.secretmanager.legacy=false
 ----
 
-2. After running the application, change your secrets using https://console.cloud.google.com/security/secret-manager[Secret Manager Cloud Console UI].
+2. After running the application, updates your secret stored in the Secret Manager.
 
 3. To refresh the secret, send the following command to your server from which hosting the application:
 +
@@ -143,7 +145,7 @@ spring.cloud.gcp.secretmanager.legacy=false
 ----
 curl -X POST http://[host]:[port]/actuator/refresh
 ----
-Note that only `@ConfigurationProperties` annotated with `@RefreshScope` got the updated value.
+Note that only `@ConfigurationProperties` annotated with `@RefreshScope` support updating secrets without restarting the application.
 
 === Sample
 

--- a/docs/src/main/md/secretmanager.md
+++ b/docs/src/main/md/secretmanager.md
@@ -145,9 +145,9 @@ template.
         spring.cloud.gcp.secretmanager.legacy=false
 
 
-2. After running the application, updates your secret stored in the Secret Manager.
+2. After running the application, update your secret stored in the Secret Manager.
 
-3. To refresh the secret, send the following command to your server from which hosting the application:
+3. To refresh the secret, send the following command to your application sever:
 
          curl -X POST http://[host]:[port]/actuator/refresh
 

--- a/docs/src/main/md/secretmanager.md
+++ b/docs/src/main/md/secretmanager.md
@@ -134,22 +134,24 @@ template.
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
-- add the following property to your project's `application.properties`,
+- add the following property to your project's `application.properties`. The latter is used to enable [Spring Boot's Config Data API](https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4).
 
         management.endpoints.web.exposure.include=refresh
+        spring.config.import=sm://
 
-- finally, add the following property to your project's `bootstrap.properties` to enable [Spring Boot's Config Data API](https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4).
+- finally, add the following property to your project's `bootstrap.properties` to disable
+  Secret Manager boostrap phrase.
  
         spring.cloud.gcp.secretmanager.legacy=false
 
 
-2. After running the application, change your secrets using [Secret Manager Cloud Console UI](https://console.cloud.google.com/security/secret-manager).
+2. After running the application, updates your secret stored in the Secret Manager.
 
 3. To refresh the secret, send the following command to your server from which hosting the application:
 
          curl -X POST http://[host]:[port]/actuator/refresh
 
-    Note that only `@ConfigurationProperties` annotated with `@RefreshScope` got the updated value.
+    Note that only `@ConfigurationProperties` annotated with `@RefreshScope` support updating secrets without restarting the application.
 
 ### Sample
 

--- a/docs/src/main/md/secretmanager.md
+++ b/docs/src/main/md/secretmanager.md
@@ -123,6 +123,34 @@ Please consult
 for information on what operations are available for the Secret Manager
 template.
 
+### Refresh secrets without restarting the application
+
+1. Before running your application, change the project's configuration files as follows:
+
+- import the actuator starter dependency to your project,
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+- add the following property to your project's `application.properties`,
+
+        management.endpoints.web.exposure.include=refresh
+
+- finally, add the following property to your project's `bootstrap.properties` to enable [Spring Boot's Config Data API](https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4).
+ 
+        spring.cloud.gcp.secretmanager.legacy=false
+
+
+2. After running the application, change your secrets using [Secret Manager Cloud Console UI](https://console.cloud.google.com/security/secret-manager).
+
+3. To refresh the secret, send the following command to your server from which hosting the application:
+
+         curl -X POST http://[host]:[port]/actuator/refresh
+
+    Note that only `@ConfigurationProperties` annotated with `@RefreshScope` got the updated value.
+
 ### Sample
 
 A [Secret Manager Sample

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -90,4 +90,10 @@ public class GcpSecretManagerBootstrapConfiguration {
       SecretManagerTemplate secretManagerTemplate) {
     return new SecretManagerPropertySourceLocator(secretManagerTemplate, this.gcpProjectIdProvider);
   }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public GcpProjectIdProvider gcpProjectIdProvider() {
+    return gcpProjectIdProvider;
+  }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -39,6 +39,8 @@ import org.springframework.core.env.ConfigurableEnvironment;
  * into the application {@link org.springframework.core.env.Environment}.
  *
  * @since 1.2.2
+ * @deprecated since external resources should be using Spring Boot's Config Data API, more info in
+ *     <a href="https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4">here</a>.
  */
 @Deprecated
 @Configuration(proxyBeanMethods = false)
@@ -52,7 +54,6 @@ public class GcpSecretManagerBootstrapConfiguration {
   public GcpSecretManagerBootstrapConfiguration(
       GcpSecretManagerProperties properties, ConfigurableEnvironment configurableEnvironment) {
 
-    System.out.println("*** OLD WAY boostrap config GcpSecretManagerBootstrapConfiguration constructor ");
     this.gcpProjectIdProvider =
         properties.getProjectId() != null
             ? properties::getProjectId
@@ -70,7 +71,6 @@ public class GcpSecretManagerBootstrapConfiguration {
   @ConditionalOnMissingBean
   public SecretManagerServiceClient secretManagerClient(CredentialsProvider googleCredentials)
       throws IOException {
-    System.out.println("*** OLD WAY boostrap config GcpSecretManagerBootstrapConfiguration.secretManagerClient ");
     SecretManagerServiceSettings settings =
         SecretManagerServiceSettings.newBuilder()
             .setCredentialsProvider(googleCredentials)
@@ -92,11 +92,5 @@ public class GcpSecretManagerBootstrapConfiguration {
   public SecretManagerPropertySourceLocator secretManagerPropertySourceLocator(
       SecretManagerTemplate secretManagerTemplate) {
     return new SecretManagerPropertySourceLocator(secretManagerTemplate, this.gcpProjectIdProvider);
-  }
-
-  @Bean
-  @ConditionalOnMissingBean
-  public GcpProjectIdProvider gcpProjectIdProvider() {
-    return gcpProjectIdProvider;
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -51,6 +51,7 @@ public class GcpSecretManagerBootstrapConfiguration {
   public GcpSecretManagerBootstrapConfiguration(
       GcpSecretManagerProperties properties, ConfigurableEnvironment configurableEnvironment) {
 
+    System.out.println("*** OLD WAY boostrap config GcpSecretManagerBootstrapConfiguration constructor ");
     this.gcpProjectIdProvider =
         properties.getProjectId() != null
             ? properties::getProjectId
@@ -68,6 +69,7 @@ public class GcpSecretManagerBootstrapConfiguration {
   @ConditionalOnMissingBean
   public SecretManagerServiceClient secretManagerClient(CredentialsProvider googleCredentials)
       throws IOException {
+    System.out.println("*** OLD WAY boostrap config GcpSecretManagerBootstrapConfiguration.secretManagerClient ");
     SecretManagerServiceSettings settings =
         SecretManagerServiceSettings.newBuilder()
             .setCredentialsProvider(googleCredentials)
@@ -88,6 +90,7 @@ public class GcpSecretManagerBootstrapConfiguration {
   @ConditionalOnMissingBean
   public SecretManagerPropertySourceLocator secretManagerPropertySourceLocator(
       SecretManagerTemplate secretManagerTemplate) {
+    System.out.println("*** OLD WAY: SM bootstrap configuration secretManagerPropertySourceLocator");
     return new SecretManagerPropertySourceLocator(secretManagerTemplate, this.gcpProjectIdProvider);
   }
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -40,6 +40,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
  *
  * @since 1.2.2
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(GcpSecretManagerProperties.class)
 @ConditionalOnClass({SecretManagerServiceClient.class, SecretManagerTemplate.class})
@@ -90,7 +91,6 @@ public class GcpSecretManagerBootstrapConfiguration {
   @ConditionalOnMissingBean
   public SecretManagerPropertySourceLocator secretManagerPropertySourceLocator(
       SecretManagerTemplate secretManagerTemplate) {
-    System.out.println("*** OLD WAY: SM bootstrap configuration secretManagerPropertySourceLocator");
     return new SecretManagerPropertySourceLocator(secretManagerTemplate, this.gcpProjectIdProvider);
   }
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -89,6 +89,7 @@ public class GcpSecretManagerBootstrapConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  @ConditionalOnProperty(value = "spring.cloud.gcp.secretmanager.legacy", matchIfMissing = true)
   public SecretManagerPropertySourceLocator secretManagerPropertySourceLocator(
       SecretManagerTemplate secretManagerTemplate) {
     return new SecretManagerPropertySourceLocator(secretManagerTemplate, this.gcpProjectIdProvider);

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerEnvironmentPostProcessor.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerEnvironmentPostProcessor.java
@@ -28,6 +28,7 @@ public class GcpSecretManagerEnvironmentPostProcessor implements EnvironmentPost
   @Override
   public void postProcessEnvironment(
       ConfigurableEnvironment environment, SpringApplication application) {
+    System.out.println("*** OLD WAY GcpSecretManagerEnvironmentPostProcessor.postProcessEnvironment");
     boolean isSecretManagerEnabled =
         Boolean.parseBoolean(
             environment.getProperty("spring.cloud.gcp.secretmanager.enabled", "true"));

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerEnvironmentPostProcessor.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerEnvironmentPostProcessor.java
@@ -22,14 +22,14 @@ import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.env.ConfigurableEnvironment;
 
-/** Registers converters used by Spring Cloud GCP Secret Manager. */
-@Deprecated
+/**
+ * Registers converters used by Spring Cloud GCP Secret Manager.
+ */
 public class GcpSecretManagerEnvironmentPostProcessor implements EnvironmentPostProcessor {
 
   @Override
   public void postProcessEnvironment(
       ConfigurableEnvironment environment, SpringApplication application) {
-
     boolean isSecretManagerEnabled =
         Boolean.parseBoolean(
             environment.getProperty("spring.cloud.gcp.secretmanager.enabled", "true"));
@@ -39,12 +39,22 @@ public class GcpSecretManagerEnvironmentPostProcessor implements EnvironmentPost
       environment
           .getConversionService()
           .addConverter(
-              (Converter<ByteString, String>) ByteString::toStringUtf8);
+              new Converter<ByteString, String>() {
+                @Override
+                public String convert(ByteString source) {
+                  return source.toStringUtf8();
+                }
+              });
 
       environment
           .getConversionService()
           .addConverter(
-              (Converter<ByteString, byte[]>) ByteString::toByteArray);
+              new Converter<ByteString, byte[]>() {
+                @Override
+                public byte[] convert(ByteString source) {
+                  return source.toByteArray();
+                }
+              });
     }
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerEnvironmentPostProcessor.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerEnvironmentPostProcessor.java
@@ -23,12 +23,13 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.env.ConfigurableEnvironment;
 
 /** Registers converters used by Spring Cloud GCP Secret Manager. */
+@Deprecated
 public class GcpSecretManagerEnvironmentPostProcessor implements EnvironmentPostProcessor {
 
   @Override
   public void postProcessEnvironment(
       ConfigurableEnvironment environment, SpringApplication application) {
-    System.out.println("*** OLD WAY GcpSecretManagerEnvironmentPostProcessor.postProcessEnvironment");
+
     boolean isSecretManagerEnabled =
         Boolean.parseBoolean(
             environment.getProperty("spring.cloud.gcp.secretmanager.enabled", "true"));
@@ -38,22 +39,12 @@ public class GcpSecretManagerEnvironmentPostProcessor implements EnvironmentPost
       environment
           .getConversionService()
           .addConverter(
-              new Converter<ByteString, String>() {
-                @Override
-                public String convert(ByteString source) {
-                  return source.toStringUtf8();
-                }
-              });
+              (Converter<ByteString, String>) ByteString::toStringUtf8);
 
       environment
           .getConversionService()
           .addConverter(
-              new Converter<ByteString, byte[]>() {
-                @Override
-                public byte[] convert(ByteString source) {
-                  return source.toByteArray();
-                }
-              });
+              (Converter<ByteString, byte[]>) ByteString::toByteArray);
     }
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerProperties.java
@@ -31,6 +31,7 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
    * Configuration prefix for Secret Manager properties.
    */
   public static final String PREFIX = "spring.cloud.gcp.secretmanager";
+
   /**
    * Overrides the GCP OAuth2 credentials specified in the Core module.
    */

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerProperties.java
@@ -16,20 +16,30 @@
 
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
+import static com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerProperties.PREFIX;
+
 import com.google.cloud.spring.core.Credentials;
 import com.google.cloud.spring.core.CredentialsSupplier;
 import com.google.cloud.spring.core.GcpScope;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-@ConfigurationProperties("spring.cloud.gcp.secretmanager")
+@ConfigurationProperties(PREFIX)
 public class GcpSecretManagerProperties implements CredentialsSupplier {
 
-  /** Overrides the GCP OAuth2 credentials specified in the Core module. */
+  /**
+   * Configuration prefix for Secret Manager properties.
+   */
+  public static final String PREFIX = "spring.cloud.gcp.secretmanager";
+  /**
+   * Overrides the GCP OAuth2 credentials specified in the Core module.
+   */
   @NestedConfigurationProperty
   private final Credentials credentials = new Credentials(GcpScope.CLOUD_PLATFORM.getUrl());
 
-  /** Overrides the GCP Project ID specified in the Core module. */
+  /**
+   * Overrides the GCP Project ID specified in the Core module.
+   */
   private String projectId;
 
   public Credentials getCredentials() {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
+import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.secretmanager.SecretManagerPropertySource;
 import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
 import java.io.IOException;
@@ -24,38 +25,25 @@ import org.springframework.boot.context.config.ConfigData;
 import org.springframework.boot.context.config.ConfigDataLoader;
 import org.springframework.boot.context.config.ConfigDataLoaderContext;
 import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
 public class SecretManagerConfigDataLoader implements
     ConfigDataLoader<SecretManagerConfigDataResource> {
-
-  SecretManagerConfigDataLoader() {
-    System.out.println("*** NEW WAY: SecretManagerConfigDataLoader constructor");
-  }
 
   @Override
   public ConfigData load(
       ConfigDataLoaderContext context,
       SecretManagerConfigDataResource resource)
       throws IOException, ConfigDataResourceNotFoundException {
-    System.out.println("*** NEW WAY: SecretManagerConfigDataLoader.load()");
-    // SecretManagerServiceClient secretManagerServiceClient =
-    //     resource.getSecretManagerServiceClient();
-    //
-    // GcpProjectIdProvider projectIdProvider =
-    //     context.getBootstrapContext().get(GcpProjectIdProvider.class);
-    //
-    // SecretManagerTemplate template = new SecretManagerTemplate(secretManagerServiceClient,
-    //     projectIdProvider);
-    SecretManagerTemplate secretManagerTemplate = resource.secretManagerTemplate();
-  /*
-    if (!secretManagerTemplate.secretExists( resource.getLocation().toString())) {
-      throw new ConfigDataResourceNotFoundException(resource);
-    }*/
-    SecretManagerPropertySource propertySource = new SecretManagerPropertySource(
-        "spring-cloud-gcp-secret-manager", secretManagerTemplate, secretManagerTemplate.getProjectIdProvider());
+    SecretManagerTemplate secretManagerTemplate = getImperativeInfrastructure(context,
+        SecretManagerTemplate.class);
+    GcpProjectIdProvider projectIdProvider = getImperativeInfrastructure(context,
+        GcpProjectIdProvider.class);
 
-    return new ConfigData(Collections.singleton(propertySource));
+    return new ConfigData(Collections.singleton(new SecretManagerPropertySource(
+        "spring-cloud-gcp-secret-manager", secretManagerTemplate, projectIdProvider)));
+  }
+
+  private <T> T getImperativeInfrastructure(ConfigDataLoaderContext context, Class<T> clazz) {
+    return context.getBootstrapContext().get(clazz);
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
@@ -17,7 +33,8 @@ public class SecretManagerConfigDataLoader implements
   @Override
   public ConfigData load(
       ConfigDataLoaderContext context,
-      SecretManagerConfigDataResource resource) throws IOException, ConfigDataResourceNotFoundException {
+      SecretManagerConfigDataResource resource)
+      throws IOException, ConfigDataResourceNotFoundException {
     SecretManagerServiceClient secretManagerServiceClient =
         resource.getSecretManagerServiceClient();
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
-import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.secretmanager.SecretManagerPropertySource;
 import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
 import java.io.IOException;
@@ -31,12 +30,8 @@ import org.springframework.context.annotation.Configuration;
 public class SecretManagerConfigDataLoader implements
     ConfigDataLoader<SecretManagerConfigDataResource> {
 
-  private SecretManagerTemplate template;
-  private GcpProjectIdProvider idProvider;
-
-  SecretManagerConfigDataLoader(SecretManagerTemplate template, GcpProjectIdProvider idProvider) {
-    this.template = template;
-    this.idProvider = idProvider;
+  SecretManagerConfigDataLoader() {
+    System.out.println("*** NEW WAY: SecretManagerConfigDataLoader constructor");
   }
 
   @Override
@@ -44,6 +39,7 @@ public class SecretManagerConfigDataLoader implements
       ConfigDataLoaderContext context,
       SecretManagerConfigDataResource resource)
       throws IOException, ConfigDataResourceNotFoundException {
+    System.out.println("*** NEW WAY: SecretManagerConfigDataLoader.load()");
     // SecretManagerServiceClient secretManagerServiceClient =
     //     resource.getSecretManagerServiceClient();
     //
@@ -52,11 +48,13 @@ public class SecretManagerConfigDataLoader implements
     //
     // SecretManagerTemplate template = new SecretManagerTemplate(secretManagerServiceClient,
     //     projectIdProvider);
-    if (!template.secretExists(resource.getLocation().toString())) {
+    SecretManagerTemplate secretManagerTemplate = resource.secretManagerTemplate();
+  /*
+    if (!secretManagerTemplate.secretExists( resource.getLocation().toString())) {
       throw new ConfigDataResourceNotFoundException(resource);
-    }
+    }*/
     SecretManagerPropertySource propertySource = new SecretManagerPropertySource(
-        "spring-cloud-gcp-secret-manager", template, idProvider);
+        "spring-cloud-gcp-secret-manager", secretManagerTemplate, secretManagerTemplate.getProjectIdProvider());
 
     return new ConfigData(Collections.singleton(propertySource));
   }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
@@ -34,16 +34,13 @@ public class SecretManagerConfigDataLoader implements
       ConfigDataLoaderContext context,
       SecretManagerConfigDataResource resource)
       throws IOException, ConfigDataResourceNotFoundException {
-    SecretManagerTemplate secretManagerTemplate = getImperativeInfrastructure(context,
-        SecretManagerTemplate.class);
-    GcpProjectIdProvider projectIdProvider = getImperativeInfrastructure(context,
-        GcpProjectIdProvider.class);
+    SecretManagerTemplate secretManagerTemplate = context.getBootstrapContext()
+        .get(SecretManagerTemplate.class);
+
+    GcpProjectIdProvider projectIdProvider = context.getBootstrapContext()
+        .get(GcpProjectIdProvider.class);
 
     return new ConfigData(Collections.singleton(new SecretManagerPropertySource(
         "spring-cloud-gcp-secret-manager", secretManagerTemplate, projectIdProvider)));
-  }
-
-  private <T> T getImperativeInfrastructure(ConfigDataLoaderContext context, Class<T> clazz) {
-    return context.getBootstrapContext().get(clazz);
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2022-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
@@ -1,0 +1,37 @@
+package com.google.cloud.spring.autoconfigure.secretmanager;
+
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.spring.core.GcpProjectIdProvider;
+import com.google.cloud.spring.secretmanager.SecretManagerPropertySource;
+import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
+import java.io.IOException;
+import java.util.Collections;
+import org.springframework.boot.context.config.ConfigData;
+import org.springframework.boot.context.config.ConfigDataLoader;
+import org.springframework.boot.context.config.ConfigDataLoaderContext;
+import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+
+public class SecretManagerConfigDataLoader implements
+    ConfigDataLoader<SecretManagerConfigDataResource> {
+
+  @Override
+  public ConfigData load(
+      ConfigDataLoaderContext context,
+      SecretManagerConfigDataResource resource) throws IOException, ConfigDataResourceNotFoundException {
+    SecretManagerServiceClient secretManagerServiceClient =
+        resource.getSecretManagerServiceClient();
+
+    GcpProjectIdProvider projectIdProvider =
+        context.getBootstrapContext().get(GcpProjectIdProvider.class);
+
+    SecretManagerTemplate template = new SecretManagerTemplate(secretManagerServiceClient,
+        projectIdProvider);
+    if (!template.secretExists(resource.getLocation().toString())) {
+      throw new ConfigDataResourceNotFoundException(resource);
+    }
+    SecretManagerPropertySource propertySource = new SecretManagerPropertySource(
+        "spring-cloud-gcp-secret-manager", template, projectIdProvider);
+
+    return new ConfigData(Collections.singleton(propertySource));
+  }
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoader.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
-import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.secretmanager.SecretManagerPropertySource;
 import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
@@ -26,28 +25,38 @@ import org.springframework.boot.context.config.ConfigData;
 import org.springframework.boot.context.config.ConfigDataLoader;
 import org.springframework.boot.context.config.ConfigDataLoaderContext;
 import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+import org.springframework.context.annotation.Configuration;
 
+@Configuration
 public class SecretManagerConfigDataLoader implements
     ConfigDataLoader<SecretManagerConfigDataResource> {
+
+  private SecretManagerTemplate template;
+  private GcpProjectIdProvider idProvider;
+
+  SecretManagerConfigDataLoader(SecretManagerTemplate template, GcpProjectIdProvider idProvider) {
+    this.template = template;
+    this.idProvider = idProvider;
+  }
 
   @Override
   public ConfigData load(
       ConfigDataLoaderContext context,
       SecretManagerConfigDataResource resource)
       throws IOException, ConfigDataResourceNotFoundException {
-    SecretManagerServiceClient secretManagerServiceClient =
-        resource.getSecretManagerServiceClient();
-
-    GcpProjectIdProvider projectIdProvider =
-        context.getBootstrapContext().get(GcpProjectIdProvider.class);
-
-    SecretManagerTemplate template = new SecretManagerTemplate(secretManagerServiceClient,
-        projectIdProvider);
+    // SecretManagerServiceClient secretManagerServiceClient =
+    //     resource.getSecretManagerServiceClient();
+    //
+    // GcpProjectIdProvider projectIdProvider =
+    //     context.getBootstrapContext().get(GcpProjectIdProvider.class);
+    //
+    // SecretManagerTemplate template = new SecretManagerTemplate(secretManagerServiceClient,
+    //     projectIdProvider);
     if (!template.secretExists(resource.getLocation().toString())) {
       throw new ConfigDataResourceNotFoundException(resource);
     }
     SecretManagerPropertySource propertySource = new SecretManagerPropertySource(
-        "spring-cloud-gcp-secret-manager", template, projectIdProvider);
+        "spring-cloud-gcp-secret-manager", template, idProvider);
 
     return new ConfigData(Collections.singleton(propertySource));
   }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -112,7 +112,7 @@ public class SecretManagerConfigDataLocationResolver implements
       SecretManagerServiceSettings settings = SecretManagerServiceSettings.newBuilder()
           .setCredentialsProvider(credentialsProvider)
           .setHeaderProvider(
-              new UserAgentHeaderProvider(GcpSecretManagerBootstrapConfiguration.class))
+              new UserAgentHeaderProvider(SecretManagerConfigDataLoader.class))
           .build();
       secretManagerServiceClient = SecretManagerServiceClient.create(settings);
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -1,0 +1,122 @@
+package com.google.cloud.spring.autoconfigure.secretmanager;
+
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
+import com.google.cloud.spring.core.DefaultCredentialsProvider;
+import com.google.cloud.spring.core.DefaultGcpProjectIdProvider;
+import com.google.cloud.spring.core.GcpProjectIdProvider;
+import com.google.cloud.spring.core.UserAgentHeaderProvider;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.boot.BootstrapRegistry;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataLocationNotFoundException;
+import org.springframework.boot.context.config.ConfigDataLocationResolver;
+import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
+import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+
+public class SecretManagerConfigDataLocationResolver implements
+    ConfigDataLocationResolver<SecretManagerConfigDataResource> {
+
+  /**
+   * ConfigData Prefix for Google Cloud Secret Manager.
+   */
+  public static final String PREFIX = "sm://";
+
+  @Override
+  public boolean isResolvable(ConfigDataLocationResolverContext context,
+      ConfigDataLocation location) {
+    if (!location.hasPrefix(PREFIX)) {
+      return false;
+    }
+
+    return context.getBinder().bind(GcpSecretManagerProperties.PREFIX + ".enabled", Boolean.class)
+        .orElse(true);
+  }
+
+  @Override
+  public List<SecretManagerConfigDataResource> resolve(ConfigDataLocationResolverContext context,
+      ConfigDataLocation location)
+      throws ConfigDataLocationNotFoundException, ConfigDataResourceNotFoundException {
+    // Register the Secret Manager properties.
+    registerBean(
+        context, GcpSecretManagerProperties.class, getSecretManagerProperties(context));
+    // Register the Secret Manager client.
+    registerAndPromoteBean(
+        context,
+        SecretManagerServiceClient.class,
+        BootstrapRegistry.InstanceSupplier.of(createSecretManagerClient(context)));
+
+    // Register the GCP Project ID provider.
+    registerAndPromoteBean(
+        context,
+        GcpProjectIdProvider.class,
+        BootstrapRegistry.InstanceSupplier.of(createProjectIdProvider(context)));
+
+    return Collections.singletonList(
+        new SecretManagerConfigDataResource(
+            context.getBootstrapContext().get(SecretManagerServiceClient.class), location));
+  }
+
+  private static GcpSecretManagerProperties getSecretManagerProperties(
+      ConfigDataLocationResolverContext context) {
+    return context.getBinder()
+        .bind(GcpSecretManagerProperties.PREFIX, GcpSecretManagerProperties.class)
+        .orElse(new GcpSecretManagerProperties());
+  }
+
+  private static GcpProjectIdProvider createProjectIdProvider(
+      ConfigDataLocationResolverContext context) {
+    GcpSecretManagerProperties properties = context.getBootstrapContext()
+        .get(GcpSecretManagerProperties.class);
+    return properties.getProjectId() != null
+        ? properties::getProjectId : new DefaultGcpProjectIdProvider();
+  }
+
+  private static SecretManagerServiceClient createSecretManagerClient(
+      ConfigDataLocationResolverContext context) {
+    try {
+      GcpSecretManagerProperties properties = context.getBootstrapContext()
+          .get(GcpSecretManagerProperties.class);
+      DefaultCredentialsProvider credentialsProvider =
+          new DefaultCredentialsProvider(properties);
+      SecretManagerServiceSettings settings = SecretManagerServiceSettings.newBuilder()
+          .setCredentialsProvider(credentialsProvider)
+          .setHeaderProvider(
+              new UserAgentHeaderProvider(GcpSecretManagerBootstrapConfiguration.class))
+          .build();
+      return SecretManagerServiceClient.create(settings);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to create the Secret Manager Client for ConfigData loading.");
+    }
+  }
+
+  /**
+   * Registers a bean in the Bootstrap Registry.
+   *
+   * <p>The Bootstrap Registry is a temporary context which exists for creating
+   * the ConfigData property sources.
+   */
+  private static <T> void registerBean(
+      ConfigDataLocationResolverContext context, Class<T> type, T instance) {
+    context.getBootstrapContext()
+        .registerIfAbsent(type, BootstrapRegistry.InstanceSupplier.of(instance));
+  }
+
+  /**
+   * Registers the bean in the Bootstrap Registry *and* promotes it to be in the standard
+   * application context.
+   */
+  private static <T> void registerAndPromoteBean(
+      ConfigDataLocationResolverContext context, Class<T> type,
+      BootstrapRegistry.InstanceSupplier<T> supplier) {
+    context.getBootstrapContext().registerIfAbsent(type, supplier);
+    context.getBootstrapContext().addCloseListener(event -> {
+      T instance = event.getBootstrapContext().get(type);
+      event.getApplicationContext().getBeanFactory()
+          .registerSingleton("gcp-secretmanager-config-data-" + type.getSimpleName(), instance);
+    });
+  }
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -49,8 +49,7 @@ public class SecretManagerConfigDataLocationResolver implements
       return false;
     }
 
-    return context.getBinder().bind(GcpSecretManagerProperties.PREFIX + ".enabled", Boolean.class)
-        .orElse(true);
+    return true;
   }
 
   @Override

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2022-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,13 +57,13 @@ public class SecretManagerConfigDataLocationResolver implements
   public List<SecretManagerConfigDataResource> resolve(ConfigDataLocationResolverContext context,
       ConfigDataLocation location)
       throws ConfigDataLocationNotFoundException, ConfigDataResourceNotFoundException {
-    registerImperativeInfrastructure(context);
+    registerSecretManagerBeans(context);
 
     return Collections.singletonList(
         new SecretManagerConfigDataResource(location));
   }
 
-  private static void registerImperativeInfrastructure(ConfigDataLocationResolverContext context) {
+  private static void registerSecretManagerBeans(ConfigDataLocationResolverContext context) {
     // Register the Secret Manager properties.
     registerBean(
         context, GcpSecretManagerProperties.class, getSecretManagerProperties(context));

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -26,6 +26,7 @@ import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import org.apache.arrow.util.VisibleForTesting;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.BootstrapRegistry;
 import org.springframework.boot.context.config.ConfigDataLocation;
@@ -99,7 +100,8 @@ public class SecretManagerConfigDataLocationResolver implements
         ? properties::getProjectId : new DefaultGcpProjectIdProvider();
   }
 
-  private static synchronized SecretManagerServiceClient createSecretManagerClient(
+  @VisibleForTesting
+  static synchronized SecretManagerServiceClient createSecretManagerClient(
       ConfigDataLocationResolverContext context) {
     if (secretManagerServiceClient != null && !secretManagerServiceClient.isTerminated()) {
       return secretManagerServiceClient;
@@ -161,5 +163,10 @@ public class SecretManagerConfigDataLocationResolver implements
         factory.registerSingleton(beanName, instance);
       }
     });
+  }
+
+  @VisibleForTesting
+  static void setSecretManagerServiceClient(SecretManagerServiceClient client) {
+    secretManagerServiceClient = client;
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -70,7 +70,8 @@ public class SecretManagerConfigDataLocationResolver implements
     registerAndPromoteBean(
         context,
         SecretManagerServiceClient.class,
-        BootstrapRegistry.InstanceSupplier.of(createSecretManagerClient(context)));
+        // lazy register the client solely for unit test.
+        BootstrapRegistry.InstanceSupplier.from(() -> createSecretManagerClient(context)));
     // Register the GCP Project ID provider.
     registerAndPromoteBean(
         context,
@@ -98,7 +99,7 @@ public class SecretManagerConfigDataLocationResolver implements
         ? properties::getProjectId : new DefaultGcpProjectIdProvider();
   }
 
-  private static SecretManagerServiceClient createSecretManagerClient(
+  private static synchronized SecretManagerServiceClient createSecretManagerClient(
       ConfigDataLocationResolverContext context) {
     if (secretManagerServiceClient != null && !secretManagerServiceClient.isTerminated()) {
       return secretManagerServiceClient;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResource.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResource.java
@@ -17,22 +17,24 @@
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
 import org.springframework.boot.context.config.ConfigDataLocation;
 import org.springframework.boot.context.config.ConfigDataResource;
 
 public class SecretManagerConfigDataResource extends ConfigDataResource {
 
-  private final SecretManagerServiceClient secretManagerServiceClient;
+  //private final SecretManagerServiceClient secretManagerServiceClient;
+  private final SecretManagerTemplate secretManagerTemplate;
   private final ConfigDataLocation location;
 
-  public SecretManagerConfigDataResource(SecretManagerServiceClient secretManagerServiceClient,
+  public SecretManagerConfigDataResource(SecretManagerTemplate secretManagerTemplate,
       ConfigDataLocation location) {
-    this.secretManagerServiceClient = secretManagerServiceClient;
+    this.secretManagerTemplate = secretManagerTemplate;
     this.location = location;
   }
 
-  public SecretManagerServiceClient getSecretManagerServiceClient() {
-    return secretManagerServiceClient;
+  public SecretManagerTemplate secretManagerTemplate() {
+    return secretManagerTemplate;
   }
 
   public ConfigDataLocation getLocation() {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResource.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
@@ -9,7 +25,8 @@ public class SecretManagerConfigDataResource extends ConfigDataResource {
   private final SecretManagerServiceClient secretManagerServiceClient;
   private final ConfigDataLocation location;
 
-  public SecretManagerConfigDataResource(SecretManagerServiceClient secretManagerServiceClient, ConfigDataLocation location) {
+  public SecretManagerConfigDataResource(SecretManagerServiceClient secretManagerServiceClient,
+      ConfigDataLocation location) {
     this.secretManagerServiceClient = secretManagerServiceClient;
     this.location = location;
   }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResource.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResource.java
@@ -1,0 +1,25 @@
+package com.google.cloud.spring.autoconfigure.secretmanager;
+
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataResource;
+
+public class SecretManagerConfigDataResource extends ConfigDataResource {
+
+  private final SecretManagerServiceClient secretManagerServiceClient;
+  private final ConfigDataLocation location;
+
+  public SecretManagerConfigDataResource(SecretManagerServiceClient secretManagerServiceClient, ConfigDataLocation location) {
+    this.secretManagerServiceClient = secretManagerServiceClient;
+    this.location = location;
+  }
+
+  public SecretManagerServiceClient getSecretManagerServiceClient() {
+    return secretManagerServiceClient;
+  }
+
+  public ConfigDataLocation getLocation() {
+    return location;
+  }
+}
+

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResource.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResource.java
@@ -16,29 +16,18 @@
 
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
-import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
-import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
 import org.springframework.boot.context.config.ConfigDataLocation;
 import org.springframework.boot.context.config.ConfigDataResource;
 
 public class SecretManagerConfigDataResource extends ConfigDataResource {
 
-  //private final SecretManagerServiceClient secretManagerServiceClient;
-  private final SecretManagerTemplate secretManagerTemplate;
   private final ConfigDataLocation location;
 
-  public SecretManagerConfigDataResource(SecretManagerTemplate secretManagerTemplate,
-      ConfigDataLocation location) {
-    this.secretManagerTemplate = secretManagerTemplate;
+  public SecretManagerConfigDataResource(ConfigDataLocation location) {
     this.location = location;
-  }
-
-  public SecretManagerTemplate secretManagerTemplate() {
-    return secretManagerTemplate;
   }
 
   public ConfigDataLocation getLocation() {
     return location;
   }
 }
-

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResource.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResource.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
+import java.util.Objects;
 import org.springframework.boot.context.config.ConfigDataLocation;
 import org.springframework.boot.context.config.ConfigDataResource;
 
@@ -27,7 +28,27 @@ public class SecretManagerConfigDataResource extends ConfigDataResource {
     this.location = location;
   }
 
-  public ConfigDataLocation getLocation() {
-    return location;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SecretManagerConfigDataResource)) {
+      return false;
+    }
+    SecretManagerConfigDataResource that = (SecretManagerConfigDataResource) o;
+    return location.equals(that.location);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(location);
+  }
+
+  @Override
+  public String toString() {
+    return "SecretManagerConfigDataResource{"
+        + "location=" + location
+        + '}';
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -28,12 +28,16 @@ com.google.cloud.spring.autoconfigure.pubsub.health.PubSubSubscriptionHealthIndi
 com.google.cloud.spring.autoconfigure.pubsub.health.PubSubHealthIndicatorAutoConfiguration,\
 com.google.cloud.spring.autoconfigure.metrics.GcpStackdriverMetricsAutoConfiguration,\
 com.google.cloud.spring.autoconfigure.kms.GcpKmsAutoConfiguration
-
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 com.google.cloud.spring.autoconfigure.config.GcpConfigBootstrapConfiguration,\
 com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerBootstrapConfiguration
-
 org.springframework.boot.env.EnvironmentPostProcessor=\
 com.google.cloud.spring.autoconfigure.sql.CloudSqlEnvironmentPostProcessor,\
 com.google.cloud.spring.autoconfigure.sql.R2dbcCloudSqlEnvironmentPostProcessor,\
 com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerEnvironmentPostProcessor
+# ConfigData Location Resolvers
+org.springframework.boot.context.config.ConfigDataLocationResolver=\
+com.google.cloud.spring.autoconfigure.secretmanager.SecretManagerConfigDataLocationResolver
+# ConfigData Loaders
+org.springframework.boot.context.config.ConfigDataLoader=\
+com.google.cloud.spring.autoconfigure.secretmanager.SecretManagerConfigDataLoader

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -29,8 +29,8 @@ com.google.cloud.spring.autoconfigure.pubsub.health.PubSubHealthIndicatorAutoCon
 com.google.cloud.spring.autoconfigure.metrics.GcpStackdriverMetricsAutoConfiguration,\
 com.google.cloud.spring.autoconfigure.kms.GcpKmsAutoConfiguration
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
-com.google.cloud.spring.autoconfigure.config.GcpConfigBootstrapConfiguration
-#com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerBootstrapConfiguration
+com.google.cloud.spring.autoconfigure.config.GcpConfigBootstrapConfiguration,\
+com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerBootstrapConfiguration
 org.springframework.boot.env.EnvironmentPostProcessor=\
 com.google.cloud.spring.autoconfigure.sql.CloudSqlEnvironmentPostProcessor,\
 com.google.cloud.spring.autoconfigure.sql.R2dbcCloudSqlEnvironmentPostProcessor,\

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -29,12 +29,12 @@ com.google.cloud.spring.autoconfigure.pubsub.health.PubSubHealthIndicatorAutoCon
 com.google.cloud.spring.autoconfigure.metrics.GcpStackdriverMetricsAutoConfiguration,\
 com.google.cloud.spring.autoconfigure.kms.GcpKmsAutoConfiguration
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
-com.google.cloud.spring.autoconfigure.config.GcpConfigBootstrapConfiguration,\
-com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerBootstrapConfiguration
+com.google.cloud.spring.autoconfigure.config.GcpConfigBootstrapConfiguration
+#com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerBootstrapConfiguration
 org.springframework.boot.env.EnvironmentPostProcessor=\
 com.google.cloud.spring.autoconfigure.sql.CloudSqlEnvironmentPostProcessor,\
-com.google.cloud.spring.autoconfigure.sql.R2dbcCloudSqlEnvironmentPostProcessor,\
-com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerEnvironmentPostProcessor
+com.google.cloud.spring.autoconfigure.sql.R2dbcCloudSqlEnvironmentPostProcessor
+#com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerEnvironmentPostProcessor
 # ConfigData Location Resolvers
 org.springframework.boot.context.config.ConfigDataLocationResolver=\
 com.google.cloud.spring.autoconfigure.secretmanager.SecretManagerConfigDataLocationResolver

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -33,8 +33,8 @@ com.google.cloud.spring.autoconfigure.config.GcpConfigBootstrapConfiguration
 #com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerBootstrapConfiguration
 org.springframework.boot.env.EnvironmentPostProcessor=\
 com.google.cloud.spring.autoconfigure.sql.CloudSqlEnvironmentPostProcessor,\
-com.google.cloud.spring.autoconfigure.sql.R2dbcCloudSqlEnvironmentPostProcessor
-#com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerEnvironmentPostProcessor
+com.google.cloud.spring.autoconfigure.sql.R2dbcCloudSqlEnvironmentPostProcessor,\
+com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerEnvironmentPostProcessor
 # ConfigData Location Resolvers
 org.springframework.boot.context.config.ConfigDataLocationResolver=\
 com.google.cloud.spring.autoconfigure.secretmanager.SecretManagerConfigDataLocationResolver

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
@@ -1,0 +1,2 @@
+package com.google.cloud.spring.autoconfigure.secretmanager;public class SecretManagercompatibilityTests {
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
@@ -1,2 +1,85 @@
-package com.google.cloud.spring.autoconfigure.secretmanager;public class SecretManagercompatibilityTests {
+package com.google.cloud.spring.autoconfigure.secretmanager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.BootstrapRegistry.InstanceSupplier;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Unit tests to check compatibility of Secret Manager.
+ */
+public class SecretManagerCompatibilityTests {
+
+  private static final String PROJECT_NAME = "hollow-light-of-the-sealed-land";
+
+  /**
+   * Users with the legacy configuration (i.e., bootstrap phrase) should get {@link
+   * com.google.cloud.spring.secretmanager.SecretManagerTemplate} autoconfiguration and properties
+   * resolved.
+   */
+  @Test
+  void testLegacyConfiguration() {
+    SpringApplicationBuilder legacyApplication = new SpringApplicationBuilder(
+        GcpSecretManagerBootstrapConfiguration.class)
+        .properties(
+            "spring.cloud.gcp.secretmanager.project-id=" + PROJECT_NAME,
+            "spring.cloud.bootstrap.enabled=true",
+            "spring.cloud.gcp.sql.enabled=false")
+        .web(WebApplicationType.NONE);
+    try (ConfigurableApplicationContext applicationContext = legacyApplication.run()) {
+      String secret = applicationContext.getEnvironment().getProperty("sm://my-secret");
+      assertThat(secret).isEqualTo("hello");
+    }
+  }
+
+  /**
+   * Users with the new configuration (i.e., using `spring.config.import`) should get {@link
+   * com.google.cloud.spring.secretmanager.SecretManagerTemplate} autoconfiguration and properties
+   * resolved.
+   */
+  @Test
+  void testNewConfiguration() {
+    SecretManagerServiceClient client = mock(SecretManagerServiceClient.class);
+    SecretVersionName secretVersionName =
+        SecretVersionName.newBuilder()
+            .setProject(PROJECT_NAME)
+            .setSecret("my-secret")
+            .setSecretVersion("latest")
+            .build();
+
+    when(client.accessSecretVersion(secretVersionName))
+        .thenReturn(
+            AccessSecretVersionResponse.newBuilder()
+                .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("hello")))
+                .build());
+
+    SpringApplicationBuilder newApplication = new SpringApplicationBuilder(
+        GcpSecretManagerBootstrapConfiguration.class)
+        .properties(
+            "spring.cloud.gcp.secretmanager.project-id=" + PROJECT_NAME,
+            "spring.cloud.gcp.secretmanager.legacy=false",
+            "spring.config.import=sm://",
+            "spring.cloud.gcp.sql.enabled=false")
+        .addBootstrapRegistryInitializer(
+            (registry) -> registry.registerIfAbsent(
+                SecretManagerServiceClient.class,
+                InstanceSupplier.of(client)
+            )
+        )
+        .web(WebApplicationType.NONE);
+    try (ConfigurableApplicationContext applicationContext = newApplication.run()) {
+      String secret = applicationContext.getEnvironment().getProperty("sm://my-secret");
+      assertThat(secret).isEqualTo("hello");
+    }
+  }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
@@ -25,7 +25,9 @@ class SecretManagerCompatibilityTests {
   /**
    * Users with the legacy configuration (i.e., bootstrap phrase) should get {@link
    * com.google.cloud.spring.secretmanager.SecretManagerTemplate} autoconfiguration and properties
-   * resolved.
+   * resolved. Note that {@link SecretManagerBootstrapConfigurationTests.TestBootstrapConfiguration}
+   * is automatically picked to create a mock {@link SecretManagerServiceClient} object as it is
+   * specified in spring.factories.
    */
   @Test
   void testLegacyConfiguration() {
@@ -60,7 +62,8 @@ class SecretManagerCompatibilityTests {
     when(client.accessSecretVersion(secretVersionName))
         .thenReturn(
             AccessSecretVersionResponse.newBuilder()
-                .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("hello")))
+                .setPayload(
+                    SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("newSecret")))
                 .build());
 
     SpringApplicationBuilder newApplication = new SpringApplicationBuilder(
@@ -79,7 +82,7 @@ class SecretManagerCompatibilityTests {
         .web(WebApplicationType.NONE);
     try (ConfigurableApplicationContext applicationContext = newApplication.run()) {
       String secret = applicationContext.getEnvironment().getProperty("sm://my-secret");
-      assertThat(secret).isEqualTo("hello");
+      assertThat(secret).isEqualTo("newSecret");
     }
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
@@ -18,7 +18,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 /**
  * Unit tests to check compatibility of Secret Manager.
  */
-public class SecretManagerCompatibilityTests {
+class SecretManagerCompatibilityTests {
 
   private static final String PROJECT_NAME = "hollow-light-of-the-sealed-land";
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoaderUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoaderUnitTests.java
@@ -20,6 +20,7 @@ import org.springframework.boot.context.config.ConfigDataResourceNotFoundExcepti
 /**
  * Unit tests for {@link SecretManagerConfigDataLoader}.
  */
+/*
 public class SecretManagerConfigDataLoaderUnitTests {
 
   public static final String PROJECT_NAME = "hollow-light-of-the-sealed-land";
@@ -57,3 +58,4 @@ public class SecretManagerConfigDataLoaderUnitTests {
     return client;
   }
 }
+*/

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoaderUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoaderUnitTests.java
@@ -16,7 +16,8 @@ import org.springframework.boot.context.config.ConfigDataLocation;
  * Unit tests for {@link SecretManagerConfigDataLoader}.
  */
 
-public class SecretManagerConfigDataLoaderUnitTests {
+class SecretManagerConfigDataLoaderUnitTests {
+
   private final ConfigDataLoaderContext loaderContext = mock(ConfigDataLoaderContext.class);
   private final GcpProjectIdProvider idProvider = mock(GcpProjectIdProvider.class);
   private final SecretManagerTemplate template = mock(SecretManagerTemplate.class);
@@ -25,7 +26,7 @@ public class SecretManagerConfigDataLoaderUnitTests {
   private final SecretManagerConfigDataLoader loader = new SecretManagerConfigDataLoader();
 
   @Test
-  public void loadIncorrectResourceThrowsException() {
+  void loadIncorrectResourceThrowsException() {
     when(loaderContext.getBootstrapContext()).thenReturn(bootstrapContext);
     when(bootstrapContext.get(GcpProjectIdProvider.class)).thenReturn(idProvider);
     when(bootstrapContext.get(SecretManagerTemplate.class)).thenReturn(template);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoaderUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoaderUnitTests.java
@@ -1,0 +1,2 @@
+package com.google.cloud.spring.autoconfigure.secretmanager;public class SecretManagerConfigDataLoaderUnitTests {
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoaderUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoaderUnitTests.java
@@ -1,2 +1,59 @@
-package com.google.cloud.spring.autoconfigure.secretmanager;public class SecretManagerConfigDataLoaderUnitTests {
+package com.google.cloud.spring.autoconfigure.secretmanager;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+import com.google.cloud.spring.core.GcpProjectIdProvider;
+import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.config.ConfigDataLoaderContext;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+
+/**
+ * Unit tests for {@link SecretManagerConfigDataLoader}.
+ */
+public class SecretManagerConfigDataLoaderUnitTests {
+
+  public static final String PROJECT_NAME = "hollow-light-of-the-sealed-land";
+  private final GcpProjectIdProvider idProvider = mock(GcpProjectIdProvider.class);
+  private final SecretManagerTemplate template = mock(SecretManagerTemplate.class);
+  private final SecretManagerConfigDataLoader loader = new SecretManagerConfigDataLoader(template,
+      idProvider);
+  private final ConfigDataLoaderContext loaderContext = mock(ConfigDataLoaderContext.class);
+
+  @Test
+  public void loadIncorrectResourceThrowsException() {
+    SecretManagerServiceClient client = secretManagerServiceClient();
+    when(template.secretExists(anyString(), anyString())).thenReturn(false);
+    SecretManagerConfigDataResource resource = new SecretManagerConfigDataResource(client,
+        ConfigDataLocation.of("fake"));
+    assertThatExceptionOfType(ConfigDataResourceNotFoundException.class)
+        .isThrownBy(() -> loader.load(loaderContext, resource));
+  }
+
+  private static SecretManagerServiceClient secretManagerServiceClient() {
+    SecretManagerServiceClient client = mock(SecretManagerServiceClient.class);
+    SecretVersionName secretVersionName =
+        SecretVersionName.newBuilder()
+            .setProject(SecretManagerConfigDataLoaderUnitTests.PROJECT_NAME)
+            .setSecret("my-secret")
+            .setSecretVersion("latest")
+            .build();
+
+    when(client.accessSecretVersion(secretVersionName))
+        .thenReturn(
+            AccessSecretVersionResponse.newBuilder()
+                .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("hello")))
+                .build());
+
+    return client;
+  }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoaderUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLoaderUnitTests.java
@@ -1,61 +1,37 @@
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
-import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
-import com.google.cloud.secretmanager.v1.SecretPayload;
-import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
-import com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.ConfigurableBootstrapContext;
 import org.springframework.boot.context.config.ConfigDataLoaderContext;
 import org.springframework.boot.context.config.ConfigDataLocation;
-import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
 
 /**
  * Unit tests for {@link SecretManagerConfigDataLoader}.
  */
-/*
-public class SecretManagerConfigDataLoaderUnitTests {
 
-  public static final String PROJECT_NAME = "hollow-light-of-the-sealed-land";
+public class SecretManagerConfigDataLoaderUnitTests {
+  private final ConfigDataLoaderContext loaderContext = mock(ConfigDataLoaderContext.class);
   private final GcpProjectIdProvider idProvider = mock(GcpProjectIdProvider.class);
   private final SecretManagerTemplate template = mock(SecretManagerTemplate.class);
-  private final SecretManagerConfigDataLoader loader = new SecretManagerConfigDataLoader(template,
-      idProvider);
-  private final ConfigDataLoaderContext loaderContext = mock(ConfigDataLoaderContext.class);
+  private final ConfigurableBootstrapContext bootstrapContext = mock(
+      ConfigurableBootstrapContext.class);
+  private final SecretManagerConfigDataLoader loader = new SecretManagerConfigDataLoader();
 
   @Test
   public void loadIncorrectResourceThrowsException() {
-    SecretManagerServiceClient client = secretManagerServiceClient();
+    when(loaderContext.getBootstrapContext()).thenReturn(bootstrapContext);
+    when(bootstrapContext.get(GcpProjectIdProvider.class)).thenReturn(idProvider);
+    when(bootstrapContext.get(SecretManagerTemplate.class)).thenReturn(template);
     when(template.secretExists(anyString(), anyString())).thenReturn(false);
-    SecretManagerConfigDataResource resource = new SecretManagerConfigDataResource(client,
+    SecretManagerConfigDataResource resource = new SecretManagerConfigDataResource(
         ConfigDataLocation.of("fake"));
-    assertThatExceptionOfType(ConfigDataResourceNotFoundException.class)
-        .isThrownBy(() -> loader.load(loaderContext, resource));
-  }
-
-  private static SecretManagerServiceClient secretManagerServiceClient() {
-    SecretManagerServiceClient client = mock(SecretManagerServiceClient.class);
-    SecretVersionName secretVersionName =
-        SecretVersionName.newBuilder()
-            .setProject(SecretManagerConfigDataLoaderUnitTests.PROJECT_NAME)
-            .setSecret("my-secret")
-            .setSecretVersion("latest")
-            .build();
-
-    when(client.accessSecretVersion(secretVersionName))
-        .thenReturn(
-            AccessSecretVersionResponse.newBuilder()
-                .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("hello")))
-                .build());
-
-    return client;
+    assertThatCode(() -> loader.load(loaderContext, resource)).doesNotThrowAnyException();
   }
 }
-*/

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
@@ -1,6 +1,7 @@
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -9,11 +10,13 @@ import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.BootstrapRegistry;
 import org.springframework.boot.DefaultBootstrapContext;
 import org.springframework.boot.context.config.ConfigDataLocation;
 import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.ConfigurableApplicationContext;
 
 /**
  * Unit tests for {@link SecretManagerConfigDataLocationResolver}.
@@ -23,6 +26,7 @@ class SecretManagerConfigDataLocationResolverUnitTests {
   private final SecretManagerConfigDataLocationResolver resolver = new SecretManagerConfigDataLocationResolver();
   private final ConfigDataLocationResolverContext context = mock(
       ConfigDataLocationResolverContext.class);
+  private final DefaultBootstrapContext defaultBootstrapContext = new DefaultBootstrapContext();
 
   @Test
   void isResolvableReturnsFalseWithIncorrectPrefix() {
@@ -51,6 +55,10 @@ class SecretManagerConfigDataLocationResolverUnitTests {
     assertThat(locations).hasSize(1);
     assertThat(locations).first().extracting("location")
         .isEqualTo(ConfigDataLocation.of("sm://my-secret"));
+    ConfigurableApplicationContext applicationContext = mock(ConfigurableApplicationContext.class);
+    when(applicationContext.getBeanFactory()).thenReturn(new DefaultListableBeanFactory());
+    assertThatCode(
+        () -> defaultBootstrapContext.close(applicationContext)).doesNotThrowAnyException();
   }
 
   @BeforeEach
@@ -58,7 +66,6 @@ class SecretManagerConfigDataLocationResolverUnitTests {
     GcpSecretManagerProperties properties = mock(GcpSecretManagerProperties.class);
     CredentialsProvider credentialsProvider = mock(CredentialsProvider.class);
     SecretManagerServiceClient secretManagerServiceClient = mock(SecretManagerServiceClient.class);
-    DefaultBootstrapContext defaultBootstrapContext = new DefaultBootstrapContext();
 
     defaultBootstrapContext.register(GcpSecretManagerProperties.class,
         BootstrapRegistry.InstanceSupplier.of(properties));

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.DefaultBootstrapContext;
@@ -15,7 +16,6 @@ import org.springframework.boot.context.config.ConfigDataLocationResolverContext
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * Unit tests for {@link SecretManagerConfigDataLocationResolver}.
@@ -40,8 +40,7 @@ public class SecretManagerConfigDataLocationResolverUnitTests {
   @Test
   public void resolveReturnsConfigDataLocation() {
     SpringApplicationBuilder applicationBuilder =
-        new SpringApplicationBuilder(
-            TestSecretManagerConfiguration.class)
+        new SpringApplicationBuilder(TestSecretManagerConfiguration.class)
             .properties("spring.cloud.gcp.sql.enabled=false")
             .web(WebApplicationType.NONE);
     try (ConfigurableApplicationContext c = applicationBuilder.run()) {
@@ -55,12 +54,11 @@ public class SecretManagerConfigDataLocationResolverUnitTests {
     }
   }
 
-  @Configuration
-  static class TestSecretManagerConfiguration {
+  private static class TestSecretManagerConfiguration {
 
     @Bean
-    public static CredentialsProvider googleCredentials() {
-      return mock(CredentialsProvider.class);
+    public CredentialsProvider googleCredentials() {
+      return () -> mock(Credentials.class);
     }
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
@@ -1,14 +1,11 @@
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
-import com.google.cloud.spring.core.Credentials;
-import com.google.cloud.spring.core.GcpScope;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,12 +45,6 @@ class SecretManagerConfigDataLocationResolverUnitTests {
   }
 
   @Test
-  void createSecretManagerClientWithoutPresetClientTest() {
-    assertThatCode(() -> SecretManagerConfigDataLocationResolver.createSecretManagerClient(
-        context)).doesNotThrowAnyException();
-  }
-
-  @Test
   void resolveReturnsConfigDataLocation() {
     List<SecretManagerConfigDataResource> locations = resolver.resolve(context,
         ConfigDataLocation.of("sm://my-secret"));
@@ -64,7 +55,6 @@ class SecretManagerConfigDataLocationResolverUnitTests {
 
   @BeforeEach
   void registerBean() {
-    Credentials credentials = new Credentials(GcpScope.CLOUD_PLATFORM.getUrl());
     GcpSecretManagerProperties properties = mock(GcpSecretManagerProperties.class);
     CredentialsProvider credentialsProvider = mock(CredentialsProvider.class);
     SecretManagerServiceClient secretManagerServiceClient = mock(SecretManagerServiceClient.class);
@@ -79,6 +69,5 @@ class SecretManagerConfigDataLocationResolverUnitTests {
 
     when(context.getBinder()).thenReturn(new Binder());
     when(context.getBootstrapContext()).thenReturn(defaultBootstrapContext);
-    when(properties.getCredentials()).thenReturn(credentials);
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.api.gax.core.CredentialsProvider;
-import com.google.auth.Credentials;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.DefaultBootstrapContext;
@@ -61,7 +60,7 @@ public class SecretManagerConfigDataLocationResolverUnitTests {
 
     @Bean
     public static CredentialsProvider googleCredentials() {
-      return () -> mock(Credentials.class);
+      return mock(CredentialsProvider.class);
     }
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
 import java.util.List;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.DefaultBootstrapContext;
 import org.springframework.boot.WebApplicationType;
@@ -37,6 +38,7 @@ public class SecretManagerConfigDataLocationResolverUnitTests {
     assertThat(resolver.isResolvable(context, ConfigDataLocation.of("sm://"))).isTrue();
   }
 
+  @Disabled
   @Test
   public void resolveReturnsConfigDataLocation() {
     SpringApplicationBuilder applicationBuilder =

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
@@ -4,12 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.DefaultBootstrapContext;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.config.ConfigDataLocation;
 import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * Unit tests for {@link SecretManagerConfigDataLocationResolver}.
@@ -33,12 +40,28 @@ public class SecretManagerConfigDataLocationResolverUnitTests {
 
   @Test
   public void resolveReturnsConfigDataLocation() {
-    when(context.getBinder()).thenReturn(new Binder());
-    when(context.getBootstrapContext()).thenReturn(new DefaultBootstrapContext());
-    List<SecretManagerConfigDataResource> locations = resolver.resolve(context,
-        ConfigDataLocation.of("sm://my-secret"));
-    assertThat(locations.size()).isEqualTo(1);
-    assertThat(locations).first().extracting("location")
-        .isEqualTo(ConfigDataLocation.of("sm://my-secret"));
+    SpringApplicationBuilder applicationBuilder =
+        new SpringApplicationBuilder(
+            TestSecretManagerConfiguration.class)
+            .properties("spring.cloud.gcp.sql.enabled=false")
+            .web(WebApplicationType.NONE);
+    try (ConfigurableApplicationContext c = applicationBuilder.run()) {
+      when(context.getBinder()).thenReturn(new Binder());
+      when(context.getBootstrapContext()).thenReturn(new DefaultBootstrapContext());
+      List<SecretManagerConfigDataResource> locations = resolver.resolve(context,
+          ConfigDataLocation.of("sm://my-secret"));
+      assertThat(locations.size()).isEqualTo(1);
+      assertThat(locations).first().extracting("location")
+          .isEqualTo(ConfigDataLocation.of("sm://my-secret"));
+    }
+  }
+
+  @Configuration
+  static class TestSecretManagerConfiguration {
+
+    @Bean
+    public static CredentialsProvider googleCredentials() {
+      return () -> mock(Credentials.class);
+    }
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
@@ -1,0 +1,58 @@
+package com.google.cloud.spring.autoconfigure.secretmanager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.DefaultBootstrapContext;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Unit tests for {@link SecretManagerConfigDataLocationResolver}.
+ */
+public class SecretManagerConfigDataLocationResolverUnitTests {
+
+  private SecretManagerConfigDataLocationResolver resolver;
+  private final ConfigDataLocationResolverContext context = mock(
+      ConfigDataLocationResolverContext.class);
+  private MockEnvironment environment;
+
+  @BeforeEach
+  void setup() {
+    environment = new MockEnvironment();
+    Binder environmentBinder = Binder.get(environment);
+    resolver = new SecretManagerConfigDataLocationResolver();
+    when(context.getBinder()).thenReturn(environmentBinder);
+  }
+
+  @Test
+  public void isResolvableReturnsFalseWithIncorrectPrefix() {
+    assertThat(resolver.isResolvable(context, ConfigDataLocation.of("test://"))).isFalse();
+    assertThat(resolver.isResolvable(context, ConfigDataLocation.of("sm:"))).isFalse();
+  }
+
+  @Test
+  public void isResolvableReturnsFalseWithCorrectPrefix() {
+    assertThat(resolver.isResolvable(context, ConfigDataLocation.of("sm://"))).isTrue();
+  }
+
+  @Test
+  public void isResolvableReturnsFalseWhenDisabled() {
+    environment.setProperty(GcpSecretManagerProperties.PREFIX + ".enabled", "false");
+    assertThat(resolver.isResolvable(context, ConfigDataLocation.of("sm://"))).isFalse();
+  }
+
+  @Test
+  public void resolveReturnsConfigDataLocation() {
+    when(context.getBootstrapContext()).thenReturn(new DefaultBootstrapContext());
+    List<SecretManagerConfigDataResource> locations = resolver.resolve(context, ConfigDataLocation.of("sm://my-secret"));
+    assertThat(locations.size()).isEqualTo(1);
+    assertThat(locations).first().isNotNull();
+  }
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolverUnitTests.java
@@ -5,31 +5,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.DefaultBootstrapContext;
 import org.springframework.boot.context.config.ConfigDataLocation;
 import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
 import org.springframework.boot.context.properties.bind.Binder;
-import org.springframework.mock.env.MockEnvironment;
 
 /**
  * Unit tests for {@link SecretManagerConfigDataLocationResolver}.
  */
 public class SecretManagerConfigDataLocationResolverUnitTests {
 
-  private SecretManagerConfigDataLocationResolver resolver;
+  private final SecretManagerConfigDataLocationResolver resolver = new SecretManagerConfigDataLocationResolver();
   private final ConfigDataLocationResolverContext context = mock(
       ConfigDataLocationResolverContext.class);
-  private MockEnvironment environment;
-
-  @BeforeEach
-  void setup() {
-    environment = new MockEnvironment();
-    Binder environmentBinder = Binder.get(environment);
-    resolver = new SecretManagerConfigDataLocationResolver();
-    when(context.getBinder()).thenReturn(environmentBinder);
-  }
 
   @Test
   public void isResolvableReturnsFalseWithIncorrectPrefix() {
@@ -43,16 +32,13 @@ public class SecretManagerConfigDataLocationResolverUnitTests {
   }
 
   @Test
-  public void isResolvableReturnsFalseWhenDisabled() {
-    environment.setProperty(GcpSecretManagerProperties.PREFIX + ".enabled", "false");
-    assertThat(resolver.isResolvable(context, ConfigDataLocation.of("sm://"))).isFalse();
-  }
-
-  @Test
   public void resolveReturnsConfigDataLocation() {
+    when(context.getBinder()).thenReturn(new Binder());
     when(context.getBootstrapContext()).thenReturn(new DefaultBootstrapContext());
-    List<SecretManagerConfigDataResource> locations = resolver.resolve(context, ConfigDataLocation.of("sm://my-secret"));
+    List<SecretManagerConfigDataResource> locations = resolver.resolve(context,
+        ConfigDataLocation.of("sm://my-secret"));
     assertThat(locations.size()).isEqualTo(1);
-    assertThat(locations).first().isNotNull();
+    assertThat(locations).first().extracting("location")
+        .isEqualTo(ConfigDataLocation.of("sm://my-secret"));
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResourceUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResourceUnitTests.java
@@ -28,8 +28,8 @@ class SecretManagerConfigDataResourceUnitTests {
 
   @Test
   void twoResourcesWithSameLocationShouldHaveSameHashcode() {
-    assertThat(resource.hashCode()).isEqualTo(
-        new SecretManagerConfigDataResource(location).hashCode());
+    assertThat(resource).hasSameHashCodeAs(
+        new SecretManagerConfigDataResource(location));
   }
 
   @Test

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResourceUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResourceUnitTests.java
@@ -5,13 +5,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.config.ConfigDataLocation;
 
-public class SecretManagerConfigDataResourceUnitTests {
+class SecretManagerConfigDataResourceUnitTests {
 
   private ConfigDataLocation location = ConfigDataLocation.of("test");
+  private final SecretManagerConfigDataResource resource = new SecretManagerConfigDataResource(
+      location);
 
   @Test
   void resourceShouldBeEqualToItself() {
-    SecretManagerConfigDataResource resource = new SecretManagerConfigDataResource(location);
     assertThat(resource.equals(resource)).isTrue();
   }
 
@@ -22,8 +23,13 @@ public class SecretManagerConfigDataResourceUnitTests {
 
   @Test
   void twoResourcesWithSameLocationShouldBeEqual() {
-    SecretManagerConfigDataResource resource = new SecretManagerConfigDataResource(location);
     assertThat(resource.equals(new SecretManagerConfigDataResource(location))).isTrue();
+  }
+
+  @Test
+  void twoResourcesWithSameLocationShouldHaveSameHashcode() {
+    assertThat(resource.hashCode()).isEqualTo(
+        new SecretManagerConfigDataResource(location).hashCode());
   }
 
   @Test
@@ -33,8 +39,7 @@ public class SecretManagerConfigDataResourceUnitTests {
         + "location="
         + location
         + "}";
-    assertThat(new SecretManagerConfigDataResource(location)
-        .toString())
-        .isEqualTo(expectedString);
+    assertThat(resource)
+        .hasToString(expectedString);
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResourceUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataResourceUnitTests.java
@@ -1,0 +1,40 @@
+package com.google.cloud.spring.autoconfigure.secretmanager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.config.ConfigDataLocation;
+
+public class SecretManagerConfigDataResourceUnitTests {
+
+  private ConfigDataLocation location = ConfigDataLocation.of("test");
+
+  @Test
+  void resourceShouldBeEqualToItself() {
+    SecretManagerConfigDataResource resource = new SecretManagerConfigDataResource(location);
+    assertThat(resource.equals(resource)).isTrue();
+  }
+
+  @Test
+  void resourceShouldNotBeEqualToOtherObject() {
+    assertThat(new SecretManagerConfigDataResource(location).equals(location)).isFalse();
+  }
+
+  @Test
+  void twoResourcesWithSameLocationShouldBeEqual() {
+    SecretManagerConfigDataResource resource = new SecretManagerConfigDataResource(location);
+    assertThat(resource.equals(new SecretManagerConfigDataResource(location))).isTrue();
+  }
+
+  @Test
+  void toStringTest() {
+
+    String expectedString = "SecretManagerConfigDataResource{"
+        + "location="
+        + location
+        + "}";
+    assertThat(new SecretManagerConfigDataResource(location)
+        .toString())
+        .isEqualTo(expectedString);
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/README.adoc
@@ -46,40 +46,14 @@ This is done by using the `SecretManagerTemplate`.
 +
 Finally, you can view all of your secrets using the https://console.cloud.google.com/security/secret-manager[Secret Manager Cloud Console UI], which is the source of truth for all of your secrets in Secret Manager.
 
-8. Refresh the secrets without restart the application:
+8. Refresh the secrets without restarting the application:
 
-a. Before running your application, change the project's configuration files as follows:
-+
-add the actuator starter dependency to your project,
+a. After running the application, change your secrets using https://console.cloud.google.com/security/secret-manager[Secret Manager Cloud Console UI].
+
+b. To refresh the secret, send the following command to your server from which hosting the application:
 +
 [source]
 ----
-<dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-actuator</artifactId>
-</dependency>
+curl -X POST http://localhost:8080/actuator/refresh
 ----
-add the following property to your project's `application.properties`,
-+
-[source]
-----
-management.endpoints.web.exposure.include=refresh
-----
-+
-finally, add the following property to your project's `bootstrap.properties` to enable https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4[Spring Boot's Config Data API].
-+
-[source]
-----
-spring.cloud.gcp.secretmanager.legacy=false
-----
-
-b. After running the application, change your secrets using https://console.cloud.google.com/security/secret-manager[Secret Manager Cloud Console UI].
-
-c. To refresh the secret, send the following command to your server from which hosting the application:
-+
-[source]
-----
-curl -X POST http://[ip]:[port]/actuator/refresh
-----
-
-
+Note that only `@ConfigurationProperties` annotated with `@RefreshScope` got the updated value.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/README.adoc
@@ -12,9 +12,10 @@ image:http://gstatic.com/cloudssh/images/open-btn.svg[link=https://ssh.cloud.goo
 2. Enable the Secret Manager API from the "APIs & Services" menu of the Google Cloud Console.
 This can be done using the `gcloud` command line tool:
 +
-```
+[source]
+----
 gcloud services enable secretmanager.googleapis.com
-```
+----
 
 3. Authenticate in one of two ways:
 
@@ -35,13 +36,50 @@ Instructions for using the Secret Manager UI can be found in the https://cloud.g
 on port 8080. Your secret value is injected into your application through the `WebController` and you will see it
 displayed.
 +
-```
+[source]
+----
 applicationSecret: Hello world.
-```
+----
 +
 You will also see some web forms that allow you to create, read, and update secrets in Secret Manager.
 This is done by using the `SecretManagerTemplate`.
 +
 Finally, you can view all of your secrets using the https://console.cloud.google.com/security/secret-manager[Secret Manager Cloud Console UI], which is the source of truth for all of your secrets in Secret Manager.
+
+8. Refresh the secrets without restart the application:
+
+a. Before running your application, change the project's configuration files as follows:
++
+add the actuator starter dependency to your project,
++
+[source]
+----
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+</dependency>
+----
+add the following property to your project's `application.properties`,
++
+[source]
+----
+management.endpoints.web.exposure.include=refresh
+----
++
+finally, add the following property to your project's `bootstrap.properties` to enable https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4[Spring Boot's Config Data API].
++
+[source]
+----
+spring.cloud.gcp.secretmanager.legacy=false
+----
+
+b. After running the application, change your secrets using https://console.cloud.google.com/security/secret-manager[Secret Manager Cloud Console UI].
+
+c. To refresh the secret, send the following command to your server from which hosting the application:
++
+[source]
+----
+curl -X POST http://[ip]:[port]/actuator/refresh
+----
 
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/pom.xml
@@ -17,6 +17,11 @@
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretConfiguration.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretConfiguration.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretConfiguration.java
@@ -1,0 +1,19 @@
+package com.example;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+
+@ConfigurationProperties("example")
+@RefreshScope
+public class SecretConfiguration {
+
+  private String property;
+
+  public void setProperty(String property) {
+    this.property = property;
+  }
+
+  public String getProperty() {
+    return property;
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretConfiguration.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretConfiguration.java
@@ -19,17 +19,17 @@ package com.example;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 
-@ConfigurationProperties("example")
+@ConfigurationProperties("application")
 @RefreshScope
 public class SecretConfiguration {
 
-  private String property;
+  private String secret;
 
-  public void setProperty(String property) {
-    this.property = property;
+  public void setSecret(String secret) {
+    this.secret = secret;
   }
 
-  public String getProperty() {
-    return property;
+  public String getSecret() {
+    return secret;
   }
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerApplication.java
@@ -18,8 +18,10 @@ package com.example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(SecretConfiguration.class)
 public class SecretManagerApplication {
   public static void main(String[] args) {
     SpringApplication.run(SecretManagerApplication.class, args);

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -37,7 +37,7 @@ public class SecretManagerWebController {
   private final SecretConfiguration configuration;
 
   // Application secrets can be accessed using @Value syntax.
-  @Value("${example.property}")
+  @Value("${application.secret}")
   private String appSecret;
 
   public SecretManagerWebController(SecretManagerTemplate secretManagerTemplate,

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -50,7 +50,7 @@ public class SecretManagerWebController {
   @GetMapping("/")
   public ModelAndView renderIndex(ModelMap map) {
     map.put("applicationSecret", appSecret);
-    map.put("myApplicationSecret", configuration.getProperty());
+    map.put("myApplicationSecret", configuration.getSecret());
     return new ModelAndView("index.html", map);
   }
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -18,9 +18,7 @@ package com.example;
 
 import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,23 +31,25 @@ import org.springframework.web.util.HtmlUtils;
 @Controller
 public class SecretManagerWebController {
 
-  @Autowired private Environment environment;
+  private final SecretManagerTemplate secretManagerTemplate;
+  // Application secrets can be accessed using configuration properties class.
+  private final SecretConfiguration configuration;
 
-  @Autowired private SecretManagerTemplate secretManagerTemplate;
-
-  // Application secrets can be accessed using @Value and using the "sm://" syntax.
-  @Value("${sm://application-secret}")
+  // Application secrets can be accessed using @Value syntax.
+  @Value("${example.property}")
   private String appSecret;
 
-  // Multiple ways of loading the application-secret are demonstrated in bootstrap.properties.
-  // Try it with my-app-secret-1 or my-app-secret-2
-  @Value("${my-app-secret-1}")
-  private String myAppSecret;
+  public SecretManagerWebController(SecretManagerTemplate secretManagerTemplate,
+      SecretConfiguration configuration
+  ) {
+    this.secretManagerTemplate = secretManagerTemplate;
+    this.configuration = configuration;
+  }
 
   @GetMapping("/")
   public ModelAndView renderIndex(ModelMap map) {
-    map.put("applicationSecret", this.appSecret);
-    map.put("myApplicationSecret", this.myAppSecret);
+    map.put("applicationSecret", appSecret);
+    map.put("myApplicationSecret", configuration.getProperty());
     return new ModelAndView("index.html", map);
   }
 
@@ -96,7 +96,6 @@ public class SecretManagerWebController {
     }
 
     map.put("applicationSecret", this.appSecret);
-    map.put("myApplicationSecret", this.myAppSecret);
     map.put("message", "Secret created!");
     return new ModelAndView("index.html", map);
   }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -32,7 +32,8 @@ import org.springframework.web.util.HtmlUtils;
 public class SecretManagerWebController {
 
   private final SecretManagerTemplate secretManagerTemplate;
-  // Application secrets can be accessed using configuration properties class.
+  // Application secrets can be accessed using configuration properties class,
+  // secret can be refreshed when decorated with @RefreshScope on the class.
   private final SecretConfiguration configuration;
 
   // Application secrets can be accessed using @Value syntax.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -38,7 +38,7 @@ public class SecretManagerWebController {
 
   // Application secrets can be accessed using @Value syntax.
   @Value("${sm://application-secret}")
-  private String appSecret;
+  private String appSecretFromValue;
 
   public SecretManagerWebController(SecretManagerTemplate secretManagerTemplate,
       SecretConfiguration configuration
@@ -49,8 +49,8 @@ public class SecretManagerWebController {
 
   @GetMapping("/")
   public ModelAndView renderIndex(ModelMap map) {
-    map.put("applicationSecret", appSecret);
-    map.put("myApplicationSecret", configuration.getSecret());
+    map.put("applicationSecretFromValue", appSecretFromValue);
+    map.put("applicationSecretFromConfigurationProperties", configuration.getSecret());
     return new ModelAndView("index.html", map);
   }
 
@@ -96,7 +96,7 @@ public class SecretManagerWebController {
       this.secretManagerTemplate.createSecret(secretId, secretPayload.getBytes(), projectId);
     }
 
-    map.put("applicationSecret", this.appSecret);
+    map.put("applicationSecretFromValue", this.appSecretFromValue);
     map.put("message", "Secret created!");
     return new ModelAndView("index.html", map);
   }
@@ -111,7 +111,7 @@ public class SecretManagerWebController {
     } else {
       this.secretManagerTemplate.deleteSecret(secretId, projectId);
     }
-    map.put("applicationSecret", this.appSecret);
+    map.put("applicationSecretFromValue", this.appSecretFromValue);
     map.put("message", "Secret deleted!");
     return new ModelAndView("index.html", map);
   }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -37,7 +37,7 @@ public class SecretManagerWebController {
   private final SecretConfiguration configuration;
 
   // Application secrets can be accessed using @Value syntax.
-  @Value("${application.secret}")
+  @Value("${sm://application-secret}")
   private String appSecret;
 
   public SecretManagerWebController(SecretManagerTemplate secretManagerTemplate,

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -13,4 +13,3 @@ management.endpoints.web.exposure.include=refresh
 # enable external resource from GCP Secret Manager.
 spring.config.import=sm://
 application.secret=${sm://application-secret}
-example.property=${sm://demo-secret}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -3,16 +3,13 @@
 #
 # Please refer to the Spring Cloud GCP Secret Manager reference documentation for the full protocol syntax.
 
-# You load a secret at a specified version; the project is inferred from Application Default Credentials or
-# spring.cloud.gcp.secretmanager.project-id set in bootstrap.properties.
-my-app-secret-1=${sm://application-secret/latest}
-my-app-secret-2=${sm://application-secret/1}
-
 # You can also specify a secret from another project.
 # example.property=${sm://MY_PROJECT/MY_SECRET_ID/MY_VERSION}
 
 # Using SpEL, you can reference an environment variable and fallback to a secret if it is missing.
 # example.secret=${MY_ENV_VARIABLE:${sm://application-secret/latest}}
 
-
+management.endpoints.web.exposure.include=refresh
+# enable external resource from GCP Secret Manager.
 spring.config.import=sm://
+example.property=${sm://demo-secret}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -12,4 +12,5 @@
 management.endpoints.web.exposure.include=refresh
 # enable external resource from GCP Secret Manager.
 spring.config.import=sm://
+application.secret=${sm://application-secret}
 example.property=${sm://demo-secret}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -13,3 +13,6 @@ my-app-secret-2=${sm://application-secret/1}
 
 # Using SpEL, you can reference an environment variable and fallback to a secret if it is missing.
 # example.secret=${MY_ENV_VARIABLE:${sm://application-secret/latest}}
+
+
+spring.config.import=sm://

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -10,8 +10,6 @@
 # example.secret=${MY_ENV_VARIABLE:${sm://application-secret/latest}}
 
 management.endpoints.web.exposure.include=refresh
-# if you want you enable Spring Boot's Config Data API, add the following config property,
-spring.cloud.gcp.secretmanager.legacy=false
 # enable external resource from GCP Secret Manager.
 spring.config.import=sm://
 application.secret=${sm://application-secret}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -10,6 +10,8 @@
 # example.secret=${MY_ENV_VARIABLE:${sm://application-secret/latest}}
 
 management.endpoints.web.exposure.include=refresh
+# if you want you enable Spring Boot's Config Data API, add the following config property,
+spring.cloud.gcp.secretmanager.legacy=false
 # enable external resource from GCP Secret Manager.
 spring.config.import=sm://
 application.secret=${sm://application-secret}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/bootstrap.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/bootstrap.properties
@@ -1,6 +1,7 @@
 # Configuration-level settings for Secret Manager must be specified in a bootstrap.properties file because
-# because Secret Manager secrets are resolved before application.properties is resolved by Spring.
+# Secret Manager secrets are resolved before application.properties is resolved by Spring.
 
 # spring.cloud.gcp.secretmanager.enabled=<true or false> (this is true by default when the starter is added.)
 # spring.cloud.gcp.secretmanager.project-id=<your-project-id>
 # spring.cloud.gcp.secretmanager.credentials.location=<secretmanager-specific-credentials>
+spring.cloud.gcp.secretmanager.legacy=false

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
@@ -40,12 +40,12 @@
 <h1>Secret Manager Demo with Spring Cloud GCP</h1>
 
 <div class="panel">
-    <h3>Secret Manager Property Source</h3>
-    At the bootstrap phase, we loaded the following secret into the application context:
-    <br/>
-    <br/>
-    <b>application-secret:</b> <i>[[${applicationSecret}]]</i><br/>
-    <b>my-application-secret:</b> <i>[[${myApplicationSecret}]]</i>
+  <h3>Secret Manager Property Source</h3>
+  At the bootstrap phase, we loaded the following secret into the application context:
+  <br/>
+  <br/>
+  <b>application-secret:</b> <i>[[${applicationSecret}]]</i><br/>
+  <b>my-application-secret:</b> <i>[[${myApplicationSecret}]]</i>
 </div>
 
 <div class="panel">
@@ -67,14 +67,14 @@
       Get a secret by secret ID from Secret Manager. You will receive an error if you
       try to get a secret ID that does not already exist.
     </p>
-      <form method="GET" action="/getSecret">
-          <ol>
-              <li>Secret ID: <input type="text" name="secretId"/></li>
-              <li>Version (optional): <input type="text" name="version"/></li>
-              <li>Project ID (optional): <input type="text" name="projectId"/></li>
-              <li><input type="submit" value="Get Secret"/></li>
-          </ol>
-      </form>
+    <form method="GET" action="/getSecret">
+      <ol>
+        <li>Secret ID: <input type="text" name="secretId"/></li>
+        <li>Version (optional): <input type="text" name="version"/></li>
+        <li>Project ID (optional): <input type="text" name="projectId"/></li>
+        <li><input type="submit" value="Get Secret"/></li>
+      </ol>
+    </form>
   </div>
 
   <div class="panel highlight">
@@ -83,14 +83,14 @@
       This will create a secret if the provided secret ID does not exists.
       Otherwise it will create version under the provided secret ID.
     </p>
-      <form method="POST" action="/createSecret">
-          <ol>
-              <li>Secret ID: <input type="text" name="secretId"/></li>
-              <li>Secret Payload: <input type="text" name="secretPayload"/></li>
-              <li>Project ID (optional): <input type="text" name="projectId"/></li>
-              <li><input type="submit" value="Create/Update Secret"/></li>
-          </ol>
-      </form>
+    <form method="POST" action="/createSecret">
+      <ol>
+        <li>Secret ID: <input type="text" name="secretId"/></li>
+        <li>Secret Payload: <input type="text" name="secretPayload"/></li>
+        <li>Project ID (optional): <input type="text" name="projectId"/></li>
+        <li><input type="submit" value="Create/Update Secret"/></li>
+      </ol>
+    </form>
 
   </div>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
@@ -44,8 +44,8 @@
   At the bootstrap phase, we loaded the following secret into the application context:
   <br/>
   <br/>
-  <b>application-secret:</b> <i>[[${applicationSecret}]]</i><br/>
-  <b>my-application-secret:</b> <i>[[${myApplicationSecret}]]</i>
+  <b>Application secret from @Value:</b> <i>[[${applicationSecretFromValue}]]</i><br/>
+  <b>Application secret from @ConfigurationProperties:</b> <i>[[${applicationSecretFromConfigurationProperties}]]</i>
 </div>
 
 <div class="panel">
@@ -80,8 +80,8 @@
   <div class="panel highlight">
     <h3>Create/Update Secret</h3>
     <p>
-      This will create a secret if the provided secret ID does not exists.
-      Otherwise it will create version under the provided secret ID.
+      This will create a secret if the provided secret ID does not exist.
+      Otherwise, it will create version under the provided secret ID.
     </p>
     <form method="POST" action="/createSecret">
       <ol>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleIntegrationTests.java
@@ -32,7 +32,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-/** Application secret named "application-secret" must exist and have a value of "Hello world.". */
+/**
+ * Application secret named "application-secret" must exist and have a value of "Hello world.".
+ */
 @EnabledIfSystemProperty(named = "it.secretmanager", matches = "true")
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
@@ -42,15 +44,20 @@ class SecretManagerSampleIntegrationTests {
 
   private static final String SECRET_TO_DELETE = "secret-manager-sample-delete-secret";
 
-  @Autowired private SecretManagerTemplate secretManagerTemplate;
+  @Autowired
+  private SecretManagerTemplate secretManagerTemplate;
 
-  @Autowired private TestRestTemplate testRestTemplate;
+  @Autowired
+  private TestRestTemplate testRestTemplate;
 
   @Test
   void testApplicationStartup() {
     ResponseEntity<String> response = this.testRestTemplate.getForEntity("/", String.class);
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
-    assertThat(response.getBody()).contains("<b>application-secret:</b> <i>Hello world.</i>");
+    assertThat(response.getBody()).contains(
+        "<b>Application secret from @Value:</b> <i>Hello world.</i>");
+    assertThat(response.getBody()).contains(
+        "<b>Application secret from @ConfigurationProperties:</b> <i>Hello world.</i>");
   }
 
   @Test

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertySource.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertySource.java
@@ -36,6 +36,7 @@ public class SecretManagerPropertySource extends EnumerablePropertySource<Secret
       GcpProjectIdProvider projectIdProvider) {
     super(propertySourceName, secretManagerTemplate);
 
+    System.out.println("*** WHO KNOWS - SecretManagerPropertySource constructor");
     this.projectIdProvider = projectIdProvider;
   }
 

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertySource.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertySource.java
@@ -35,8 +35,6 @@ public class SecretManagerPropertySource extends EnumerablePropertySource<Secret
       SecretManagerTemplate secretManagerTemplate,
       GcpProjectIdProvider projectIdProvider) {
     super(propertySourceName, secretManagerTemplate);
-
-    System.out.println("*** WHO KNOWS - SecretManagerPropertySource constructor");
     this.projectIdProvider = projectIdProvider;
   }
 

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerTemplate.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerTemplate.java
@@ -39,15 +39,12 @@ import com.google.protobuf.ByteString;
  */
 public class SecretManagerTemplate implements SecretManagerOperations {
 
-  /** Default value for the latest version of the secret. */
+  /**
+   * Default value for the latest version of the secret.
+   */
   public static final String LATEST_VERSION = "latest";
 
   private final SecretManagerServiceClient secretManagerServiceClient;
-
-  public GcpProjectIdProvider getProjectIdProvider() {
-    return projectIdProvider;
-  }
-
   private final GcpProjectIdProvider projectIdProvider;
 
   public SecretManagerTemplate(

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerTemplate.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerTemplate.java
@@ -44,6 +44,10 @@ public class SecretManagerTemplate implements SecretManagerOperations {
 
   private final SecretManagerServiceClient secretManagerServiceClient;
 
+  public GcpProjectIdProvider getProjectIdProvider() {
+    return projectIdProvider;
+  }
+
   private final GcpProjectIdProvider projectIdProvider;
 
   public SecretManagerTemplate(

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-secretmanager/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-secretmanager/pom.xml
@@ -26,6 +26,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-bootstrap</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>spring-cloud-gcp-secretmanager</artifactId>
 		</dependency>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-secretmanager/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-secretmanager/pom.xml
@@ -25,10 +25,12 @@
 			<artifactId>spring-cloud-context</artifactId>
 		</dependency>
 
+<!--
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-bootstrap</artifactId>
 		</dependency>
+-->
 
 		<dependency>
 			<groupId>com.google.cloud</groupId>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-secretmanager/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-secretmanager/pom.xml
@@ -25,13 +25,6 @@
 			<artifactId>spring-cloud-context</artifactId>
 		</dependency>
 
-<!--
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-bootstrap</artifactId>
-		</dependency>
--->
-
 		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>spring-cloud-gcp-secretmanager</artifactId>


### PR DESCRIPTION
External resources from GCP Secret Manager can be imported to custom project by add the following line in the `application.properties`:
`spring.config.import=sm://`

This feature is implemented using Spring Boot’s Config Data API, more info can be found in [here](https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4)
fix #149 

Users who want to use this feature should either exclude `<artifactId>spring-cloud-starter-bootstrap</artifactId>` from their dependency or to set `spring.cloud.gcp.secretmanager.legacy=false`
