### PR TITLE
fix: Datastore lazy reference save/update behavior

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
@@ -165,6 +165,10 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
       Iterable<T> entities, Set<Key> persisted, Key... ancestors) {
     List<Entity> entitiesForSave = new LinkedList<>();
     for (T entity : entities) {
+      // If entity is lazy referenced, now load all properties before attempt to save
+      if (LazyUtil.isLazy(entity)) {
+        entity = (T) LazyUtil.getLazyValue(entity);
+      }
       Key key = getKey(entity, true, ancestors);
       if (!persisted.contains(key)) {
         persisted.add(key);
@@ -528,11 +532,6 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
         validateKey(entity, keyToPathElement(ancestor));
       }
     }
-    // If entity is lazy referenced, now load all properties before attempt to save
-    if (LazyUtil.isLazy(entity)) {
-      entity = LazyUtil.getLazyValue(entity);
-    }
-
     Key key = getKey(entity, true, ancestors);
     Builder builder = Entity.newBuilder(key);
     List<Entity> entitiesToSave = new ArrayList<>();

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
@@ -527,7 +527,7 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
 
   private List<Entity> convertToEntityForSave(
       Object entity, Set<Key> persistedEntities, Key... ancestors) {
-    if (ancestors.length != 0) {
+    if (ancestors != null) {
       for (Key ancestor : ancestors) {
         validateKey(entity, keyToPathElement(ancestor));
       }

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/LazyUtil.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/LazyUtil.java
@@ -90,6 +90,22 @@ final class LazyUtil {
     return false;
   }
 
+  static boolean isLazy(Object object) {
+    SimpleLazyDynamicInvocationHandler handler = getProxy(object);
+    if (handler != null) {
+      return handler.getKeys() != null;
+    }
+    return false;
+  }
+
+  static Object getLazyValue(Object object) {
+    // validate it's object is lazy.
+    Assert.isTrue(isLazy(object), "A lazy loaded object is required.");
+
+    SimpleLazyDynamicInvocationHandler proxy = getProxy(object);
+    return proxy.getValue();
+  }
+
   /**
    * Extract keys from a proxy object.
    *
@@ -143,6 +159,10 @@ final class LazyUtil {
 
     public Value getKeys() {
       return this.keys;
+    }
+
+    T getValue() {
+      return value;
     }
 
     @Override

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/LazyUtil.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/LazyUtil.java
@@ -90,6 +90,12 @@ final class LazyUtil {
     return false;
   }
 
+  /**
+   * Check if the object is a lazy loaded proxy.
+   *
+   * @param object an object
+   * @return true if the object is a proxy
+   */
   static boolean isLazy(Object object) {
     SimpleLazyDynamicInvocationHandler handler = getProxy(object);
     if (handler != null) {
@@ -98,9 +104,14 @@ final class LazyUtil {
     return false;
   }
 
+  /**
+   * Loads the value provided by the proxy supplier.
+   *
+   * @param object an object that is a proxy
+   * @return value provided by the proxy supplier.
+   */
   static Object getLazyValue(Object object) {
-    // validate it's object is lazy.
-    Assert.isTrue(isLazy(object), "A lazy loaded object is required.");
+    Assert.isTrue(isLazy(object), "A proxy object is required.");
 
     SimpleLazyDynamicInvocationHandler proxy = getProxy(object);
     return proxy.getValue();

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/LazyUtil.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/LazyUtil.java
@@ -113,8 +113,11 @@ final class LazyUtil {
   static Object getLazyValue(Object object) {
     Assert.isTrue(isLazy(object), "A proxy object is required.");
 
-    SimpleLazyDynamicInvocationHandler proxy = getProxy(object);
-    return proxy.getValue();
+    SimpleLazyDynamicInvocationHandler handler = getProxy(object);
+    if (handler != null) {
+      return handler.getValue();
+    }
+    return null;
   }
 
   /**

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/ChildEntity.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/ChildEntity.java
@@ -34,10 +34,6 @@ public class ChildEntity {
     return id;
   }
 
-  // public void setId(String id) {
-  //   this.id = id;
-  // }
-
   public String getValue() {
     return value;
   }

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/ChildEntity.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/ChildEntity.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.data.datastore.it;
+
+import com.google.cloud.spring.data.datastore.core.mapping.Entity;
+import org.springframework.data.annotation.Id;
+
+@Entity
+public class ChildEntity {
+  @Id String id;
+
+  String value;
+
+  public ChildEntity(String id, String value) {
+    this.id = id;
+    this.value = value;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  // public void setId(String id) {
+  //   this.id = id;
+  // }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/LazyEntity.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/LazyEntity.java
@@ -41,6 +41,10 @@ public class LazyEntity {
     return this.lazyChild;
   }
 
+  public void setLazyChild(LazyEntity lazyChild) {
+    this.lazyChild = lazyChild;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {


### PR DESCRIPTION
The issue:
- when the lazy referenced child is not evaluated, save to datastore works as intended by only saving its key and not loading it.
- When this lazy referenced child is loaded/updated, the code logic treats it as a regular entity, where in fact, its value can only be accessed via proxy. As result, it tries to allocate a new key, hence error observed in #1203. Or if the id field is `Long`, it would not fail, but rather saved to Datastore as a new entity with null values.
 
Trying to fix by loading the real entity when attempting to save. When the entity is not loaded/evaluated, it will still fall to original logic without loading it.
fixes #1203 

SonarCloud failed on test coverage, I'll look into adding tests.