### PR TITLE
fix: clean-up missed stored entities after datastore integration test.

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/it/DatastoreIntegrationTests.java
@@ -145,6 +145,9 @@ class DatastoreIntegrationTests extends AbstractDatastoreIntegrationTests {
     this.datastoreTemplate.deleteAll(LazyEntity.class);
     this.datastoreTemplate.deleteAll(Product.class);
     this.datastoreTemplate.deleteAll(Store.class);
+    this.datastoreTemplate.deleteAll(Company.class);
+    this.datastoreTemplate.deleteAll(Employee.class);
+    this.datastoreTemplate.deleteAll(ServiceConfiguration.class);
     this.testEntityRepository.deleteAll();
     if (this.keyForMap != null) {
       this.datastore.delete(this.keyForMap);


### PR DESCRIPTION
delete created test entities in ci tests.