### PR TITLE
add null check to deal with edge case where Sql Spanner Query has nul…

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
@@ -130,6 +130,9 @@ public class StructAccessor {
   }
 
   public Object getSingleValue(int colIndex) {
+    if (this.struct.isNull(colIndex)) {
+      return null;
+    }
     Type colType = this.struct.getColumnType(colIndex);
     Class sourceType = getSingleItemTypeCode(colType);
     BiFunction readFunction = singleItemReadMethodMappingIntCol.get(sourceType);

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerRepositoryIntegrationTests.java
@@ -625,6 +625,17 @@ public class SpannerRepositoryIntegrationTests extends AbstractSpannerIntegratio
     assertThat(tradesWithActionNotNull).hasSize(2);
   }
 
+  @Test
+  void queryMethodsTest_sqlQueryReturnNull() {
+    Trade sellTradeWithNullSymbol = Trade.makeTrade("trader1", 0, 4);
+    sellTradeWithNullSymbol.setAction("SELL");
+    sellTradeWithNullSymbol.setSymbol(null);
+    this.spannerOperations.insert(sellTradeWithNullSymbol);
+
+    Optional<String> symbol = this.tradeRepository.getSymbolById(sellTradeWithNullSymbol.getId());
+    assertThat(symbol).isEmpty();
+  }
+
   private List<Trade> insertTrades(String traderId, String action, int numTrades) {
     List<Trade> trades = new ArrayList<>();
     for (int i = 0; i < numTrades; i++) {

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/TradeRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/TradeRepository.java
@@ -146,4 +146,7 @@ public interface TradeRepository extends SpannerRepository<Trade, Key> {
 
   @NonNull
   Trade getByAction(String s);
+
+  @Query("SELECT symbol from :com.google.cloud.spring.data.spanner.test.domain.Trade: where id = @id")
+  Optional<String> getSymbolById(@Param("id") String id);
 }


### PR DESCRIPTION
Fix for edge case with spring cloud gcp data spanner SQL query: 
when the query result is a simple field, and return is null, it should not fail. Like this one.
`@Query("SELECT name from test where id = @id")`
`Optional<String> getNameById(@Param("id") String id);`

fixes #637 