### PR TITLE
Add refdoc for short vs fully qualified topics/subscriptions

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -300,7 +300,7 @@ include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/
 Google Cloud Pub/Sub allows many subscriptions to be associated to the same topic.
 `PubSubTemplate` allows you to listen to subscriptions via the `subscribe()` method.
 When listening to a subscription, messages will be pulled from Google Cloud Pub/Sub asynchronously and passed to a user provided message handler.
-The subscription name could either be a short subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/[project_name]/subscriptions/<subscription_name>` format.
+The subscription name could either be a short subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/[project_name]/subscriptions/[subscription_name]` format.
 
 ===== Example
 Subscribe to a subscription with a message handler:

--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -273,7 +273,7 @@ It provides the common set of operations needed to interact with Google Cloud Pu
 
 `PubSubTemplate` provides asynchronous methods to publish messages to a Google Cloud Pub/Sub topic.
 The `publish()` method takes in a topic name to post the message to, a payload of a generic type and, optionally, a map with the message headers.
-The topic name could either be a canonical topic name within the current project, or the fully-qualified name referring to a topic in a different project using the `projects/<project_name>/topics/<topic_name>` format.
+The topic name could either be a short topic name within the current project, or the fully-qualified name referring to a topic in a different project using the `projects/[project_name]/topics/[topic_name]` format.
 
 Here is an example of how to publish a message to a Google Cloud Pub/Sub topic:
 
@@ -300,7 +300,7 @@ include::{project-root}/spring-cloud-gcp-autoconfigure/src/test/java/com/google/
 Google Cloud Pub/Sub allows many subscriptions to be associated to the same topic.
 `PubSubTemplate` allows you to listen to subscriptions via the `subscribe()` method.
 When listening to a subscription, messages will be pulled from Google Cloud Pub/Sub asynchronously and passed to a user provided message handler.
-The subscription name could either be a canonical subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/<project_name>/subscriptions/<subscription_name>` format.
+The subscription name could either be a short subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/[project_name]/subscriptions/<subscription_name>` format.
 
 ===== Example
 Subscribe to a subscription with a message handler:
@@ -477,7 +477,7 @@ flux.doOnNext(AcknowledgeablePubsubMessage::ack);
 `PubSubAdmin` is the abstraction provided by Spring Cloud GCP to manage Google Cloud Pub/Sub resources.
 It allows for the creation, deletion and listing of topics and subscriptions.
 
-NOTE: Generally when referring to topics and subscriptions, you can either use the short canonical name within the current project, or the fully-qualified name referring to a topic or subscription in a different project using the `projects/<project_name>/(topics|subscriptions)/<name>` format.
+NOTE: Generally when referring to topics and subscriptions, you can either use the short canonical name within the current project, or the fully-qualified name referring to a topic or subscription in a different project using the `projects/[project_name]/(topics|subscriptions)/<name>` format.
 
 The Spring Boot starter for GCP Pub/Sub auto-configures a `PubSubAdmin` object using the `GcpProjectIdProvider` and the `CredentialsProvider` auto-configured by the Spring Boot GCP Core starter.
 

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -43,6 +43,8 @@ The `PubSubInboundChannelAdapter` delegates the conversion to the desired payloa
 
 To use the inbound channel adapter, a `PubSubInboundChannelAdapter` must be provided and configured on the user application side.
 
+NOTE: The subscription name could either be a short subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/[project_name]/subscriptions/<subscription_name>` format.
+
 [source,java]
 ----
 @Bean
@@ -202,6 +204,8 @@ This can be overridden by using `setBlockOnPull()` method to wait for at least o
 By default, `PubSubMessageSource` pulls from the subscription one message at a time.
 To pull a batch of messages on each request, use the `setMaxFetchSize()` method to set the batch size.
 
+NOTE: The subscription name could either be a short subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/[project_name]/subscriptions/<subscription_name>` format.
+
 [source,java]
 ----
 @Bean
@@ -246,6 +250,8 @@ It delegates this conversion to the `PubSubTemplate`.
 To customize the conversion, you can specify a `PubSubMessageConverter` in the `PubSubTemplate` that should convert the `Object` payload and headers of the Spring `Message` to a `PubsubMessage`.
 
 To use the outbound channel adapter, a `PubSubMessageHandler` bean must be provided and configured on the user application side.
+
+NOTE: The topic name could either be a short topic name within the current project, or the fully-qualified name referring to a topic in a different project using the `projects/[project_name]/topics/[topic_name]` format.
 
 [source,java]
 ----

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -43,7 +43,7 @@ The `PubSubInboundChannelAdapter` delegates the conversion to the desired payloa
 
 To use the inbound channel adapter, a `PubSubInboundChannelAdapter` must be provided and configured on the user application side.
 
-NOTE: The subscription name could either be a short subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/[project_name]/subscriptions/<subscription_name>` format.
+NOTE: The subscription name could either be a short subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/[project_name]/subscriptions/[subscription_name]` format.
 
 [source,java]
 ----
@@ -204,7 +204,7 @@ This can be overridden by using `setBlockOnPull()` method to wait for at least o
 By default, `PubSubMessageSource` pulls from the subscription one message at a time.
 To pull a batch of messages on each request, use the `setMaxFetchSize()` method to set the batch size.
 
-NOTE: The subscription name could either be a short subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/[project_name]/subscriptions/<subscription_name>` format.
+NOTE: The subscription name could either be a short subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/[project_name]/subscriptions/[subscription_name]` format.
 
 [source,java]
 ----

--- a/docs/src/main/md/pubsub.md
+++ b/docs/src/main/md/pubsub.md
@@ -297,10 +297,10 @@ to interact with Google Cloud Pub/Sub.
 `PubSubTemplate` provides asynchronous methods to publish messages to a
 Google Cloud Pub/Sub topic. The `publish()` method takes in a topic name
 to post the message to, a payload of a generic type and, optionally, a
-map with the message headers. The topic name could either be a canonical
+map with the message headers. The topic name could either be a short
 topic name within the current project, or the fully-qualified name
 referring to a topic in a different project using the
-`projects/<project_name>/topics/<topic_name>` format.
+`projects/[project_name]/topics/[topic_name]` format.
 
 Here is an example of how to publish a message to a Google Cloud Pub/Sub
 topic:
@@ -339,9 +339,9 @@ same topic. `PubSubTemplate` allows you to listen to subscriptions via
 the `subscribe()` method. When listening to a subscription, messages
 will be pulled from Google Cloud Pub/Sub asynchronously and passed to a
 user provided message handler. The subscription name could either be a
-canonical subscription name within the current project, or the
+short subscription name within the current project, or the
 fully-qualified name referring to a subscription in a different project
-using the `projects/<project_name>/subscriptions/<subscription_name>`
+using the `projects/[project_name]/subscriptions/<subscription_name>`
 format.
 
 ##### Example
@@ -645,7 +645,7 @@ Generally when referring to topics and subscriptions, you can either use
 the short canonical name within the current project, or the
 fully-qualified name referring to a topic or subscription in a different
 project using the
-`projects/<project_name>/(topics|subscriptions)/<name>` format.
+`projects/[project_name]/(topics|subscriptions)/<name>` format.
 
 </div>
 

--- a/docs/src/main/md/pubsub.md
+++ b/docs/src/main/md/pubsub.md
@@ -341,7 +341,7 @@ will be pulled from Google Cloud Pub/Sub asynchronously and passed to a
 user provided message handler. The subscription name could either be a
 short subscription name within the current project, or the
 fully-qualified name referring to a subscription in a different project
-using the `projects/[project_name]/subscriptions/<subscription_name>`
+using the `projects/[project_name]/subscriptions/[subscription_name]`
 format.
 
 ##### Example

--- a/docs/src/main/md/spring-integration.md
+++ b/docs/src/main/md/spring-integration.md
@@ -56,6 +56,8 @@ delegates the conversion to the desired payload type to the
 
 To use the inbound channel adapter, a `PubSubInboundChannelAdapter` must
 be provided and configured on the user application side.
+> **NOTE:** The subscription name could either be a short subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/[project_name]/subscriptions/[subscription_name]` format.
+
 
 ``` java
 @Bean
@@ -245,6 +247,9 @@ By default, `PubSubMessageSource` pulls from the subscription one
 message at a time. To pull a batch of messages on each request, use the
 `setMaxFetchSize()` method to set the batch size.
 
+> **NOTE:** The subscription name could either be a short subscription name within the current project, or the fully-qualified name referring to a subscription in a different project using the `projects/[project_name]/subscriptions/[subscription_name]` format.
+
+
 ``` java
 @Bean
 @InboundChannelAdapter(channel = "pubsubInputChannel", poller = @Poller(fixedDelay = "100"))
@@ -306,6 +311,8 @@ to the `PubSubTemplate`. To customize the conversion, you can specify a
 
 To use the outbound channel adapter, a `PubSubMessageHandler` bean must
 be provided and configured on the user application side.
+
+> **NOTE:**  The topic name could either be a short topic name within the current project, or the fully-qualified name referring to a topic in a different project using the `projects/[project_name]/topics/[topic_name]` format.
 
 ``` java
 @Bean

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
@@ -178,7 +178,7 @@ public class PubSubAdmin implements AutoCloseable {
    *
    * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param topicName short topic name, e.g., "topicName", or the fully-qualified topic name in
    *     the {@code projects/[project_name]/topics/[topic_name]} format
    * @return the created subscription
@@ -192,7 +192,7 @@ public class PubSubAdmin implements AutoCloseable {
    *
    * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param topicName short topic name, e.g., "topicName", or the fully-qualified topic name in
    *     the {@code projects/[project_name]/topics/[topic_name]} format
    * @param ackDeadline deadline in seconds before a message is resent, must be between 10 and 600
@@ -209,7 +209,7 @@ public class PubSubAdmin implements AutoCloseable {
    *
    * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param topicName short topic name, e.g., "topicName", or the fully-qualified topic name in
    *     the {@code projects/[project_name]/topics/[topic_name]} format
    * @param pushEndpoint the URL of the service receiving the push messages. If not provided, uses
@@ -226,7 +226,7 @@ public class PubSubAdmin implements AutoCloseable {
    *
    * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param topicName short topic name, e.g., "topicName", or the fully-qualified topic name in
    *     the {@code projects/[project_name]/topics/[topic_name]} format
    * @param ackDeadline deadline in seconds before a message is resent, must be between 10 and 600
@@ -283,7 +283,7 @@ public class PubSubAdmin implements AutoCloseable {
    *
    * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @return subscription configuration or {@code null} if subscription doesn't exist
    */
   public Subscription getSubscription(String subscriptionName) {
@@ -306,7 +306,7 @@ public class PubSubAdmin implements AutoCloseable {
    *
    * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    */
   public void deleteSubscription(String subscriptionName) {
     Assert.hasText(subscriptionName, "No subscription name was specified");

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/PubSubAdmin.java
@@ -113,7 +113,7 @@ public class PubSubAdmin implements AutoCloseable {
    * Create a new topic on Google Cloud Pub/Sub.
    *
    * @param topicName the name for the new topic within the current project, or the fully-qualified
-   *     topic name in the {@code projects/<project_name>/topics/<topic_name>} format
+   *     topic name in the {@code projects/[project_name]/topics/[topic_name]} format
    * @return the created topic
    */
   public Topic createTopic(String topicName) {
@@ -126,8 +126,8 @@ public class PubSubAdmin implements AutoCloseable {
   /**
    * Get the configuration of a Google Cloud Pub/Sub topic.
    *
-   * @param topicName canonical topic name, e.g., "topicName", or the fully-qualified topic name in
-   *     the {@code projects/<project_name>/topics/<topic_name>} format
+   * @param topicName short topic name, e.g., "topicName", or the fully-qualified topic name in
+   *     the {@code projects/[project_name]/topics/[topic_name]} format
    * @return topic configuration or {@code null} if topic doesn't exist
    */
   public Topic getTopic(String topicName) {
@@ -148,8 +148,8 @@ public class PubSubAdmin implements AutoCloseable {
   /**
    * Delete a topic from Google Cloud Pub/Sub.
    *
-   * @param topicName canonical topic name, e.g., "topicName", or the fully-qualified topic name in
-   *     the {@code projects/<project_name>/topics/<topic_name>} format
+   * @param topicName short topic name, e.g., "topicName", or the fully-qualified topic name in
+   *     the {@code projects/[project_name]/topics/[topic_name]} format
    */
   public void deleteTopic(String topicName) {
     Assert.hasText(topicName, NO_TOPIC_SPECIFIED);
@@ -176,11 +176,11 @@ public class PubSubAdmin implements AutoCloseable {
   /**
    * Create a new subscription on Google Cloud Pub/Sub.
    *
-   * @param subscriptionName canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
-   * @param topicName canonical topic name, e.g., "topicName", or the fully-qualified topic name in
-   *     the {@code projects/<project_name>/topics/<topic_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   * @param topicName short topic name, e.g., "topicName", or the fully-qualified topic name in
+   *     the {@code projects/[project_name]/topics/[topic_name]} format
    * @return the created subscription
    */
   public Subscription createSubscription(String subscriptionName, String topicName) {
@@ -190,11 +190,11 @@ public class PubSubAdmin implements AutoCloseable {
   /**
    * Create a new subscription on Google Cloud Pub/Sub.
    *
-   * @param subscriptionName canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
-   * @param topicName canonical topic name, e.g., "topicName", or the fully-qualified topic name in
-   *     the {@code projects/<project_name>/topics/<topic_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   * @param topicName short topic name, e.g., "topicName", or the fully-qualified topic name in
+   *     the {@code projects/[project_name]/topics/[topic_name]} format
    * @param ackDeadline deadline in seconds before a message is resent, must be between 10 and 600
    *     seconds. If not provided, set to default of 10 seconds
    * @return the created subscription
@@ -207,11 +207,11 @@ public class PubSubAdmin implements AutoCloseable {
   /**
    * Create a new subscription on Google Cloud Pub/Sub.
    *
-   * @param subscriptionName canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
-   * @param topicName canonical topic name, e.g., "topicName", or the fully-qualified topic name in
-   *     the {@code projects/<project_name>/topics/<topic_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   * @param topicName short topic name, e.g., "topicName", or the fully-qualified topic name in
+   *     the {@code projects/[project_name]/topics/[topic_name]} format
    * @param pushEndpoint the URL of the service receiving the push messages. If not provided, uses
    *     message pulling by default
    * @return the created subscription
@@ -224,11 +224,11 @@ public class PubSubAdmin implements AutoCloseable {
   /**
    * Create a new subscription on Google Cloud Pub/Sub.
    *
-   * @param subscriptionName canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
-   * @param topicName canonical topic name, e.g., "topicName", or the fully-qualified topic name in
-   *     the {@code projects/<project_name>/topics/<topic_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   * @param topicName short topic name, e.g., "topicName", or the fully-qualified topic name in
+   *     the {@code projects/[project_name]/topics/[topic_name]} format
    * @param ackDeadline deadline in seconds before a message is resent, must be between 10 and 600
    *     seconds. If not provided, set to default of 10 seconds
    * @param pushEndpoint the URL of the service receiving the push messages. If not provided, uses
@@ -281,9 +281,9 @@ public class PubSubAdmin implements AutoCloseable {
   /**
    * Get the configuration of a Google Cloud Pub/Sub subscription.
    *
-   * @param subscriptionName canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    * @return subscription configuration or {@code null} if subscription doesn't exist
    */
   public Subscription getSubscription(String subscriptionName) {
@@ -304,9 +304,9 @@ public class PubSubAdmin implements AutoCloseable {
   /**
    * Delete a subscription from Google Cloud Pub/Sub.
    *
-   * @param subscriptionName canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscriptionName short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    */
   public void deleteSubscription(String subscriptionName) {
     Assert.hasText(subscriptionName, "No subscription name was specified");

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/publisher/PubSubPublisherOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/publisher/PubSubPublisherOperations.java
@@ -30,8 +30,8 @@ public interface PubSubPublisherOperations {
   /**
    * Send a message to Pub/Sub.
    *
-   * @param topic canonical topic name, e.g., "topicName", or the fully-qualified topic name in the
-   *     {@code projects/<project_name>/topics/<topic_name>} format
+   * @param topic short topic name, e.g., "topicName", or the fully-qualified topic name in the
+   *     {@code projects/[project_name]/topics/[topic_name]} format
    * @param payload an object that will be serialized and sent
    * @param headers the headers to publish
    * @param <T> the type of the payload to publish
@@ -42,8 +42,8 @@ public interface PubSubPublisherOperations {
   /**
    * Send a message to Pub/Sub.
    *
-   * @param topic canonical topic name, e.g., "topicName", or the fully-qualified topic name in the
-   *     {@code projects/<project_name>/topics/<topic_name>} format
+   * @param topic short topic name, e.g., "topicName", or the fully-qualified topic name in the
+   *     {@code projects/[project_name]/topics/[topic_name]} format
    * @param payload an object that will be serialized and sent
    * @param <T> the type of the payload to publish
    * @return the listenable future of the call
@@ -53,8 +53,8 @@ public interface PubSubPublisherOperations {
   /**
    * Send a message to Pub/Sub.
    *
-   * @param topic canonical topic name, e.g., "topicName", or the fully-qualified topic name in the
-   *     {@code projects/<project_name>/topics/<topic_name>} format
+   * @param topic short topic name, e.g., "topicName", or the fully-qualified topic name in the
+   *     {@code projects/[project_name]/topics/[topic_name]} format
    * @param pubsubMessage a Google Cloud Pub/Sub API message
    * @return the listenable future of the call
    */

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberOperations.java
@@ -39,9 +39,9 @@ public interface PubSubSubscriberOperations {
    *
    * <p>The created {@link Subscriber} is returned so it can be stopped.
    *
-   * @param subscription canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    * @param messageConsumer the callback method triggered when new messages arrive
    * @return subscriber listening to new messages
    * @since 1.1
@@ -55,9 +55,9 @@ public interface PubSubSubscriberOperations {
    *
    * <p>The created {@link Subscriber} is returned so it can be stopped.
    *
-   * @param subscription canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    * @param messageConsumer the callback method triggered when new messages arrive
    * @param payloadType the type to which the payload of the Pub/Sub message should be converted
    * @param <T> the type of the payload
@@ -72,9 +72,9 @@ public interface PubSubSubscriberOperations {
   /**
    * Pull and auto-acknowledge a number of messages from a Google Cloud Pub/Sub subscription.
    *
-   * @param subscription canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -89,9 +89,9 @@ public interface PubSubSubscriberOperations {
    * Asynchronously pull and auto-acknowledge a number of messages from a Google Cloud Pub/Sub
    * subscription.
    *
-   * @param subscription canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -107,9 +107,9 @@ public interface PubSubSubscriberOperations {
   /**
    * Pull a number of messages from a Google Cloud Pub/Sub subscription.
    *
-   * @param subscription canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -123,9 +123,9 @@ public interface PubSubSubscriberOperations {
   /**
    * Asynchronously pull a number of messages from a Google Cloud Pub/Sub subscription.
    *
-   * @param subscription canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -142,9 +142,9 @@ public interface PubSubSubscriberOperations {
    * Pull a number of messages from a Google Cloud Pub/Sub subscription and convert them to Spring
    * messages with the desired payload type.
    *
-   * @param subscription canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -162,9 +162,9 @@ public interface PubSubSubscriberOperations {
    * Asynchronously pull a number of messages from a Google Cloud Pub/Sub subscription and convert
    * them to Spring messages with the desired payload type.
    *
-   * @param subscription canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -182,9 +182,9 @@ public interface PubSubSubscriberOperations {
   /**
    * Pull and auto-acknowledge a message from a Google Cloud Pub/Sub subscription.
    *
-   * @param subscription canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    * @return a received message, or {@code null} if none exists in the subscription
    */
   PubsubMessage pullNext(String subscription);
@@ -192,9 +192,9 @@ public interface PubSubSubscriberOperations {
   /**
    * Asynchronously pull and auto-acknowledge a message from a Google Cloud Pub/Sub subscription.
    *
-   * @param subscription canonical subscription name, e.g., "subscriptionName", or the
+   * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/<project_name>/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/<subscription_name>} format
    * @return the ListenableFuture for the asynchronous execution, returning a received message, or
    *     {@code null} if none exists in the subscription
    * @since 1.2.3

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberOperations.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberOperations.java
@@ -41,7 +41,7 @@ public interface PubSubSubscriberOperations {
    *
    * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param messageConsumer the callback method triggered when new messages arrive
    * @return subscriber listening to new messages
    * @since 1.1
@@ -57,7 +57,7 @@ public interface PubSubSubscriberOperations {
    *
    * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param messageConsumer the callback method triggered when new messages arrive
    * @param payloadType the type to which the payload of the Pub/Sub message should be converted
    * @param <T> the type of the payload
@@ -74,7 +74,7 @@ public interface PubSubSubscriberOperations {
    *
    * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -91,7 +91,7 @@ public interface PubSubSubscriberOperations {
    *
    * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -109,7 +109,7 @@ public interface PubSubSubscriberOperations {
    *
    * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -125,7 +125,7 @@ public interface PubSubSubscriberOperations {
    *
    * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -144,7 +144,7 @@ public interface PubSubSubscriberOperations {
    *
    * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -164,7 +164,7 @@ public interface PubSubSubscriberOperations {
    *
    * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @param maxMessages the maximum number of pulled messages. If this value is null then up to
    *     Integer.MAX_VALUE messages will be requested.
    * @param returnImmediately returns immediately even if subscription doesn't contain enough
@@ -184,7 +184,7 @@ public interface PubSubSubscriberOperations {
    *
    * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @return a received message, or {@code null} if none exists in the subscription
    */
   PubsubMessage pullNext(String subscription);
@@ -194,7 +194,7 @@ public interface PubSubSubscriberOperations {
    *
    * @param subscription short subscription name, e.g., "subscriptionName", or the
    *     fully-qualified subscription name in the {@code
-   *     projects/[project_name]/subscriptions/<subscription_name>} format
+   *     projects/[project_name]/subscriptions/[subscription_name]} format
    * @return the ListenableFuture for the asynchronous execution, returning a received message, or
    *     {@code null} if none exists in the subscription
    * @since 1.2.3

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapter.java
@@ -54,10 +54,11 @@ public class PubSubInboundChannelAdapter extends MessageProducerSupport {
   private HealthTrackerRegistry healthTrackerRegistry;
 
   /**
-   * Instantiates a streaming Pub/Sub subscirtion adapter.
+   * Instantiates a streaming Pub/Sub subscription adapter.
    *
    * @param pubSubSubscriberOperations {@link PubSubSubscriberOperations} to use
-   * @param subscriptionName short or fully qualified subscription name
+   * @param subscriptionName short subscription name, e.g., "subscriptionName", or the fully-qualified subscription name
+   *                        in the {@code projects/[project_name]/subscriptions/[subscription_name]} format
    */
   public PubSubInboundChannelAdapter(
       PubSubSubscriberOperations pubSubSubscriberOperations, String subscriptionName) {

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/PubSubSubscriptionUtils.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/PubSubSubscriptionUtils.java
@@ -32,7 +32,7 @@ public final class PubSubSubscriptionUtils {
   /**
    * Create a {@link ProjectSubscriptionName} based on a subscription name within a project or the
    * fully-qualified subscription name. If the specified subscription is in the {@code
-   * projects/<project_name>/subscriptions/<subscription_name>} format, then the {@code projectId}
+   * projects/[project_name]/subscriptions/<subscription_name>} format, then the {@code projectId}
    * is ignored}
    *
    * @param subscription the subscription name in the project or the fully-qualified project name
@@ -47,7 +47,7 @@ public final class PubSubSubscriptionUtils {
 
     if (ProjectSubscriptionName.isParsableFrom(subscription)) {
       // Fully-qualified subscription name in the
-      // "projects/<project_name>/subscriptions/<subscription_name>" format
+      // "projects/[project_name]/subscriptions/<subscription_name>" format
       projectSubscriptionName = ProjectSubscriptionName.parse(subscription);
     } else {
       Assert.notNull(

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/PubSubSubscriptionUtils.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/PubSubSubscriptionUtils.java
@@ -32,7 +32,7 @@ public final class PubSubSubscriptionUtils {
   /**
    * Create a {@link ProjectSubscriptionName} based on a subscription name within a project or the
    * fully-qualified subscription name. If the specified subscription is in the {@code
-   * projects/[project_name]/subscriptions/<subscription_name>} format, then the {@code projectId}
+   * projects/[project_name]/subscriptions/[subscription_name]} format, then the {@code projectId}
    * is ignored}
    *
    * @param subscription the subscription name in the project or the fully-qualified project name
@@ -47,7 +47,7 @@ public final class PubSubSubscriptionUtils {
 
     if (ProjectSubscriptionName.isParsableFrom(subscription)) {
       // Fully-qualified subscription name in the
-      // "projects/[project_name]/subscriptions/<subscription_name>" format
+      // "projects/[project_name]/subscriptions/[subscription_name]" format
       projectSubscriptionName = ProjectSubscriptionName.parse(subscription);
     } else {
       Assert.notNull(

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtils.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/PubSubTopicUtils.java
@@ -33,7 +33,7 @@ public final class PubSubTopicUtils {
   /**
    * Create a {@link ProjectTopicName} based on a topic name within a project or the fully-qualified
    * topic name. If the specified topic is in the {@code
-   * projects/<project_name>/topics/<topic_name>} format, then the {@code projectId} is ignored}
+   * projects/[project_name]/topics/[topic_name]} format, then the {@code projectId} is ignored}
    *
    * @param topic the topic name in the project or the fully-qualified project name
    * @param projectId the project ID to use if the topic is not a fully-qualified name
@@ -45,7 +45,7 @@ public final class PubSubTopicUtils {
     ProjectTopicName projectTopicName = null;
 
     if (ProjectTopicName.isParsableFrom(topic)) {
-      // Fully-qualified topic name in the "projects/<project_name>/topics/<topic_name>" format
+      // Fully-qualified topic name in the "projects/[project_name]/topics/[topic_name]" format
       projectTopicName = ProjectTopicName.parse(topic);
     } else {
       Assert.notNull(projectId, "The project ID can't be null when using canonical topic name.");
@@ -57,7 +57,7 @@ public final class PubSubTopicUtils {
 
   /**
    * Create a {@link TopicName} based on a topic name within a project or the fully-qualified topic
-   * name. If the specified topic is in the {@code projects/<project_name>/topics/<topic_name>}
+   * name. If the specified topic is in the {@code projects/[project_name]/topics/[topic_name]}
    * format, then the {@code projectId} is ignored}
    *
    * @param topic the topic name in the project or the fully-qualified project name


### PR DESCRIPTION
Several documentation changes:
1) Added notes to Spring Integration adapters that subscription/topic names can be fully qualified.
2) Replaced javadoc `<property>` with `[property]` because IntelliJ does not render what it thinks are HTML tags (`<...>`).
3) Replaced "canonical" with "short", because "canonical" reads as ambiguous -- are short names canonical, or are the fully qualified names canonical? It's kind of both -- short names are historically canonical to Spring Cloud GCP, but fully qualified ones are canonical to the client library.

Fixes #581.