### PR TITLE
Add documentation for api logger ehnancers

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -65,7 +65,7 @@ Your configuration may then look like this:
 ----
 
 If you want to have more control over the log output, you can further configure the appender.
-The following properties are available:
+The following properties are available (see link:https://github.com/googleapis/java-logging-logback[java-logging-logback project] for the full list):
 
 [options="header",]
 |=======================================================================
@@ -74,6 +74,8 @@ The following properties are available:
 This can also be set via the `STACKDRIVER_LOG_NAME` environmental variable.
 | `flushLevel` | `WARN` | If a log entry with this level is encountered, trigger a flush of locally buffered log to Cloud Logging.
 This can also be set via the `STACKDRIVER_LOG_FLUSH_LEVEL` environmental variable.
+| `enhancer` |  | Fully qualified class name for customizing a logging entry; must implement `com.google.cloud.logging.LoggingEnhancer`.
+| `loggingEventEnhancer` |  | Fully qualified class name for customizing a logging entry given an link:https://logback.qos.ch/apidocs/ch/qos/logback/classic/spi/ILoggingEvent.html[`ILoggingEvent`]; must implement `com.google.cloud.logging.logback.LoggingEventEnhancer`.
 |=======================================================================
 
 ==== Asynchronous Logging

--- a/docs/src/main/md/logging.md
+++ b/docs/src/main/md/logging.md
@@ -95,12 +95,14 @@ Your configuration may then look like this:
 ```
 
 If you want to have more control over the log output, you can further
-configure the appender. The following properties are available:
+configure the appender. The following properties are available  (see [java-logging-logback project](https://github.com/googleapis/java-logging-logback) for the full list):
 
-| Property     | Default Value | Description                                                                                                                                                                                 |
-| ------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log`        | `spring.log`  | The Cloud Logging Log name. This can also be set via the `STACKDRIVER_LOG_NAME` environmental variable.                                                                                     |
-| `flushLevel` | `WARN`        | If a log entry with this level is encountered, trigger a flush of locally buffered log to Cloud Logging. This can also be set via the `STACKDRIVER_LOG_FLUSH_LEVEL` environmental variable. |
+| Property    | Default Value | Description                                                                                                                                                                                                                                 |
+|-------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `log`       | `spring.log` | The Cloud Logging Log name. This can also be set via the `STACKDRIVER_LOG_NAME` environmental variable.                                                                                                                                     |
+| `flushLevel` | `WARN`      | If a log entry with this level is encountered, trigger a flush of locally buffered log to Cloud Logging. This can also be set via the `STACKDRIVER_LOG_FLUSH_LEVEL` environmental variable.                                                 |
+| `enhancer`  |             | Fully qualified class name for customizing a logging entry; must implement `com.google.cloud.logging.LoggingEnhancer`.                                                                                                                      |
+| `loggingEventEnhancer`  |             | Fully qualified class name for customizing a logging entry given an [`ILoggingEvent`](https://logback.qos.ch/apidocs/ch/qos/logback/classic/spi/ILoggingEvent.html); must implement `com.google.cloud.logging.logback.LoggingEventEnhancer`. |
 
 #### Asynchronous Logging
 


### PR DESCRIPTION
The enhancers' usage is confusing, so while I linked to the main logback appender library, I've added two rows specifying the exact interface that must be implemented for each. Otherwise the ehnancers get silently ignored, which... is not ideal.

Note that documentation temporarily has to be mirrored manually between markdown and asciidoc.

Fixes #1218.