### PR TITLE
Modify spanner sample docs to instruct user running spanner using emulator

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -1507,7 +1507,12 @@ Once the Spanner emulator is running, ensure that the following properties are s
 
 ----
 spring.cloud.gcp.spanner.emulator.enabled=true
-spring.cloud.gcp.spanner.emulator-host=${EMULATOR_HOSTPORT}
+----
+
+Note that the default emulator hostname and port (i.e., localhost:9010) is used. If you prefer a customized value, ensure the following property is set in your `application.properties` of your Spring application:
+
+----
+spring.cloud.gcp.spanner.emulator-host=ip:port
 ----
 
 === Sample

--- a/docs/src/main/md/spanner.md
+++ b/docs/src/main/md/spanner.md
@@ -1786,7 +1786,10 @@ properties are set in your `application.properties` of your Spring
 application:
 
     spring.cloud.gcp.spanner.emulator.enabled=true
-    spring.cloud.gcp.spanner.emulator-host=${EMULATOR_HOSTPORT}
+
+Note that the default emulator hostname and port (i.e., localhost:9010) is used. If you prefer a customized value, ensure the following property is set in your `application.properties` of your Spring application:
+
+    spring.cloud.gcp.spanner.emulator-host=ip:port
 
 ### Sample
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/README.adoc
@@ -29,6 +29,12 @@ After that, you would need to create an instance using this command:
 $ gcloud spanner instances create spring-demo --config=emulator-config --description="Test Instance" --nodes=1
 ----
 
+Add the following property to `application.properties`:
+
+----
+spring.cloud.gcp.spanner.emulator.enabled=true
+----
+
 Note that you need to set the `SPANNER_EMULATOR_HOST` environment variable to use the emulator.
 
 ----

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/README.adoc
@@ -35,11 +35,7 @@ Add the following property to `application.properties`:
 spring.cloud.gcp.spanner.emulator.enabled=true
 ----
 
-Note that you need to set the `SPANNER_EMULATOR_HOST` environment variable to use the emulator.
-
-----
-$ export SPANNER_EMULATOR_HOST=localhost:9010
-----
+Note that the `SPANNER_EMULATOR_HOST` environment variable is NOT needed in this case as `GcpSpannerEmulatorAutoConfiguration` will define a default hostname and port (i.e, localhost:9010) for the emulator.
 
 === Running the application
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-template-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-template-sample/README.adoc
@@ -25,11 +25,13 @@ After that, you would need to create an instance using this command:
 $ gcloud spanner instances create spring-demo --config=emulator-config --description="Test Instance" --nodes=1
 ----
 
-Note that you need to set the `SPANNER_EMULATOR_HOST` environment variable to use the emulator.
+Add the following property to `application.properties`:
 
 ----
-$ export SPANNER_EMULATOR_HOST=localhost:9010
+spring.cloud.gcp.spanner.emulator.enabled=true
 ----
+
+Note that the `SPANNER_EMULATOR_HOST` environment variable is NOT needed in this case as `GcpSpannerEmulatorAutoConfiguration` will define a default hostname and port (i.e, localhost:9010) for the emulator.
 
 === Running the application
 Run `$ mvn clean install` from the root directory of the project.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-template-sample/src/main/java/com/example/SpannerTemplateExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-template-sample/src/main/java/com/example/SpannerTemplateExample.java
@@ -21,6 +21,7 @@ import com.google.cloud.spring.data.spanner.core.SpannerOperations;
 import com.google.cloud.spring.data.spanner.core.admin.SpannerDatabaseAdminTemplate;
 import com.google.cloud.spring.data.spanner.core.admin.SpannerSchemaUtils;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -29,12 +30,13 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-// import org.springframework.stereotype.Component;
 
 /** Example usage of the Spanner Template. */
 @SpringBootApplication
 public class SpannerTemplateExample {
   private static final Log LOGGER = LogFactory.getLog(SpannerTemplateExample.class);
+
+  private static final String TEMPLATE_TRADER_1 = "template_trader1";
 
   @Autowired private SpannerOperations spannerOperations;
 
@@ -47,18 +49,18 @@ public class SpannerTemplateExample {
     this.spannerOperations.delete(Trader.class, KeySet.all());
     this.spannerOperations.delete(Trade.class, KeySet.all());
 
-    Trader trader = new Trader("template_trader1", "John", "Doe");
+    Trader trader = new Trader(TEMPLATE_TRADER_1, "John", "Doe");
 
     this.spannerOperations.insert(trader);
 
     Trade t =
         new Trade(
-            "1", "BUY", 100.0, 50.0, "STOCK1", "template_trader1", Arrays.asList(99.0, 101.00));
+            "1", "BUY", 100.0, 50.0, "STOCK1", TEMPLATE_TRADER_1, Arrays.asList(99.0, 101.00));
 
     this.spannerOperations.insert(t);
 
     t.setTradeId("2");
-    t.setTraderId("template_trader1");
+    t.setTraderId(TEMPLATE_TRADER_1);
     t.setAction("SELL");
     this.spannerOperations.insert(t);
 
@@ -76,12 +78,12 @@ public class SpannerTemplateExample {
   void createTablesIfNotExists() {
     if (!this.spannerDatabaseAdminTemplate.tableExists("trades_template")) {
       this.spannerDatabaseAdminTemplate.executeDdlStrings(
-          Arrays.asList(this.spannerSchemaUtils.getCreateTableDdlString(Trade.class)), true);
+          Collections.singletonList(this.spannerSchemaUtils.getCreateTableDdlString(Trade.class)), true);
     }
 
     if (!this.spannerDatabaseAdminTemplate.tableExists("traders_template")) {
       this.spannerDatabaseAdminTemplate.executeDdlStrings(
-          Arrays.asList(this.spannerSchemaUtils.getCreateTableDdlString(Trader.class)), true);
+          Collections.singletonList(this.spannerSchemaUtils.getCreateTableDdlString(Trader.class)), true);
     }
   }
 


### PR DESCRIPTION
Property `spring.cloud.gcp.spanner.emulator.enabled` is missing in spanner sample docs. It is required per [Spring Cloud GCP Spanner doc](https://googlecloudplatform.github.io/spring-cloud-gcp/reference/html/index.html#configuration-5) if the user want to run an instance on emulator.