### PR TITLE
Support default secret value when accessing non-existed secret for Secret Manager

### DIFF
--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -36,7 +36,7 @@ dependencies {
 By default, Spring Cloud GCP Secret Manager will authenticate using Application Default Credentials.
 This can be overridden using the authentication properties.
 
-NOTE: All of the below settings must be specified in a https://cloud.spring.io/spring-cloud-commons/multi/multi__spring_cloud_context_application_context_services.html#_the_bootstrap_application_context[`bootstrap.properties`] (or `bootstrap.yaml`) file which is the properties file used to configure settings for bootstrap-phase Spring configuration.
+NOTE: All the below settings must be specified in a https://cloud.spring.io/spring-cloud-commons/multi/multi__spring_cloud_context_application_context_services.html#_the_bootstrap_application_context[`bootstrap.properties`] (or `bootstrap.yaml`) file which is the properties file used to configure settings for bootstrap-phase Spring configuration.
 
 |===
 | Name | Description | Required | Default value
@@ -44,6 +44,8 @@ NOTE: All of the below settings must be specified in a https://cloud.spring.io/s
 | `spring.cloud.gcp.secretmanager.credentials.location` | OAuth2 credentials for authenticating to the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
 | `spring.cloud.gcp.secretmanager.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key for authenticating to the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
 | `spring.cloud.gcp.secretmanager.project-id` | The default GCP Project used to access Secret Manager API for the template and property source. | No | By default, infers the project from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
+|`spring.cloud.gcp.secretmanager.allow-default-secret`| Define the behavior when accessing a non-existed secret string/bytes. +
+If set to `true`, `null` will be returned when accessing a non-existed secret; otherwise throwing an exception. | No | `false`
 |===
 
 === Secret Manager Property Source
@@ -146,6 +148,18 @@ spring.cloud.gcp.secretmanager.legacy=false
 curl -X POST http://[host]:[port]/actuator/refresh
 ----
 Note that only `@ConfigurationProperties` annotated with `@RefreshScope` support updating secrets without restarting the application.
+
+=== Allow default secret
+
+By default, when accessing a non-existed secret, the Secret Manager will throw an exception.
+
+However, if your want to use a default value in such a scenario, you can add the following property to project's properties.
+[source]
+----
+`spring.cloud.gcp.secretmanager.allow-default-secret=true`
+----
+
+Therefore, a variable annotated with `@Value("${${sm://application-fake}:DEFAULT}")` will be resolved as `DEFAULT` when there is no `application-fake` existed in Secret Manager and `application-fake` is NOT a valid application property.
 
 === Sample
 

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -44,8 +44,8 @@ NOTE: All the below settings must be specified in a https://cloud.spring.io/spri
 | `spring.cloud.gcp.secretmanager.credentials.location` | OAuth2 credentials for authenticating to the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
 | `spring.cloud.gcp.secretmanager.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key for authenticating to the Google Cloud Secret Manager API. | No | By default, infers credentials from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
 | `spring.cloud.gcp.secretmanager.project-id` | The default GCP Project used to access Secret Manager API for the template and property source. | No | By default, infers the project from https://cloud.google.com/docs/authentication/production[Application Default Credentials].
-|`spring.cloud.gcp.secretmanager.allow-default-secret`| Define the behavior when accessing a non-existed secret string/bytes. +
-If set to `true`, `null` will be returned when accessing a non-existed secret; otherwise throwing an exception. | No | `false`
+|`spring.cloud.gcp.secretmanager.allow-default-secret`| Define the behavior when accessing a non-existent secret string/bytes. +
+If set to `true`, `null` will be returned when accessing a non-existent secret; otherwise throwing an exception. | No | `false`
 |===
 
 === Secret Manager Property Source
@@ -151,7 +151,7 @@ Note that only `@ConfigurationProperties` annotated with `@RefreshScope` support
 
 === Allow default secret
 
-By default, when accessing a non-existed secret, the Secret Manager will throw an exception.
+By default, when accessing a non-existent secret, the Secret Manager will throw an exception.
 
 However, if your want to use a default value in such a scenario, you can add the following property to project's properties.
 [source]
@@ -159,7 +159,7 @@ However, if your want to use a default value in such a scenario, you can add the
 `spring.cloud.gcp.secretmanager.allow-default-secret=true`
 ----
 
-Therefore, a variable annotated with `@Value("${${sm://application-fake}:DEFAULT}")` will be resolved as `DEFAULT` when there is no `application-fake` existed in Secret Manager and `application-fake` is NOT a valid application property.
+Therefore, a variable annotated with `@Value("${${sm://application-fake}:DEFAULT}")` will be resolved as `DEFAULT` when there is no `application-fake` in Secret Manager and `application-fake` is NOT a valid application property.
 
 === Sample
 

--- a/docs/src/main/md/secretmanager.md
+++ b/docs/src/main/md/secretmanager.md
@@ -52,13 +52,14 @@ configure settings for bootstrap-phase Spring configuration.
 
 </div>
 
-|                                                          |                                                                                                                  |          |                                                                                                                                 |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Name                                                     | Description                                                                                                      | Required | Default value                                                                                                                   |
-| `spring.cloud.gcp.secretmanager.enabled`                 | Enables the Secret Manager bootstrap property and template configuration.                                        | No       | `true`                                                                                                                          |
-| `spring.cloud.gcp.secretmanager.credentials.location`    | OAuth2 credentials for authenticating to the Google Cloud Secret Manager API.                                    | No       | By default, infers credentials from [Application Default Credentials](https://cloud.google.com/docs/authentication/production). |
-| `spring.cloud.gcp.secretmanager.credentials.encoded-key` | Base64-encoded contents of OAuth2 account private key for authenticating to the Google Cloud Secret Manager API. | No       | By default, infers credentials from [Application Default Credentials](https://cloud.google.com/docs/authentication/production). |
-| `spring.cloud.gcp.secretmanager.project-id`              | The default GCP Project used to access Secret Manager API for the template and property source.                  | No       | By default, infers the project from [Application Default Credentials](https://cloud.google.com/docs/authentication/production). |
+|                                                                                                                 |                                                                                                                                                                                       |          |                                                                                                                                 |
+|-----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Name                                                                                                            | Description                                                                                                                                                                           | Required | Default value                                                                                                                   |
+| `spring.cloud.gcp.secretmanager.enabled`                                                                        | Enables the Secret Manager bootstrap property and template configuration.                                                                                                             | No       | `true`                                                                                                                          |
+| `spring.cloud.gcp.secretmanager.credentials.location`                                                           | OAuth2 credentials for authenticating to the Google Cloud Secret Manager API.                                                                                                         | No       | By default, infers credentials from [Application Default Credentials](https://cloud.google.com/docs/authentication/production). |
+| `spring.cloud.gcp.secretmanager.credentials.encoded-key`                                                        | Base64-encoded contents of OAuth2 account private key for authenticating to the Google Cloud Secret Manager API.                                                                      | No       | By default, infers credentials from [Application Default Credentials](https://cloud.google.com/docs/authentication/production). |
+| `spring.cloud.gcp.secretmanager.project-id`                                                                     | The default GCP Project used to access Secret Manager API for the template and property source.                                                                                       | No       | By default, infers the project from [Application Default Credentials](https://cloud.google.com/docs/authentication/production). |
+| `spring.cloud.gcp.secretmanager.allow-default-secret`                                                           | Define the behavior when accessing a non-existed secret string/bytes. If set to `true`, `null` will be returned when accessing a non-existed secret; otherwise throwing an exception. | No | `false`|
 
 ### Secret Manager Property Source
 
@@ -152,6 +153,16 @@ template.
          curl -X POST http://[host]:[port]/actuator/refresh
 
     Note that only `@ConfigurationProperties` annotated with `@RefreshScope` support updating secrets without restarting the application.
+
+### Allow default secret
+
+By default, when accessing a non-existed secret, the Secret Manager will throw an exception.
+
+However, if your want to use a default value in such a scenario, you can add the following property to project's properties:
+
+        spring.cloud.gcp.secretmanager.allow-default-secret=true
+
+Therefore, a variable annotated with `@Value("${${sm://application-fake}:DEFAULT}")` will be resolved as `DEFAULT` when there is no `application-fake` existed in Secret Manager and `application-fake` is NOT a valid application property.
 
 ### Sample
 

--- a/docs/src/main/md/secretmanager.md
+++ b/docs/src/main/md/secretmanager.md
@@ -59,7 +59,7 @@ configure settings for bootstrap-phase Spring configuration.
 | `spring.cloud.gcp.secretmanager.credentials.location`                                                           | OAuth2 credentials for authenticating to the Google Cloud Secret Manager API.                                                                                                         | No       | By default, infers credentials from [Application Default Credentials](https://cloud.google.com/docs/authentication/production). |
 | `spring.cloud.gcp.secretmanager.credentials.encoded-key`                                                        | Base64-encoded contents of OAuth2 account private key for authenticating to the Google Cloud Secret Manager API.                                                                      | No       | By default, infers credentials from [Application Default Credentials](https://cloud.google.com/docs/authentication/production). |
 | `spring.cloud.gcp.secretmanager.project-id`                                                                     | The default GCP Project used to access Secret Manager API for the template and property source.                                                                                       | No       | By default, infers the project from [Application Default Credentials](https://cloud.google.com/docs/authentication/production). |
-| `spring.cloud.gcp.secretmanager.allow-default-secret`                                                           | Define the behavior when accessing a non-existed secret string/bytes. If set to `true`, `null` will be returned when accessing a non-existed secret; otherwise throwing an exception. | No | `false`|
+| `spring.cloud.gcp.secretmanager.allow-default-secret`                                                           | Define the behavior when accessing a non-existent secret string/bytes. If set to `true`, `null` will be returned when accessing a non-existent secret; otherwise throwing an exception. | No | `false`|
 
 ### Secret Manager Property Source
 
@@ -162,7 +162,7 @@ However, if your want to use a default value in such a scenario, you can add the
 
         spring.cloud.gcp.secretmanager.allow-default-secret=true
 
-Therefore, a variable annotated with `@Value("${${sm://application-fake}:DEFAULT}")` will be resolved as `DEFAULT` when there is no `application-fake` existed in Secret Manager and `application-fake` is NOT a valid application property.
+Therefore, a variable annotated with `@Value("${${sm://application-fake}:DEFAULT}")` will be resolved as `DEFAULT` when there is no `application-fake` in Secret Manager and `application-fake` is NOT a valid application property.
 
 ### Sample
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -86,8 +86,8 @@ public class GcpSecretManagerBootstrapConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public SecretManagerTemplate secretManagerTemplate(SecretManagerServiceClient client) {
-    return new SecretManagerTemplate(client, this.gcpProjectIdProvider,
-        this.properties.isAllowDefaultSecret());
+    return new SecretManagerTemplate(client, this.gcpProjectIdProvider)
+        .setAllowDefaultSecretValue(this.properties.isAllowDefaultSecret());
   }
 
   @Bean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerBootstrapConfiguration.java
@@ -50,10 +50,12 @@ import org.springframework.core.env.ConfigurableEnvironment;
 public class GcpSecretManagerBootstrapConfiguration {
 
   private final GcpProjectIdProvider gcpProjectIdProvider;
+  private final GcpSecretManagerProperties properties;
 
   public GcpSecretManagerBootstrapConfiguration(
       GcpSecretManagerProperties properties, ConfigurableEnvironment configurableEnvironment) {
 
+    this.properties = properties;
     this.gcpProjectIdProvider =
         properties.getProjectId() != null
             ? properties::getProjectId
@@ -84,7 +86,8 @@ public class GcpSecretManagerBootstrapConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public SecretManagerTemplate secretManagerTemplate(SecretManagerServiceClient client) {
-    return new SecretManagerTemplate(client, this.gcpProjectIdProvider);
+    return new SecretManagerTemplate(client, this.gcpProjectIdProvider,
+        this.properties.isAllowDefaultSecret());
   }
 
   @Bean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerProperties.java
@@ -43,6 +43,15 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
    */
   private String projectId;
 
+  /**
+   * Whether the secret manager will allow a default secret value when accessing a non-existed
+   * secret.
+   *
+   * <p>When set it to false, the secret manager will throw an {@link
+   * com.google.api.gax.rpc.NotFoundException}.
+   */
+  private boolean allowDefaultSecret;
+
   public Credentials getCredentials() {
     return credentials;
   }
@@ -53,5 +62,13 @@ public class GcpSecretManagerProperties implements CredentialsSupplier {
 
   public void setProjectId(String projectId) {
     this.projectId = projectId;
+  }
+
+  public boolean isAllowDefaultSecret() {
+    return allowDefaultSecret;
+  }
+
+  public void setAllowDefaultSecret(boolean allowDefaultSecret) {
+    this.allowDefaultSecret = allowDefaultSecret;
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -132,7 +132,9 @@ public class SecretManagerConfigDataLocationResolver implements
         .get(SecretManagerServiceClient.class);
     GcpProjectIdProvider projectIdProvider = context.getBootstrapContext()
         .get(GcpProjectIdProvider.class);
-    return new SecretManagerTemplate(client, projectIdProvider);
+    GcpSecretManagerProperties properties = context.getBootstrapContext()
+        .get(GcpSecretManagerProperties.class);
+    return new SecretManagerTemplate(client, projectIdProvider, properties.isAllowDefaultSecret());
   }
 
   /**

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -134,7 +134,9 @@ public class SecretManagerConfigDataLocationResolver implements
         .get(GcpProjectIdProvider.class);
     GcpSecretManagerProperties properties = context.getBootstrapContext()
         .get(GcpSecretManagerProperties.class);
-    return new SecretManagerTemplate(client, projectIdProvider, properties.isAllowDefaultSecret());
+
+    return new SecretManagerTemplate(client, projectIdProvider)
+        .setAllowDefaultSecretValue(properties.isAllowDefaultSecret());
   }
 
   /**

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerBootstrapConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerBootstrapConfigurationTests.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.rpc.NotFoundException;
 import com.google.auth.Credentials;
 import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
@@ -138,6 +139,16 @@ class SecretManagerBootstrapConfigurationTests {
               AccessSecretVersionResponse.newBuilder()
                   .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("hello")))
                   .build());
+
+      secretVersionName =
+          SecretVersionName.newBuilder()
+              .setProject(PROJECT_NAME)
+              .setSecret("fake-secret")
+              .setSecretVersion("latest")
+              .build();
+
+      when(client.accessSecretVersion(secretVersionName))
+          .thenThrow(NotFoundException.class);
 
       secretVersionName =
           SecretVersionName.newBuilder()

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
@@ -1,7 +1,7 @@
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -73,7 +73,7 @@ class SecretManagerCompatibilityTests {
     try (ConfigurableApplicationContext applicationContext = application.run()) {
       ConfigurableEnvironment environment = applicationContext.getEnvironment();
       assertThat(environment.getProperty("sm://my-secret")).isEqualTo("hello");
-      assertThatCode(() -> environment.getProperty("sm://fake-secret"))
+      assertThatThrownBy(() -> environment.getProperty("sm://fake-secret"))
           .isExactlyInstanceOf(NotFoundException.class);
     }
   }
@@ -109,7 +109,7 @@ class SecretManagerCompatibilityTests {
     try (ConfigurableApplicationContext applicationContext = application.run()) {
       ConfigurableEnvironment environment = applicationContext.getEnvironment();
       assertThat(environment.getProperty("sm://my-secret")).isEqualTo("newSecret");
-      assertThatCode(() -> environment.getProperty("sm://fake-secret"))
+      assertThatThrownBy(() -> environment.getProperty("sm://fake-secret"))
           .isExactlyInstanceOf(NotFoundException.class);
     }
   }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
@@ -1,19 +1,25 @@
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import com.google.cloud.secretmanager.v1.SecretPayload;
 import com.google.cloud.secretmanager.v1.SecretVersionName;
+import com.google.cloud.spring.autoconfigure.secretmanager.SecretManagerBootstrapConfigurationTests.TestBootstrapConfiguration;
+import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
 import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.BootstrapRegistry.InstanceSupplier;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
 
 /**
  * Unit tests to check compatibility of Secret Manager.
@@ -21,26 +27,66 @@ import org.springframework.context.ConfigurableApplicationContext;
 class SecretManagerCompatibilityTests {
 
   private static final String PROJECT_NAME = "hollow-light-of-the-sealed-land";
+  private SpringApplicationBuilder application;
+  private SecretManagerServiceClient client;
+
+  @BeforeEach
+  void init() {
+    application = new SpringApplicationBuilder(GcpSecretManagerBootstrapConfiguration.class)
+        .web(WebApplicationType.NONE)
+        .properties(
+            "spring.cloud.gcp.secretmanager.project-id=" + PROJECT_NAME,
+            "spring.cloud.gcp.sql.enabled=false");
+
+    client = mock(SecretManagerServiceClient.class);
+    SecretVersionName secretVersionName =
+        SecretVersionName.newBuilder()
+            .setProject(PROJECT_NAME)
+            .setSecret("my-secret")
+            .setSecretVersion("latest")
+            .build();
+    when(client.accessSecretVersion(secretVersionName))
+        .thenReturn(
+            AccessSecretVersionResponse.newBuilder()
+                .setPayload(
+                    SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("newSecret")))
+                .build());
+    secretVersionName =
+        SecretVersionName.newBuilder()
+            .setProject(PROJECT_NAME)
+            .setSecret("fake-secret")
+            .setSecretVersion("latest")
+            .build();
+    when(client.accessSecretVersion(secretVersionName))
+        .thenThrow(NotFoundException.class);
+  }
 
   /**
    * Users with the legacy configuration (i.e., bootstrap phrase) should get {@link
-   * com.google.cloud.spring.secretmanager.SecretManagerTemplate} autoconfiguration and properties
-   * resolved. Note that {@link SecretManagerBootstrapConfigurationTests.TestBootstrapConfiguration}
-   * is automatically picked to create a mock {@link SecretManagerServiceClient} object as it is
-   * specified in spring.factories.
+   * SecretManagerTemplate} autoconfiguration and properties resolved. Note that {@link
+   * TestBootstrapConfiguration} is automatically picked to create a mock {@link
+   * SecretManagerServiceClient} object as it is specified in spring.factories.
    */
   @Test
-  void testLegacyConfiguration() {
-    SpringApplicationBuilder legacyApplication = new SpringApplicationBuilder(
-        GcpSecretManagerBootstrapConfiguration.class)
-        .properties(
-            "spring.cloud.gcp.secretmanager.project-id=" + PROJECT_NAME,
-            "spring.cloud.bootstrap.enabled=true",
-            "spring.cloud.gcp.sql.enabled=false")
-        .web(WebApplicationType.NONE);
-    try (ConfigurableApplicationContext applicationContext = legacyApplication.run()) {
-      String secret = applicationContext.getEnvironment().getProperty("sm://my-secret");
-      assertThat(secret).isEqualTo("hello");
+  void testLegacyConfigurationWhenDefaultSecretIsNotAllowed() {
+    application.properties("spring.cloud.bootstrap.enabled=true");
+    try (ConfigurableApplicationContext applicationContext = application.run()) {
+      ConfigurableEnvironment environment = applicationContext.getEnvironment();
+      assertThat(environment.getProperty("sm://my-secret")).isEqualTo("hello");
+      assertThatCode(() -> environment.getProperty("sm://fake-secret"))
+          .isExactlyInstanceOf(NotFoundException.class);
+    }
+  }
+
+  @Test
+  void testLegacyConfigurationWhenDefaultSecretIsAllowed() {
+    application.properties(
+        "spring.cloud.bootstrap.enabled=true",
+        "spring.cloud.gcp.secretmanager.allow-default-secret=true");
+    try (ConfigurableApplicationContext applicationContext = application.run()) {
+      ConfigurableEnvironment environment = applicationContext.getEnvironment();
+      assertThat(environment.getProperty("sm://my-secret")).isEqualTo("hello");
+      assertThat(environment.getProperty("sm://fake-secret")).isNull();
     }
   }
 
@@ -50,39 +96,40 @@ class SecretManagerCompatibilityTests {
    * resolved.
    */
   @Test
-  void testNewConfiguration() {
-    SecretManagerServiceClient client = mock(SecretManagerServiceClient.class);
-    SecretVersionName secretVersionName =
-        SecretVersionName.newBuilder()
-            .setProject(PROJECT_NAME)
-            .setSecret("my-secret")
-            .setSecretVersion("latest")
-            .build();
-
-    when(client.accessSecretVersion(secretVersionName))
-        .thenReturn(
-            AccessSecretVersionResponse.newBuilder()
-                .setPayload(
-                    SecretPayload.newBuilder().setData(ByteString.copyFromUtf8("newSecret")))
-                .build());
-
-    SpringApplicationBuilder newApplication = new SpringApplicationBuilder(
-        GcpSecretManagerBootstrapConfiguration.class)
-        .properties(
-            "spring.cloud.gcp.secretmanager.project-id=" + PROJECT_NAME,
+  void testNewConfigurationWhenDefaultSecretIsNotAllowed() {
+    application.properties(
             "spring.cloud.gcp.secretmanager.legacy=false",
-            "spring.config.import=sm://",
-            "spring.cloud.gcp.sql.enabled=false")
+            "spring.config.import=sm://")
         .addBootstrapRegistryInitializer(
             (registry) -> registry.registerIfAbsent(
                 SecretManagerServiceClient.class,
                 InstanceSupplier.of(client)
             )
-        )
-        .web(WebApplicationType.NONE);
-    try (ConfigurableApplicationContext applicationContext = newApplication.run()) {
-      String secret = applicationContext.getEnvironment().getProperty("sm://my-secret");
-      assertThat(secret).isEqualTo("newSecret");
+        );
+    try (ConfigurableApplicationContext applicationContext = application.run()) {
+      ConfigurableEnvironment environment = applicationContext.getEnvironment();
+      assertThat(environment.getProperty("sm://my-secret")).isEqualTo("newSecret");
+      assertThatCode(() -> environment.getProperty("sm://fake-secret"))
+          .isExactlyInstanceOf(NotFoundException.class);
+    }
+  }
+
+  @Test
+  void testNewConfigurationWhenDefaultSecretIsAllowed() {
+    application.properties(
+            "spring.cloud.gcp.secretmanager.legacy=false",
+            "spring.cloud.gcp.secretmanager.allow-default-secret=true",
+            "spring.config.import=sm://")
+        .addBootstrapRegistryInitializer(
+            (registry) -> registry.registerIfAbsent(
+                SecretManagerServiceClient.class,
+                InstanceSupplier.of(client)
+            )
+        );
+    try (ConfigurableApplicationContext applicationContext = application.run()) {
+      ConfigurableEnvironment environment = applicationContext.getEnvironment();
+      assertThat(environment.getProperty("sm://my-secret")).isEqualTo("newSecret");
+      assertThat(environment.getProperty("sm://fake-secret")).isNull();
     }
   }
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -31,6 +31,9 @@ import org.springframework.web.util.HtmlUtils;
 @Controller
 public class SecretManagerWebController {
 
+  private static final String INDEX_PAGE = "index.html";
+  private static final String APPLICATION_SECRET_FROM_VALUE = "applicationSecretFromValue";
+
   private final SecretManagerTemplate secretManagerTemplate;
   // Application secrets can be accessed using configuration properties class,
   // secret can be refreshed when decorated with @RefreshScope on the class.
@@ -54,9 +57,9 @@ public class SecretManagerWebController {
   @GetMapping("/")
   public ModelAndView renderIndex(ModelMap map) {
     map.put("applicationDefaultSecret", defaultSecret);
-    map.put("applicationSecretFromValue", appSecretFromValue);
+    map.put(APPLICATION_SECRET_FROM_VALUE, appSecretFromValue);
     map.put("applicationSecretFromConfigurationProperties", configuration.getSecret());
-    return new ModelAndView("index.html", map);
+    return new ModelAndView(INDEX_PAGE, map);
   }
 
   @GetMapping("/getSecret")
@@ -101,9 +104,9 @@ public class SecretManagerWebController {
       this.secretManagerTemplate.createSecret(secretId, secretPayload.getBytes(), projectId);
     }
 
-    map.put("applicationSecretFromValue", this.appSecretFromValue);
+    map.put(APPLICATION_SECRET_FROM_VALUE, this.appSecretFromValue);
     map.put("message", "Secret created!");
-    return new ModelAndView("index.html", map);
+    return new ModelAndView(INDEX_PAGE, map);
   }
 
   @PostMapping("/deleteSecret")
@@ -116,8 +119,8 @@ public class SecretManagerWebController {
     } else {
       this.secretManagerTemplate.deleteSecret(secretId, projectId);
     }
-    map.put("applicationSecretFromValue", this.appSecretFromValue);
+    map.put(APPLICATION_SECRET_FROM_VALUE, this.appSecretFromValue);
     map.put("message", "Secret deleted!");
-    return new ModelAndView("index.html", map);
+    return new ModelAndView(INDEX_PAGE, map);
   }
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -36,6 +36,10 @@ public class SecretManagerWebController {
   // secret can be refreshed when decorated with @RefreshScope on the class.
   private final SecretConfiguration configuration;
 
+  // For the default value takes place, there should be no property called `application-fake`
+  // in property files.
+  @Value("${${sm://application-fake}:DEFAULT}")
+  private String defaultSecret;
   // Application secrets can be accessed using @Value syntax.
   @Value("${sm://application-secret}")
   private String appSecretFromValue;
@@ -49,6 +53,7 @@ public class SecretManagerWebController {
 
   @GetMapping("/")
   public ModelAndView renderIndex(ModelMap map) {
+    map.put("applicationDefaultSecret", defaultSecret);
     map.put("applicationSecretFromValue", appSecretFromValue);
     map.put("applicationSecretFromConfigurationProperties", configuration.getSecret());
     return new ModelAndView("index.html", map);

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -13,3 +13,5 @@ management.endpoints.web.exposure.include=refresh
 # enable external resource from GCP Secret Manager.
 spring.config.import=sm://
 application.secret=${sm://application-secret}
+# enable default secret value when accessing non-exited secret.
+spring.cloud.gcp.secretmanager.allow-default-secret=true

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/templates/index.html
@@ -44,6 +44,7 @@
   At the bootstrap phase, we loaded the following secret into the application context:
   <br/>
   <br/>
+  <b>Default Application secret if not found:</b> <i>[[${applicationDefaultSecret}]]</i><br/>
   <b>Application secret from @Value:</b> <i>[[${applicationSecretFromValue}]]</i><br/>
   <b>Application secret from @ConfigurationProperties:</b> <i>[[${applicationSecretFromConfigurationProperties}]]</i>
 </div>

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerOperations.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerOperations.java
@@ -143,7 +143,7 @@ public interface SecretManagerOperations {
    * <p>If the secret ID string is passed in, then this will return the payload of the secret for
    * the default project at the latest version.
    *
-   * @param secretIdentifier the GCP secret ID of the secret or an sm:// formatted string specifying
+   * @param secretIdentifier the GCP secret ID of the secret or a sm:// formatted string specifying
    *     the secret.
    * @return The secret payload as String
    */
@@ -159,7 +159,7 @@ public interface SecretManagerOperations {
    * <p>If the secret ID string is passed in, then this will return the payload of the secret for
    * the default project at the latest version.
    *
-   * @param secretIdentifier the GCP secret ID of the secret or an sm:// formatted string specifying
+   * @param secretIdentifier the GCP secret ID of the secret or a sm:// formatted string specifying
    *     the secret.
    * @return The secret payload as byte array
    */

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerTemplate.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerTemplate.java
@@ -56,11 +56,16 @@ public class SecretManagerTemplate implements SecretManagerOperations {
 
   public SecretManagerTemplate(
       SecretManagerServiceClient secretManagerServiceClient,
-      GcpProjectIdProvider projectIdProvider,
-      boolean allowDefaultSecretValue) {
+      GcpProjectIdProvider projectIdProvider) {
     this.secretManagerServiceClient = secretManagerServiceClient;
     this.projectIdProvider = projectIdProvider;
+    this.allowDefaultSecretValue = false;
+  }
+
+  public SecretManagerTemplate setAllowDefaultSecretValue(boolean allowDefaultSecretValue) {
     this.allowDefaultSecretValue = allowDefaultSecretValue;
+
+    return this;
   }
 
   @Override

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerTemplate.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerTemplate.java
@@ -17,7 +17,6 @@
 package com.google.cloud.spring.secretmanager;
 
 import com.google.api.gax.rpc.NotFoundException;
-import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
 import com.google.cloud.secretmanager.v1.AddSecretVersionRequest;
 import com.google.cloud.secretmanager.v1.CreateSecretRequest;
 import com.google.cloud.secretmanager.v1.DeleteSecretRequest;
@@ -30,6 +29,9 @@ import com.google.cloud.secretmanager.v1.SecretPayload;
 import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.protobuf.ByteString;
+import javax.annotation.Nullable;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Offers convenience methods for performing common operations on Secret Manager including creating
@@ -44,14 +46,21 @@ public class SecretManagerTemplate implements SecretManagerOperations {
    */
   public static final String LATEST_VERSION = "latest";
 
+  private static final Log LOGGER = LogFactory.getLog(SecretManagerTemplate.class);
   private final SecretManagerServiceClient secretManagerServiceClient;
   private final GcpProjectIdProvider projectIdProvider;
+  /**
+   * Define the behavior when accessing a non-existed secret string/bytes.
+   */
+  private boolean allowDefaultSecretValue;
 
   public SecretManagerTemplate(
       SecretManagerServiceClient secretManagerServiceClient,
-      GcpProjectIdProvider projectIdProvider) {
+      GcpProjectIdProvider projectIdProvider,
+      boolean allowDefaultSecretValue) {
     this.secretManagerServiceClient = secretManagerServiceClient;
     this.projectIdProvider = projectIdProvider;
+    this.allowDefaultSecretValue = allowDefaultSecretValue;
   }
 
   @Override
@@ -72,13 +81,17 @@ public class SecretManagerTemplate implements SecretManagerOperations {
   }
 
   @Override
+  @Nullable
   public String getSecretString(String secretIdentifier) {
-    return getSecretByteString(secretIdentifier).toStringUtf8();
+    ByteString secretByteString = getSecretByteString(secretIdentifier);
+    return secretByteString == null ? null : secretByteString.toStringUtf8();
   }
 
   @Override
+  @Nullable
   public byte[] getSecretBytes(String secretIdentifier) {
-    return getSecretByteString(secretIdentifier).toByteArray();
+    ByteString secretByteString = getSecretByteString(secretIdentifier);
+    return secretByteString == null ? null : secretByteString.toByteArray();
   }
 
   @Override
@@ -165,9 +178,25 @@ public class SecretManagerTemplate implements SecretManagerOperations {
   }
 
   ByteString getSecretByteString(SecretVersionName secretVersionName) {
-    AccessSecretVersionResponse response =
-        secretManagerServiceClient.accessSecretVersion(secretVersionName);
-    return response.getPayload().getData();
+    ByteString secretData;
+    try {
+      secretData = secretManagerServiceClient
+          .accessSecretVersion(secretVersionName)
+          .getPayload()
+          .getData();
+    } catch (NotFoundException ex) {
+      LOGGER.warn(secretVersionName.toString() + " doesn't exist in Secret Manager.");
+      if (!this.allowDefaultSecretValue) {
+        throw ex;
+      }
+      // If no secret is found in Secret Manager and default secret is allowed,
+      // returns null rather than throwing the exception to facilitate default
+      // secret value parsing.
+      // See https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/213
+      return null;
+    }
+
+    return secretData;
   }
 
   /**

--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerTestConfiguration.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerTestConfiguration.java
@@ -92,7 +92,7 @@ public class SecretManagerTestConfiguration {
 
   @Bean
   public SecretManagerTemplate secretManagerTemplate(SecretManagerServiceClient client) {
-    return new SecretManagerTemplate(client, this.projectIdProvider);
+    return new SecretManagerTemplate(client, this.projectIdProvider, false);
   }
 
   @Bean

--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerTestConfiguration.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerTestConfiguration.java
@@ -92,7 +92,7 @@ public class SecretManagerTestConfiguration {
 
   @Bean
   public SecretManagerTemplate secretManagerTemplate(SecretManagerServiceClient client) {
-    return new SecretManagerTemplate(client, this.projectIdProvider, false);
+    return new SecretManagerTemplate(client, this.projectIdProvider);
   }
 
   @Bean


### PR DESCRIPTION
Fix https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/213

As adding a new behavior to the Secret Manager, introducing a new opt-in property: `spring.cloud.gcp.secretmanager.allow-default-secret`. When it set to `true`, the SecretManager will return `null` when accessing a non-exited secret, rather than throwing an exception. 

Customers can define a default value for non-existed secret using `@Value("${${sm://application-fake}:DEFAULT}")`, the framework will resolve the value as `DEFAULT` if `sm://application-fake` is NOT existed in Secret Manager and `application-fake` is NOT a property.