### PR TITLE
Support publisher shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ refer to the [commit
 history](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commits/main)
 on GitHub.
 
-## 3.4.0.BUILD-SNAPSHOT
+## 3.4.0-SNAPSHOT
+
+### Pub/Sub
+
+  - Allow Publishers shutdown gracefully
+    (<https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1260>)
 
 ## 3.3.0
 

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/CachingPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/CachingPublisherFactory.java
@@ -18,6 +18,9 @@ package com.google.cloud.spring.pubsub.support;
 
 import com.google.cloud.pubsub.v1.Publisher;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The caching implementation of the {@link PublisherFactory}.
@@ -29,7 +32,8 @@ public class CachingPublisherFactory implements PublisherFactory {
   private final ConcurrentHashMap<String, Publisher> publishers =
       new ConcurrentHashMap<>();
 
-  private PublisherFactory delegate;
+  private static final Logger LOGGER = LoggerFactory.getLogger(CachingPublisherFactory.class);
+  private final PublisherFactory delegate;
 
   /**
    * Constructs a caching {@link PublisherFactory} using the delegate.
@@ -52,5 +56,14 @@ public class CachingPublisherFactory implements PublisherFactory {
    */
   public PublisherFactory getDelegate() {
     return delegate;
+  }
+
+  /**
+   * Shutdown all cached {@link Publisher} gracefully.
+   */
+  @PreDestroy
+  public void shutdown() {
+    LOGGER.info("Shutting down Publishers...");
+    publishers.forEachValue(1L, Publisher::shutdown);
   }
 }

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/CachingPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/CachingPublisherFactory.java
@@ -19,8 +19,6 @@ package com.google.cloud.spring.pubsub.support;
 import com.google.cloud.pubsub.v1.Publisher;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.PreDestroy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The caching implementation of the {@link PublisherFactory}.
@@ -32,13 +30,12 @@ public class CachingPublisherFactory implements PublisherFactory {
   private final ConcurrentHashMap<String, Publisher> publishers =
       new ConcurrentHashMap<>();
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(CachingPublisherFactory.class);
   private final PublisherFactory delegate;
 
   /**
    * Constructs a caching {@link PublisherFactory} using the delegate.
    *
-   * @param delegate a {@link PublisherFactory} that needs to be cachecd.
+   * @param delegate a {@link PublisherFactory} that needs to be cached.
    */
   public CachingPublisherFactory(PublisherFactory delegate) {
     this.delegate = delegate;
@@ -63,7 +60,6 @@ public class CachingPublisherFactory implements PublisherFactory {
    */
   @PreDestroy
   public void shutdown() {
-    LOGGER.info("Shutting down Publishers...");
     publishers.forEachValue(1L, Publisher::shutdown);
   }
 }

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/CachingPublisherFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/CachingPublisherFactoryTests.java
@@ -49,8 +49,13 @@ class CachingPublisherFactoryTests {
 
     assertThat(cachingPublisherFactory.createPublisher("topic2")).isEqualTo(publisher2);
     assertThat(cachingPublisherFactory.createPublisher("topic2")).isEqualTo(publisher2);
+    assertThat(cachingPublisherFactory.getDelegate()).isEqualTo(delegate);
 
     verify(delegate, times(1)).createPublisher("topic1");
     verify(delegate, times(1)).createPublisher("topic2");
+
+    cachingPublisherFactory.shutdown();
+    verify(publisher1, times(1)).shutdown();
+    verify(publisher2, times(1)).shutdown();
   }
 }


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/864.

Add `@PreDestroy` method to shutdown cached `Publisher` in `CachingPublisherFactory`.