### PR TITLE
fix(kms): to honor kms credentials when present.

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/kms/GcpKmsAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/kms/GcpKmsAutoConfiguration.java
@@ -20,7 +20,6 @@ import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.kms.v1.KeyManagementServiceClient;
 import com.google.cloud.kms.v1.KeyManagementServiceSettings;
 import com.google.cloud.spring.core.DefaultCredentialsProvider;
-import com.google.cloud.spring.core.DefaultGcpProjectIdProvider;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.core.UserAgentHeaderProvider;
 import com.google.cloud.spring.kms.KmsTemplate;
@@ -42,18 +41,24 @@ public class GcpKmsAutoConfiguration {
   private final GcpProjectIdProvider gcpProjectIdProvider;
   private final CredentialsProvider credentialsProvider;
 
-  public GcpKmsAutoConfiguration(GcpKmsProperties properties,
+  public GcpKmsAutoConfiguration(
+      GcpProjectIdProvider coreProjectIdProvider,
+      GcpKmsProperties properties,
       CredentialsProvider credentialsProvider)
       throws IOException {
     this.gcpProjectIdProvider =
         properties.getProjectId() != null
             ? properties::getProjectId
-            : new DefaultGcpProjectIdProvider();
+            : coreProjectIdProvider;
 
     this.credentialsProvider =
         properties.getCredentials().hasKey()
             ? new DefaultCredentialsProvider(properties)
             : credentialsProvider;
+  }
+
+  GcpProjectIdProvider getGcpProjectIdProvider() {
+    return gcpProjectIdProvider;
   }
 
   @Bean

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/kms/KmsAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/kms/KmsAutoConfigurationTests.java
@@ -66,12 +66,6 @@ class KmsAutoConfigurationTests {
   static class TestBootstrapConfiguration {
 
     @Bean
-    public static KeyManagementServiceClient keyManagementClient() {
-      KeyManagementServiceClient client = mock(KeyManagementServiceClient.class);
-      return client;
-    }
-
-    @Bean
     public static CredentialsProvider googleCredentials() {
       return () -> mock(Credentials.class);
     }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/kms/KmsAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/kms/KmsAutoConfigurationTests.java
@@ -36,9 +36,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * Unit tests for {@link GcpKmsAutoConfiguration}.
- */
+/** Unit tests for {@link GcpKmsAutoConfiguration}. */
 class KmsAutoConfigurationTests {
 
   private static final String CORE_PROJECT_NAME = "core-project";
@@ -47,10 +45,13 @@ class KmsAutoConfigurationTests {
   private static final String CORE_CREDENTIAL_CLIENT_ID = "12345";
   private static final String KMS_CREDENTIAL_CLIENT_ID = "45678";
 
-  private SpringApplicationBuilder applicationBuilder = new SpringApplicationBuilder(
-      TestConfiguration.class, GcpKmsAutoConfiguration.class).properties(
-      "spring.cloud.gcp.kms.project-id=" + KMS_PROJECT_NAME, "spring.cloud.bootstrap.enabled=true",
-      "spring.cloud.gcp.sql.enabled=false").web(WebApplicationType.NONE);
+  private SpringApplicationBuilder applicationBuilder =
+      new SpringApplicationBuilder(TestConfiguration.class, GcpKmsAutoConfiguration.class)
+          .properties(
+              "spring.cloud.gcp.kms.project-id=" + KMS_PROJECT_NAME,
+              "spring.cloud.bootstrap.enabled=true",
+              "spring.cloud.gcp.sql.enabled=false")
+          .web(WebApplicationType.NONE);
 
   private ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(
           AutoConfigurations.of(GcpKmsAutoConfiguration.class))

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/kms/KmsAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/kms/KmsAutoConfigurationTests.java
@@ -18,33 +18,43 @@ package com.google.cloud.spring.autoconfigure.kms;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.auth.oauth2.UserCredentials;
 import com.google.cloud.kms.v1.KeyManagementServiceClient;
+import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.kms.KmsTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Unit tests for {@link GcpKmsAutoConfiguration}. */
+/**
+ * Unit tests for {@link GcpKmsAutoConfiguration}.
+ */
 class KmsAutoConfigurationTests {
 
-  private static final String PROJECT_NAME = "hollow-light-of-the-sealed-land";
-  private static final String LOCATION_NAME = "global";
-  private static final String KEY_RING_NAME = "key-ring-id";
-  private static final String KEY_ID_NAME = "key-id";
+  private static final String CORE_PROJECT_NAME = "core-project";
+  private static final String KMS_PROJECT_NAME = "hollow-light-of-the-sealed-land";
+  private static final String KMS_CREDENTIAL_LOCATION = "src/test/resources/fake-credential-key.json";
+  private static final String CORE_CREDENTIAL_CLIENT_ID = "12345";
+  private static final String KMS_CREDENTIAL_CLIENT_ID = "45678";
 
-  private SpringApplicationBuilder applicationBuilder =
-      new SpringApplicationBuilder(TestBootstrapConfiguration.class, GcpKmsAutoConfiguration.class)
-          .properties(
-              "spring.cloud.gcp.kms.project-id=" + PROJECT_NAME,
-              "spring.cloud.bootstrap.enabled=true",
-              "spring.cloud.gcp.sql.enabled=false")
-          .web(WebApplicationType.NONE);
+  private SpringApplicationBuilder applicationBuilder = new SpringApplicationBuilder(
+      TestConfiguration.class, GcpKmsAutoConfiguration.class).properties(
+      "spring.cloud.gcp.kms.project-id=" + KMS_PROJECT_NAME, "spring.cloud.bootstrap.enabled=true",
+      "spring.cloud.gcp.sql.enabled=false").web(WebApplicationType.NONE);
+
+  private ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(
+          AutoConfigurations.of(GcpKmsAutoConfiguration.class))
+      .withUserConfiguration(TestConfiguration.class);
 
   @Test
   void testKeyManagementClientCreated() {
@@ -62,12 +72,59 @@ class KmsAutoConfigurationTests {
     }
   }
 
+  @Test
+  void testShouldTakeCoreCredentials() {
+    this.contextRunner.run(ctx -> {
+      KeyManagementServiceClient client = ctx.getBean(KeyManagementServiceClient.class);
+      Credentials credentials = client.getSettings().getCredentialsProvider().getCredentials();
+      assertThat(((UserCredentials) credentials).getClientId()).isEqualTo(
+          CORE_CREDENTIAL_CLIENT_ID);
+    });
+  }
+
+  @Test
+  void testShouldTakeKmsCredentials() {
+    this.contextRunner.withPropertyValues(
+        "spring.cloud.gcp.kms.credentials.location=file:" + KMS_CREDENTIAL_LOCATION).run(ctx -> {
+      KeyManagementServiceClient client = ctx.getBean(KeyManagementServiceClient.class);
+      Credentials credentials = client.getSettings().getCredentialsProvider().getCredentials();
+      assertThat(((ServiceAccountCredentials) credentials).getClientId()).isEqualTo(
+          KMS_CREDENTIAL_CLIENT_ID);
+    });
+  }
+
+  @Test
+  void testShouldTakeKmsProjectIdWhenPresent() {
+    this.contextRunner.withPropertyValues("spring.cloud.gcp.kms.project-id=" + KMS_PROJECT_NAME)
+        .run(ctx -> {
+          GcpKmsAutoConfiguration autoConfiguration = ctx.getBean(GcpKmsAutoConfiguration.class);
+          assertThat(autoConfiguration.getGcpProjectIdProvider().getProjectId()).isEqualTo(
+              KMS_PROJECT_NAME);
+        });
+  }
+
+  @Test
+  void testShouldTakeCoreProjectId() {
+    this.contextRunner.run(ctx -> {
+      GcpKmsAutoConfiguration autoConfiguration = ctx.getBean(GcpKmsAutoConfiguration.class);
+      assertThat(autoConfiguration.getGcpProjectIdProvider().getProjectId()).isEqualTo(
+          CORE_PROJECT_NAME);
+    });
+  }
+
   @Configuration
-  static class TestBootstrapConfiguration {
+  static class TestConfiguration {
 
     @Bean
     public static CredentialsProvider googleCredentials() {
-      return () -> mock(Credentials.class);
+      UserCredentials mockUserCredential = mock(UserCredentials.class);
+      when(mockUserCredential.getClientId()).thenReturn(CORE_CREDENTIAL_CLIENT_ID);
+      return () -> mockUserCredential;
+    }
+
+    @Bean
+    public static GcpProjectIdProvider gcpProjectIdProvider() {
+      return () -> CORE_PROJECT_NAME;
     }
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/kms/KmsAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/kms/KmsAutoConfigurationTests.java
@@ -74,28 +74,32 @@ class KmsAutoConfigurationTests {
 
   @Test
   void testShouldTakeCoreCredentials() {
-    this.contextRunner.run(ctx -> {
-      KeyManagementServiceClient client = ctx.getBean(KeyManagementServiceClient.class);
-      Credentials credentials = client.getSettings().getCredentialsProvider().getCredentials();
-      assertThat(((UserCredentials) credentials).getClientId()).isEqualTo(
-          CORE_CREDENTIAL_CLIENT_ID);
-    });
+    this.contextRunner
+        .run(ctx -> {
+          KeyManagementServiceClient client = ctx.getBean(KeyManagementServiceClient.class);
+          Credentials credentials = client.getSettings().getCredentialsProvider().getCredentials();
+          assertThat(((UserCredentials) credentials).getClientId()).isEqualTo(
+              CORE_CREDENTIAL_CLIENT_ID);
+        });
   }
 
   @Test
   void testShouldTakeKmsCredentials() {
-    this.contextRunner.withPropertyValues(
-        "spring.cloud.gcp.kms.credentials.location=file:" + KMS_CREDENTIAL_LOCATION).run(ctx -> {
-      KeyManagementServiceClient client = ctx.getBean(KeyManagementServiceClient.class);
-      Credentials credentials = client.getSettings().getCredentialsProvider().getCredentials();
-      assertThat(((ServiceAccountCredentials) credentials).getClientId()).isEqualTo(
-          KMS_CREDENTIAL_CLIENT_ID);
-    });
+    this.contextRunner
+        .withPropertyValues(
+            "spring.cloud.gcp.kms.credentials.location=file:" + KMS_CREDENTIAL_LOCATION)
+        .run(ctx -> {
+          KeyManagementServiceClient client = ctx.getBean(KeyManagementServiceClient.class);
+          Credentials credentials = client.getSettings().getCredentialsProvider().getCredentials();
+          assertThat(((ServiceAccountCredentials) credentials).getClientId()).isEqualTo(
+              KMS_CREDENTIAL_CLIENT_ID);
+        });
   }
 
   @Test
   void testShouldTakeKmsProjectIdWhenPresent() {
-    this.contextRunner.withPropertyValues("spring.cloud.gcp.kms.project-id=" + KMS_PROJECT_NAME)
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.kms.project-id=" + KMS_PROJECT_NAME)
         .run(ctx -> {
           GcpKmsAutoConfiguration autoConfiguration = ctx.getBean(GcpKmsAutoConfiguration.class);
           assertThat(autoConfiguration.getGcpProjectIdProvider().getProjectId()).isEqualTo(
@@ -105,11 +109,12 @@ class KmsAutoConfigurationTests {
 
   @Test
   void testShouldTakeCoreProjectId() {
-    this.contextRunner.run(ctx -> {
-      GcpKmsAutoConfiguration autoConfiguration = ctx.getBean(GcpKmsAutoConfiguration.class);
-      assertThat(autoConfiguration.getGcpProjectIdProvider().getProjectId()).isEqualTo(
-          CORE_PROJECT_NAME);
-    });
+    this.contextRunner
+        .run(ctx -> {
+          GcpKmsAutoConfiguration autoConfiguration = ctx.getBean(GcpKmsAutoConfiguration.class);
+          assertThat(autoConfiguration.getGcpProjectIdProvider().getProjectId()).isEqualTo(
+              CORE_PROJECT_NAME);
+        });
   }
 
   @Configuration

--- a/spring-cloud-gcp-autoconfigure/src/test/resources/fake-credential-key.json
+++ b/spring-cloud-gcp-autoconfigure/src/test/resources/fake-credential-key.json
@@ -5,8 +5,8 @@
   "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEugIBADANBgkqhkiG9w0BAQEFAASCBKQwggSgAgEAAoIBAQCh/y7v8lk1Ko79\nWVbQZCtmd0PXZr8WrUmmdEv2aaQQF/ed/KL2M/T2dbTlQ4EeOP+aK/5T8JSuxxZ5\na6e8TsovKXJz2qjeBLpzNFbx2xSyldYziC6v+bRCPKWCQLRNVdz/iYmOqjOu1/Ri\n8njOF7gG3XMQxryl9pmpJbVXj38Zw1n8mefT/g/+l6fObsVIgLs9WjGE9HDMKzx8\n9Ph7f+Ru1EuBrFOgHfKvWeIjVtQWqr3Dz+M1KyLFezYtXGB5HLg02sPJM+tMdcMj\nL9xpuodc6noBBeKvijEfTErLIaO1cJS5AgFHDyEsspaRdgXpJroM4w8ZSj3J0Wp7\ntJ7PeaG/AgMBAAECgf9ubAMSi59DHj9Zcgw7AAyVS7ZynRaj3nrVe3BMBrZOQggH\nKK3sJH5VgOZNYDYi47dW36X8kYDHoe0v1rH/KbWncBkT33g73f05ifO56Buzn27i\nsXEhgpPckno+ztwX2u9JP/cDyAByrcFnsN+nm4NVKp3EUbNFbVJQeeOiS63XYLvO\nuIUGlYJrnqa2zWp/YwhOmvZz5fNhfN/Js+V8kaA/xK/Dk0xhgvAqv73lgYZyL5pg\nlImHgHIm5alAMpchu4bInv2CjhKsgyPvHZU0Wihdm5it58hME0gN3ekD6lbdsp+1\nEwZ50JXALUPvzeMGXWorxuBUe9hpMcDmugR6rjECgYEAzpELFjiX2sNZPDX7cTM0\nYwWCdcvJUVTEapnpWuU2OhDreGMlBAWO6hkTIq6kmBZ0c30o10FNhXBrg0AyesgG\nheY6wO+v4e5hnVIdud2ih7AWDaKXVrb63Z/aF3EUhxcVk0wmnJtQ605cjMjeJOJF\nEyQCGsaiLbsEBsEKrXfLL08CgYEAyMOlz8dCNrEm16rbTE7NZpqql7IJhcAcXB5Z\nGUZicK98W4HnT6r5qPePgCjHnxjXl+/T6siH1B8CxQwtzETI8bu0Jd3ZvL7HZnIS\nHDWiGn72OJnYOvxvq1SvIqdTvlCMKqRQancp8wWP9oubzjS5ZZLGemaqvVL2Occp\nsfUZSpECgYBXPdz/2pEQHNcwXeA/VA/5DlemJpZ1GicGmtB6yjnX1lOM+dqlUy+j\n4Uk6qaXscfdm22KHXxY9mFhgC5oGTzqqDK2d1N1kv4hMqGTTni7Jve3iflwKjKdx\nONUkd2bjEzXSiyP3moVXjDX8Y82mqEXiKqAU7PWL+ONfcuJulxyicwKBgAcPoohR\nSMnlpykUsEvZxa2jKPbW4zDaFeVDh/y0lgfClEwfoIQTzl4b/ucSCBtXY1XLsJdk\nYCqcwJsvl3jEvpCJ+ocOa3cQ+rBmuK5XUJE//+bzukAw2ria7OH6Ip7h9FwXlWB5\nOnd6rZqNRHiXMCIbbHGnpL+t6E0V7Sh+J1qRAoGALRlR4TpW+UQvJIs5iBuF4/vg\n9iWLVOY8QoDYQ1k755EY53Q8tk3fO2ESUyV7A35zu/TQWm7z5PTFCl9R5dpWywMU\nTG7xr3tNVP7oDUN9ofN2ipB99EavN81k3co+nnWwhniJn0zHEpTq9IvGozwGuUjN\nIkiy17wHSSocTzvLDNk=\n-----END PRIVATE KEY-----\n",
   "client_email": "test@fake-project.iam.gserviceaccount.com",
   "client_id": "45678",
-  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-  "token_uri": "https://oauth2.googleapis.com/token",
-  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/one-time-test-account%40mzhu-test3.iam.gserviceaccount.com"
+  "auth_uri": "https://fake.auth.url.com/o/oauth2/auth",
+  "token_uri": "https://fake.token.url.com/token",
+  "auth_provider_x509_cert_url": "https://fake.auth.provider.cert.url.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.fake.client.cert.com/robot/v1/metadata/x509/test@fake-project.iam.gserviceaccount.com"
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/resources/fake-credential-key.json
+++ b/spring-cloud-gcp-autoconfigure/src/test/resources/fake-credential-key.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "fake-project-id",
+  "private_key_id": "fake-key",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEugIBADANBgkqhkiG9w0BAQEFAASCBKQwggSgAgEAAoIBAQCh/y7v8lk1Ko79\nWVbQZCtmd0PXZr8WrUmmdEv2aaQQF/ed/KL2M/T2dbTlQ4EeOP+aK/5T8JSuxxZ5\na6e8TsovKXJz2qjeBLpzNFbx2xSyldYziC6v+bRCPKWCQLRNVdz/iYmOqjOu1/Ri\n8njOF7gG3XMQxryl9pmpJbVXj38Zw1n8mefT/g/+l6fObsVIgLs9WjGE9HDMKzx8\n9Ph7f+Ru1EuBrFOgHfKvWeIjVtQWqr3Dz+M1KyLFezYtXGB5HLg02sPJM+tMdcMj\nL9xpuodc6noBBeKvijEfTErLIaO1cJS5AgFHDyEsspaRdgXpJroM4w8ZSj3J0Wp7\ntJ7PeaG/AgMBAAECgf9ubAMSi59DHj9Zcgw7AAyVS7ZynRaj3nrVe3BMBrZOQggH\nKK3sJH5VgOZNYDYi47dW36X8kYDHoe0v1rH/KbWncBkT33g73f05ifO56Buzn27i\nsXEhgpPckno+ztwX2u9JP/cDyAByrcFnsN+nm4NVKp3EUbNFbVJQeeOiS63XYLvO\nuIUGlYJrnqa2zWp/YwhOmvZz5fNhfN/Js+V8kaA/xK/Dk0xhgvAqv73lgYZyL5pg\nlImHgHIm5alAMpchu4bInv2CjhKsgyPvHZU0Wihdm5it58hME0gN3ekD6lbdsp+1\nEwZ50JXALUPvzeMGXWorxuBUe9hpMcDmugR6rjECgYEAzpELFjiX2sNZPDX7cTM0\nYwWCdcvJUVTEapnpWuU2OhDreGMlBAWO6hkTIq6kmBZ0c30o10FNhXBrg0AyesgG\nheY6wO+v4e5hnVIdud2ih7AWDaKXVrb63Z/aF3EUhxcVk0wmnJtQ605cjMjeJOJF\nEyQCGsaiLbsEBsEKrXfLL08CgYEAyMOlz8dCNrEm16rbTE7NZpqql7IJhcAcXB5Z\nGUZicK98W4HnT6r5qPePgCjHnxjXl+/T6siH1B8CxQwtzETI8bu0Jd3ZvL7HZnIS\nHDWiGn72OJnYOvxvq1SvIqdTvlCMKqRQancp8wWP9oubzjS5ZZLGemaqvVL2Occp\nsfUZSpECgYBXPdz/2pEQHNcwXeA/VA/5DlemJpZ1GicGmtB6yjnX1lOM+dqlUy+j\n4Uk6qaXscfdm22KHXxY9mFhgC5oGTzqqDK2d1N1kv4hMqGTTni7Jve3iflwKjKdx\nONUkd2bjEzXSiyP3moVXjDX8Y82mqEXiKqAU7PWL+ONfcuJulxyicwKBgAcPoohR\nSMnlpykUsEvZxa2jKPbW4zDaFeVDh/y0lgfClEwfoIQTzl4b/ucSCBtXY1XLsJdk\nYCqcwJsvl3jEvpCJ+ocOa3cQ+rBmuK5XUJE//+bzukAw2ria7OH6Ip7h9FwXlWB5\nOnd6rZqNRHiXMCIbbHGnpL+t6E0V7Sh+J1qRAoGALRlR4TpW+UQvJIs5iBuF4/vg\n9iWLVOY8QoDYQ1k755EY53Q8tk3fO2ESUyV7A35zu/TQWm7z5PTFCl9R5dpWywMU\nTG7xr3tNVP7oDUN9ofN2ipB99EavN81k3co+nnWwhniJn0zHEpTq9IvGozwGuUjN\nIkiy17wHSSocTzvLDNk=\n-----END PRIVATE KEY-----\n",
+  "client_email": "test@fake-project.iam.gserviceaccount.com",
+  "client_id": "45678",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/one-time-test-account%40mzhu-test3.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
fixes #1271.

I find it hard to increase test coverage without exposing more getter methods from `KmsTemplate.class` or `GcpKmsAutoConfiguration.class`. Any thoughts?