### PR TITLE
chore: fix broken SQL IAM auth docs links

### DIFF
--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -175,7 +175,7 @@ The customized `ConnectionFactory` is then ready to connect to Cloud SQL. The re
 
 === Cloud SQL IAM database authentication
 
-Currently, Cloud SQL only supports https://cloud.google.com/sql/docs/postgres/authentication:[IAM database authentication for PostgreSQL].
+Currently, Cloud SQL only supports https://cloud.google.com/sql/docs/postgres/authentication[IAM database authentication for PostgreSQL].
 It allows you to connect to the database using an IAM account, rather than a predefined database username and password.
 You will need to do the following to enable it:
 

--- a/docs/src/main/md/sql.md
+++ b/docs/src/main/md/sql.md
@@ -221,7 +221,7 @@ and operational, ready to interact with your SQL database.
 ### Cloud SQL IAM database authentication
 
 Currently, Cloud SQL only supports [IAM database authentication for
-PostgreSQL](https://cloud.google.com/sql/docs/postgres/authentication:).
+PostgreSQL](https://cloud.google.com/sql/docs/postgres/authentication).
 It allows you to connect to the database using an IAM account, rather
 than a predefined database username and password. You will need to do
 the following to enable it:


### PR DESCRIPTION
# Summary
Fixes a simple documentation typo for SQL IAM auth which breaks a link.

# Closed Issues
Closes #1273 

# Notes
- this is my first contribution here so go easy if missed something; please let me know and I'll try to work swiftly to get up to spec
- ~I did sign my CLA~ had some proof here but apparently yall got a CI/CD job to check it 🤣
