### PR TITLE
Catch generic throwable and pass exception to returned future

### DIFF
--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
@@ -285,6 +285,9 @@ public class BigQueryTemplate implements BigQueryOperations {
                 writeApiFutureResponse.setException(e);
                 // Restore interrupted state in case of an InterruptedException
                 Thread.currentThread().interrupt();
+              } catch (Throwable t) {
+                writeApiFutureResponse.setException(t);
+                Thread.currentThread().interrupt();
               }
             });
     asyncTask

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
@@ -57,7 +57,7 @@ import org.springframework.scheduling.concurrent.DefaultManagedTaskScheduler;
 import org.springframework.util.concurrent.ListenableFuture;
 
 @ExtendWith(MockitoExtension.class)
-public class BigQueryTemplateTest {
+class BigQueryTemplateTest {
 
   private BigQueryWriteClient bigQueryWriteClientMock;
   private String newLineSeperatedJson =
@@ -114,7 +114,7 @@ public class BigQueryTemplateTest {
   }
 
   @Test
-  public void getWriteApiResponseTest()
+  void getWriteApiResponseTest()
       throws DescriptorValidationException, IOException, InterruptedException {
 
     InputStream jsoninputStream = new ByteArrayInputStream(newLineSeperatedJson.getBytes());
@@ -137,7 +137,7 @@ public class BigQueryTemplateTest {
   }
 
   @Test
-  public void writeJsonStreamTest()
+  void writeJsonStreamTest()
       throws DescriptorValidationException, IOException, InterruptedException, ExecutionException {
 
     InputStream jsoninputStream = new ByteArrayInputStream(newLineSeperatedJson.getBytes());
@@ -155,7 +155,7 @@ public class BigQueryTemplateTest {
   }
 
   @Test
-  public void writeJsonStreamWithSchemaTest()
+  void writeJsonStreamWithSchemaTest()
       throws DescriptorValidationException, IOException, InterruptedException, ExecutionException {
 
     InputStream jsoninputStream = new ByteArrayInputStream(newLineSeperatedJson.getBytes());
@@ -178,7 +178,7 @@ public class BigQueryTemplateTest {
 
 
   @Test
-  public void writeJsonStreamFailsOnGenericWritingException()
+  void writeJsonStreamFailsOnGenericWritingException()
       throws DescriptorValidationException, IOException, InterruptedException, ExecutionException {
 
     InputStream jsoninputStream = new ByteArrayInputStream(newLineSeperatedJson.getBytes());


### PR DESCRIPTION
This PR adds a catch-all for any unforeseen errors and passes the error to the returned future.

In normal code, catching `Throwable` is a bad idea -- the error should be allowed to propagate and stop the app. However, when running in a separate thread, an uncaught `Throwable` will simply disappear without a trace, so we have to catch it and hand the error over to the returned future, so that the failure may be acted upon.

Unrelated changes:
* lightly refactored to have the template get created before each test, since every test will need it.
* somehow this test was still on JUnit4. Upgraded to JUnit5.