### PR TITLE
Make CreateDisposition configurable on BigQueryTemplate

### DIFF
--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
@@ -19,6 +19,7 @@ package com.google.cloud.spring.bigquery.core;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobInfo.CreateDisposition;
 import com.google.cloud.bigquery.JobInfo.WriteDisposition;
 import com.google.cloud.bigquery.JobStatus.State;
 import com.google.cloud.bigquery.Schema;
@@ -74,6 +75,8 @@ public class BigQueryTemplate implements BigQueryOperations {
   private boolean autoDetectSchema = true;
 
   private WriteDisposition writeDisposition = WriteDisposition.WRITE_APPEND;
+
+  private CreateDisposition createDisposition;
 
   private Duration jobPollInterval = Duration.ofSeconds(2);
 
@@ -177,6 +180,18 @@ public class BigQueryTemplate implements BigQueryOperations {
   }
 
   /**
+   * Sets the {@link CreateDisposition} which specifies whether a new table may be created in
+   * BigQuery if needed.
+   *
+   * @param createDisposition whether to never create a new table in the BigQuery table or only if
+   *     needed.
+   */
+  public void setCreateDisposition(CreateDisposition createDisposition) {
+    Assert.notNull(createDisposition, "BigQuery create disposition must not be null.");
+    this.createDisposition = createDisposition;
+  }
+
+  /**
    * Sets the {@link Duration} amount of time to wait between successive polls on the status of a
    * BigQuery job.
    *
@@ -203,6 +218,7 @@ public class BigQueryTemplate implements BigQueryOperations {
         WriteChannelConfiguration.newBuilder(tableId)
             .setFormatOptions(dataFormatOptions)
             .setWriteDisposition(this.writeDisposition)
+            .setCreateDisposition(this.createDisposition)
             .setAutodetect(this.autoDetectSchema);
 
     if (schema != null) {


### PR DESCRIPTION
This  change is adding the possibility to be able to change the `CreateDisposition` (`CREATE_IF_NEEDED` or `CREATE_NEVER`) on the `BigQueryTemplate` ackin to how you would currently configure the `WriteDisposition`.

In our use case we have to use `CREATE_NEVER` because we want to prevent even the attempt to create a table in BigQuery. Currently this is only be possible by using a `BigQuery` instance directly, because the `CreateDisposition` is not passed through by the template to the `WriteChannelConfiguration` and eventually the writer falls back to the `CREATE_IF_NEEDED` default.