### PR TITLE
fix: add supported type to Spanner read to query option conversion

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerReadOptions.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerReadOptions.java
@@ -97,6 +97,8 @@ public class SpannerReadOptions extends AbstractSpannerRequestOptions<ReadOption
     for (ReadOption ro : this.getOptions()) {
       if (ro instanceof Options.ReadAndQueryOption) {
         query.addQueryOption((Options.ReadAndQueryOption) ro);
+      } else if (ro instanceof Options.ReadQueryUpdateTransactionOption) {
+        query.addQueryOption((Options.ReadQueryUpdateTransactionOption) ro);
       } else {
         throw new IllegalArgumentException(
             String.format("Can't convert %s to SpannerQueryOptions ", this));

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerTemplate.java
@@ -221,11 +221,11 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
 
   /**
    * In many cases {@link KeySet} with {@link SpannerReadOptions} are compatible with {@link
-   * SpannerReadOptions}. The method throws exception when it is impossible.
+   * SpannerQueryOptions}. The method throws exception when it is impossible.
    *
    * @param options read-parameters
    * @return query-parameters
-   * @throws IllegalArgumentException when {@link SpannerQueryOptions} can't be converted to {@link
+   * @throws IllegalArgumentException when {@link SpannerReadOptions} can't be converted to {@link
    *     SpannerQueryOptions} or {@code keys} have "ranges".
    * @see SpannerReadOptions#toQueryOptions()
    */

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerReadOptionsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerReadOptionsTests.java
@@ -20,9 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-import com.google.cloud.spanner.Options;
-import com.google.cloud.spanner.Options.ReadOption;
 import com.google.cloud.spanner.Options.ReadAndQueryOption;
+import com.google.cloud.spanner.Options.ReadOption;
 import com.google.cloud.spanner.Options.ReadQueryUpdateTransactionOption;
 import java.util.Arrays;
 import java.util.Collections;

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerReadOptionsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerReadOptionsTests.java
@@ -63,7 +63,7 @@ class SpannerReadOptionsTests {
     SpannerReadOptions spannerReadOptions = new SpannerReadOptions();
     ReadOption r1 = mock(ReadOption.class);
     spannerReadOptions.addReadOption(r1);
-    assertThatThrownBy(() -> spannerReadOptions.toQueryOptions())
+    assertThatThrownBy(spannerReadOptions::toQueryOptions)
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Can't convert");
   }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerReadOptionsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerReadOptionsTests.java
@@ -49,13 +49,23 @@ class SpannerReadOptionsTests {
   }
 
   @Test
-  void convertReadToQueryOptionTest() {
+  void convertReadToQueryOptionTest_withSupportedOptions() {
     SpannerReadOptions spannerReadOptions = new SpannerReadOptions();
     ReadAndQueryOption r1 = mock(ReadAndQueryOption.class);
     ReadQueryUpdateTransactionOption r2 = mock(ReadQueryUpdateTransactionOption.class);
     spannerReadOptions.addReadOption(r1).addReadOption(r2);
     SpannerQueryOptions spannerQueryOptions = spannerReadOptions.toQueryOptions();
     assertThat(spannerQueryOptions.getOptions()).hasSize(2);
+  }
+
+  @Test
+  void convertReadToQueryOptionTest_throwIfNotSupported() {
+    SpannerReadOptions spannerReadOptions = new SpannerReadOptions();
+    ReadOption r1 = mock(ReadOption.class);
+    spannerReadOptions.addReadOption(r1);
+    assertThatThrownBy(() -> spannerReadOptions.toQueryOptions())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Can't convert");
   }
 
   @Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerReadOptionsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerReadOptionsTests.java
@@ -20,7 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
+import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.Options.ReadOption;
+import com.google.cloud.spanner.Options.ReadAndQueryOption;
+import com.google.cloud.spanner.Options.ReadQueryUpdateTransactionOption;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
@@ -44,6 +47,16 @@ class SpannerReadOptionsTests {
     ReadOption r2 = mock(ReadOption.class);
     spannerReadOptions.addReadOption(r1).addReadOption(r2);
     assertThat(Arrays.asList(spannerReadOptions.getOptions())).containsExactlyInAnyOrder(r1, r2);
+  }
+
+  @Test
+  void convertReadToQueryOptionTest() {
+    SpannerReadOptions spannerReadOptions = new SpannerReadOptions();
+    ReadAndQueryOption r1 = mock(ReadAndQueryOption.class);
+    ReadQueryUpdateTransactionOption r2 = mock(ReadQueryUpdateTransactionOption.class);
+    spannerReadOptions.addReadOption(r1).addReadOption(r2);
+    SpannerQueryOptions spannerQueryOptions = spannerReadOptions.toQueryOptions();
+    assertThat(spannerQueryOptions.getOptions()).hasSize(2);
   }
 
   @Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
@@ -36,6 +36,7 @@ import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.Options.ReadOption;
 import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ReadOnlyTransaction;
@@ -445,6 +446,19 @@ class SpannerTemplateTests {
     SpannerTemplate spyTemplate = spy(this.spannerTemplate);
     KeySet keys = KeySet.newBuilder().addKey(Key.of("key1")).addKey(Key.of("key2")).build();
     SpannerReadOptions options = new SpannerReadOptions();
+    spyTemplate.read(ParentEntity.class, keys, options);
+    verify(spyTemplate, times(1)).read(eq(ParentEntity.class), same(keys), eq(options));
+    verify(this.databaseClient, times(1)).singleUse();
+  }
+
+  @Test
+  void findKeySetTestEagerConvertedOptions() {
+    SpannerTemplate spyTemplate = spy(this.spannerTemplate);
+    KeySet keys = KeySet.newBuilder().addKey(Key.of("key1")).addKey(Key.of("key2")).build();
+    SpannerReadOptions options =
+            new SpannerReadOptions()
+                    .addReadOption(mock(Options.ReadAndQueryOption.class))
+                    .addReadOption(mock(Options.ReadQueryUpdateTransactionOption.class));
     spyTemplate.read(ParentEntity.class, keys, options);
     verify(spyTemplate, times(1)).read(eq(ParentEntity.class), same(keys), eq(options));
     verify(this.databaseClient, times(1)).singleUse();

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
@@ -460,7 +460,7 @@ class SpannerTemplateTests {
                     .addReadOption(mock(Options.ReadAndQueryOption.class))
                     .addReadOption(mock(Options.ReadQueryUpdateTransactionOption.class));
     spyTemplate.read(ParentEntity.class, keys, options);
-    verify(spyTemplate, times(1)).read(eq(ParentEntity.class), same(keys), eq(options));
+    verify(spyTemplate).read(eq(ParentEntity.class), same(keys), eq(options));
     verify(this.databaseClient, times(1)).singleUse();
   }
 


### PR DESCRIPTION
Fixes #1306 which points out a missed condition: when converting Spanner `ReadOption` to `QueryOption`, [`ReadQueryUpdateTransactionOption`](https://github.com/googleapis/java-spanner/blob/d59e2db88a365a6c119040983459eb3f1b98dfe5/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Options.java#L51) should also result in a valid conversion.
