### PR TITLE
fix(codegen): use find and replace to switch to local gapic-generator-java repo

### DIFF
--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -48,10 +48,19 @@ cd googleapis
 # fix googleapis committish for test/dev purpose
 git checkout f88ca86
 # todo: change to local repo --> gapic
-# very not stable change - todo: change to search and replace.
-sed -i '274,278d' WORKSPACE
 
-sed -i '274 i local_repository(\n    name = "gapic_generator_java",\n    path = "../gapic-generator-java/",\n)' WORKSPACE
+# Finds http_archive() rule with name = "gapic_generator_java",
+# and replaces with local_repository() rule in googleapis/WORKSPACE
+LOCAL_REPO="local_repository(\n    name = \\\"gapic_generator_java\\\",\n    path = \\\"..\/gapic_generator_java\/\\\",\n)"
+# Using perl for multi-line replace
+# -0777 slurps file instead of per-line
+# -p for input loop over lines in file
+# -i to edit file in-place
+# -e to enter one line of program
+perl -0777 -pi -e "s/http_archive\(\n    name \= \"gapic_generator_java\"(.*?)\)/$LOCAL_REPO/s" WORKSPACE
+# "s/{find_pattern}/{replace_text}/s":
+# substitute first occurrence of text matching {find_pattern} with {replace_text},
+# with dot matching all characters including new lines
 
 # call bazel target - todo: separate target in future
 bazel build //google/cloud/$client_lib_name/v1:"$client_lib_name"_java_gapic

--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -51,7 +51,7 @@ git checkout f88ca86
 
 # Finds http_archive() rule with name = "gapic_generator_java",
 # and replaces with local_repository() rule in googleapis/WORKSPACE
-LOCAL_REPO="local_repository(\n    name = \\\"gapic_generator_java\\\",\n    path = \\\"..\/gapic_generator_java\/\\\",\n)"
+LOCAL_REPO="local_repository(\n    name = \\\"gapic_generator_java\\\",\n    path = \\\"..\/gapic-generator-java\/\\\",\n)"
 # Using perl for multi-line replace
 # -0777 slurps file instead of per-line
 # -p for input loop over lines in file

--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -49,18 +49,10 @@ cd googleapis
 git checkout f88ca86
 # todo: change to local repo --> gapic
 
-# Finds http_archive() rule with name = "gapic_generator_java",
-# and replaces with local_repository() rule in googleapis/WORKSPACE
+# In googleapis/WORKSPACE, find http_archive() rule with name = "gapic_generator_java",
+# and replace with local_repository() rule
 LOCAL_REPO="local_repository(\n    name = \\\"gapic_generator_java\\\",\n    path = \\\"..\/gapic-generator-java\/\\\",\n)"
-# Using perl for multi-line replace
-# -0777 slurps file instead of per-line
-# -p for input loop over lines in file
-# -i to edit file in-place
-# -e to enter one line of program
 perl -0777 -pi -e "s/http_archive\(\n    name \= \"gapic_generator_java\"(.*?)\)/$LOCAL_REPO/s" WORKSPACE
-# "s/{find_pattern}/{replace_text}/s":
-# substitute first occurrence of text matching {find_pattern} with {replace_text},
-# with dot matching all characters including new lines
 
 # call bazel target - todo: separate target in future
 bazel build //google/cloud/$client_lib_name/v1:"$client_lib_name"_java_gapic


### PR DESCRIPTION
To replace `http_archive()` rule with `local_repository()` rule for using local repo of `gapic-generator-java`, this PR updates the current approach in generator script of replacement by line number to search and replace with pattern matching.
- Some additional notes for the perl one-liner logic, not sure if they'd be helpful to include as inline comments?
```
# Using perl for multi-line replace
# -0777 slurps file instead of per-line
# -p for assuming input loop around program, like sed
# -i to edit file in-place
# -e to enter one line of program
# "s/{find_pattern}/{replace_text}/s": substitute first occurrence of text matching {find_pattern} with {replace_text}, with dot matching all characters including new lines
```

**Potential conflicts:** with #1313, will just need to update location of change if merged after.
