### PR TITLE
fix(actions): suppress IT only on PRs

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -34,7 +34,12 @@ jobs:
           done < files.txt
       - name: Add skip IT label
         run: |
-          cat $GITHUB_EVENT_PATH
+          echo $GITHUB_SHA
+          #cat $GITHUB_EVENT_PATH
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/GoogleCloudPlatform/spring-cloud-gcp/commits/$GITHUB_SHA/pulls
+          echo ""
           echo "pr number is $PR_NUMBER"
           if [ -z $PR_NUMBER ]; then
             exit

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -2,60 +2,22 @@ name: Integration Tests
 
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
+    branches:
+      - 'main'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'generator/**'
+      - 'generated/**'
   workflow_dispatch:
   schedule:
     - cron: '05 8 * * *' # 08:00 UTC every day
 
 
 jobs:
-  check:
-    name: Check IT-disabling files
-    outputs:
-      run_job: ${{ steps.check_files.outputs.run_job }}
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-      - name: check modified files
-        id: check_files
-        run: |
-          git diff --name-only HEAD^ HEAD > files.txt
-          echo "run_job=false" >> $GITHUB_OUTPUT
-          while IFS= read -r file
-          do
-            if [[ $file != generated/* ]] && [[ $file != generator/* ]]; then
-              echo "run_job=true" >> $GITHUB_OUTPUT
-              break
-            fi
-          done < files.txt
-      - name: Add skip IT label
-        run: |
-          echo $GITHUB_SHA
-          #cat $GITHUB_EVENT_PATH
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            /repos/GoogleCloudPlatform/spring-cloud-gcp/commits/$GITHUB_SHA/pulls
-          echo ""
-          echo "pr number is $PR_NUMBER"
-          if [ -z $PR_NUMBER ]; then
-            exit
-          fi
-          if [[ $ADD_LABEL == "true" ]]; then
-            gh pr edit $PR_NUMBER --add-label "skip-integration-tests"
-          else
-            gh pr edit $PR_NUMBER --remove-label "skip-integration-tests"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
-          ADD_LABEL: ${{steps.check_files.outputs.run_job == 'false'}}
   integrationTests:
     needs: check
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && (needs.check.outputs.run_job == 'true' || github.event.number == '')
+    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -33,8 +33,9 @@ jobs:
             fi
           done < files.txt
       - name: Add skip IT label
-        if: github.event_name == 'pull_request'
+        #if: github.event.number == null
         run: |
+          echo "pr number is $PR_NUMBER"
           if [[ $ADD_LABEL == "true" ]]; then
             gh pr edit $PR_NUMBER --add-label "skip-integration-tests"
           else
@@ -46,7 +47,8 @@ jobs:
           ADD_LABEL: ${{steps.check_files.outputs.run_job == 'false'}}
   integrationTests:
     needs: check
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && ((github.event_name == 'pull_request' && needs.check.outputs.run_job == 'true') || github.event_name != 'pull_request')
+    # if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && ((github.event_name == 'pull_request' && needs.check.outputs.run_job == 'true') || github.event_name != 'pull_request')
+    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && needs.check.outputs.run_job == 'true'
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -33,7 +33,7 @@ jobs:
             fi
           done < files.txt
       - name: Add skip IT label
-        if: {{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request'
         run: |
           if [[ $ADD_LABEL == "true" ]]; then
             gh pr edit $PR_NUMBER --add-label "skip-integration-tests"

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -33,6 +33,7 @@ jobs:
             fi
           done < files.txt
       - name: Add skip IT label
+        if: {{ github.event_name == 'pull_request' }}
         run: |
           if [[ $ADD_LABEL == "true" ]]; then
             gh pr edit $PR_NUMBER --add-label "skip-integration-tests"
@@ -45,7 +46,7 @@ jobs:
           ADD_LABEL: ${{steps.check_files.outputs.run_job == 'false'}}
   integrationTests:
     needs: check
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && needs.check.outputs.run_job == 'true'
+    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && ((github.event_name == 'pull_request' && needs.check.outputs.run_job == 'true') || github.event_name != 'pull_request')
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -34,6 +34,7 @@ jobs:
           done < files.txt
       - name: Add skip IT label
         run: |
+          cat $GITHUB_EVENT_PATH
           echo "pr number is $PR_NUMBER"
           if [ -z $PR_NUMBER ]; then
             exit

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -16,7 +16,6 @@ on:
 
 jobs:
   integrationTests:
-    needs: check
     if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -33,9 +33,11 @@ jobs:
             fi
           done < files.txt
       - name: Add skip IT label
-        #if: github.event.number == null
         run: |
           echo "pr number is $PR_NUMBER"
+          if [ -z $PR_NUMBER ]; then
+            exit
+          fi
           if [[ $ADD_LABEL == "true" ]]; then
             gh pr edit $PR_NUMBER --add-label "skip-integration-tests"
           else
@@ -47,8 +49,7 @@ jobs:
           ADD_LABEL: ${{steps.check_files.outputs.run_job == 'false'}}
   integrationTests:
     needs: check
-    # if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && ((github.event_name == 'pull_request' && needs.check.outputs.run_job == 'true') || github.event_name != 'pull_request')
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && needs.check.outputs.run_job == 'true'
+    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && (needs.check.outputs.run_job == 'true' || github.event.number == '')
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
Switching trigger logic to use `on`.
* PRs will trigger ITs only if
  * They have at least 1 change in a folder other than `generat[ed|or]/`. [details](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths)
  * The PR has been opened or [`synchronized`](https://github.com/orgs/community/discussions/25161#discussioncomment-3246673)
* Pushes to `main` will also trigger the ITs (e.g. merge a PR)

The logic for excluding ITs from dependabot was moved to the job's `if` entry