### PR TITLE
Find the lost transaction manager

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -10,6 +10,7 @@ com.google.cloud.spring.autoconfigure.spanner.health.SpannerHealthIndicatorAutoC
 com.google.cloud.spring.autoconfigure.spanner.SpannerTransactionManagerAutoConfiguration,\
 com.google.cloud.spring.autoconfigure.datastore.GcpDatastoreAutoConfiguration,\
 com.google.cloud.spring.autoconfigure.firestore.GcpFirestoreAutoConfiguration,\
+com.google.cloud.spring.autoconfigure.firestore.FirestoreTransactionManagerAutoConfiguration,\
 com.google.cloud.spring.autoconfigure.firestore.GcpFirestoreEmulatorAutoConfiguration,\
 com.google.cloud.spring.autoconfigure.datastore.health.DatastoreHealthIndicatorAutoConfiguration,\
 com.google.cloud.spring.autoconfigure.storage.GcpStorageAutoConfiguration,\

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/pom.xml
@@ -80,6 +80,11 @@
       <artifactId>gcloud</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/FirestoreSampleApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/FirestoreSampleApplication.java
@@ -29,11 +29,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
 /** Sample application for Spring Data Firestore. */
 @SpringBootApplication
+@EnableTransactionManagement
 public class FirestoreSampleApplication {
 
   @Bean

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserController.java
@@ -40,7 +40,10 @@ public class UserController {
 
   private final FirestoreTemplate firestoreTemplate;
 
-  public UserController(UserRepository userRepository, FirestoreTemplate firestoreTemplate) {
+  private final UserService userService;
+
+  public UserController(UserService userService, UserRepository userRepository, FirestoreTemplate firestoreTemplate) {
+    this.userService = userService;
     this.userRepository = userRepository;
     this.firestoreTemplate = firestoreTemplate;
   }
@@ -62,9 +65,7 @@ public class UserController {
 
   @GetMapping("/removeUser")
   private Mono<String> removeUserByName(@RequestParam String name) {
-    return this.userRepository
-        .delete(new User(name, 0, null))
-        .map(unusedVoid -> name + "was successfully removed");
+    return this.userService.removeUserByName(name);
   }
 
   @GetMapping("/removePhonesForUser")

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserService.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+@Service
+public class UserService {
+
+  private UserRepository userRepository;
+
+  public UserService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  // Testing that Transactional works;
+  // see https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/1297
+  @Transactional
+  public Mono<String> removeUserByName(String name) {
+    return userRepository
+        .delete(new User(name, 0, null))
+        .map(unusedVoid -> name + "was successfully removed");
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserService.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserService.java
@@ -23,7 +23,7 @@ import reactor.core.publisher.Mono;
 @Service
 public class UserService {
 
-  private UserRepository userRepository;
+  private final UserRepository userRepository;
 
   public UserService(UserRepository userRepository) {
     this.userRepository = userRepository;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/FirestoreSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/FirestoreSampleApplicationIntegrationTests.java
@@ -33,6 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @EnabledIfSystemProperty(named = "it.firestore", matches = "true")
 @ExtendWith(SpringExtension.class)

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/FirestoreSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/FirestoreSampleApplicationIntegrationTests.java
@@ -33,7 +33,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @EnabledIfSystemProperty(named = "it.firestore", matches = "true")
 @ExtendWith(SpringExtension.class)

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/TestUserClient.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/TestUserClient.java
@@ -16,13 +16,18 @@
 
 package com.example;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -38,25 +43,27 @@ public class TestUserClient {
 
   public List<User> listUsers() {
     User[] users = restTemplate.getForObject("/users", User[].class);
-    Assertions.assertThat(users).isNotNull();
+    assertThat(users).isNotNull();
     return Arrays.asList(users);
   }
 
   public List<User> findUsersByAge(int age) {
     User[] users = restTemplate.getForObject("/users/age?age=" + age, User[].class);
-    Assertions.assertThat(users).isNotNull();
+    assertThat(users).isNotNull();
     return Arrays.asList(users);
   }
 
   public List<PhoneNumber> listPhoneNumbers(String name) {
     PhoneNumber[] phoneNumbers =
         restTemplate.getForObject("/users/phones?name=" + name, PhoneNumber[].class);
-    Assertions.assertThat(phoneNumbers).isNotNull();
+    assertThat(phoneNumbers).isNotNull();
     return Arrays.asList(phoneNumbers);
   }
 
   public void removeUserByName(String name) {
-    restTemplate.getForEntity("/users/removeUser?name=" + name, String.class);
+    ResponseEntity<String> response =
+        restTemplate.getForEntity("/users/removeUser?name=" + name, String.class);
+    assertThat(response.getStatusCode()).isSameAs(HttpStatus.OK);
   }
 
   public void removePhonesForUser(String name) {


### PR DESCRIPTION
As part of https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/620, the transaction manager autoconfiguration was removed from the main Firestore autoconfig but was not added to Spring's metadata, so it's not automatically loaded.

This PR:
1) Brings back the transaction manager in `spring.factories` (we'll have to re-add for the New Way in Boot 3.0).
2) Adds a service between controller and repository, but for only one method.
3) Strengthens the test by verifying that HTTP call does not fail, but only for one method.

I'll either send a follow-up to do 2) and 3) for the remaining functionality or leave them as an exercise for the reader :)


Fixes #1297.