### PR TITLE
fix: correct fork check logic

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -16,7 +16,10 @@ on:
 
 jobs:
   integrationTests:
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' && github.actor != 'dependabot[bot]'
+    if: |
+      github.actor != 'dependabot[bot]' && ((
+        github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
+      ) || (github.event_name == 'push'))
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/linkageCheck.yaml
+++ b/.github/workflows/linkageCheck.yaml
@@ -10,7 +10,10 @@ on:
 
 jobs:
   linkageCheck:
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp'
+    if: |
+      ((
+        github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
+      ) || (github.event_name == 'push'))
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -12,7 +12,10 @@ on:
 
 jobs:
   sonar:
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp' # Only run on upstream branch
+    if: |
+      ((
+        github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
+      ) || (github.event_name == 'push'))
     name: Build with Sonar
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -17,10 +17,6 @@ on:
 
 jobs:
   updateDocs:
-    if: |
-      ((
-        github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
-      ) || (github.event_name == 'push'))
     runs-on: ubuntu-20.04
     steps:
     - name: Get current date

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -17,7 +17,10 @@ on:
 
 jobs:
   updateDocs:
-    if: github.repository == 'GoogleCloudPlatform/spring-cloud-gcp'
+    if: |
+      ((
+        github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
+      ) || (github.event_name == 'push'))
     runs-on: ubuntu-20.04
     steps:
     - name: Get current date


### PR DESCRIPTION
- Disabled the following workflows when a PR comes from a fork:
  - Integration tests
  - Linkage check
  - SonarCloud analysis

- Removed the fork procedence check in `updateDocs.yaml` because its `on` clause states that it will only be run from `push`es (i.e. a PR has been merged)

- Confirmed logic is working:
  * [fork PR](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1329) - skips
  * [local PR](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1330) - runs