### PR TITLE
fix: removed broken readme link. fix broken cloud-logging link.

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -56,8 +56,6 @@ dependencies {
 }
 ----
 
-See the <<README.adoc, sections>> in the README for selecting an available version and Maven repository.
-
 In the following sections, it will be assumed you are using the Spring Cloud GCP BOM and the dependency snippets will not contain versions.
 
 ==== Starter Dependencies

--- a/docs/src/main/asciidoc/trace.adoc
+++ b/docs/src/main/asciidoc/trace.adoc
@@ -158,7 +158,7 @@ You can then search and filter traces based on these additional tags in the Clou
 
 === Integration with Logging
 
-Integration with Cloud Logging is available through the link:logging.adoc[Cloud Logging Support].
+Integration with Cloud Logging is available through the link:#cloud-logging[Cloud Logging Support].
 If the Trace integration is used together with the Logging one, the request logs will be associated to the corresponding traces.
 The trace logs can be viewed by going to the https://console.cloud.google.com/traces/traces[Google Cloud Console Trace List], selecting a trace and pressing the `Logs -> View` link in the `Details` section.
 

--- a/docs/src/main/md/getting-started.md
+++ b/docs/src/main/md/getting-started.md
@@ -59,8 +59,6 @@ Or, if you’re a Gradle user:
         implementation platform("com.google.cloud:spring-cloud-gcp-dependencies:{project-version}")
     }
 
-See the [sections](#README.adoc) in the README for selecting an
-available version and Maven repository.
 
 In the following sections, it will be assumed you are using the Spring
 Cloud GCP BOM and the dependency snippets will not contain versions.

--- a/docs/src/main/md/trace.md
+++ b/docs/src/main/md/trace.md
@@ -198,7 +198,7 @@ the Cloud Trace service.
 ### Integration with Logging
 
 Integration with Cloud Logging is available through the [Cloud Logging
-Support](logging.adoc). If the Trace integration is used together with
+Support](#cloud-logging). If the Trace integration is used together with
 the Logging one, the request logs will be associated to the
 corresponding traces. The trace logs can be viewed by going to the
 [Google Cloud Console Trace


### PR DESCRIPTION
Noticed two broken links in docs:
- the `README.adoc` link seems redundant, as version already included in code snippet.
- fix link to `cloud-logging`