### PR TITLE
fix: use logic from #1315

### DIFF
--- a/generator/download-repos.sh
+++ b/generator/download-repos.sh
@@ -19,9 +19,11 @@ cd googleapis
 git checkout f88ca86
 # todo: change to local repo --> gapic
 # very not stable change - todo: change to search and replace.
-sed -i '274,278d' WORKSPACE
 
-sed -i '274 i local_repository(\n    name = "gapic_generator_java",\n    path = "../gapic-generator-java/",\n)' WORKSPACE
+# In googleapis/WORKSPACE, find http_archive() rule with name = "gapic_generator_java",
+# and replace with local_repository() rule
+LOCAL_REPO="local_repository(\n    name = \\\"gapic_generator_java\\\",\n    path = \\\"..\/gapic-generator-java\/\\\",\n)"
+perl -0777 -pi -e "s/http_archive\(\n    name \= \"gapic_generator_java\"(.*?)\)/$LOCAL_REPO/s" WORKSPACE
 
 cd -
 

--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -39,11 +39,8 @@ fi
 
 # call bazel target - todo: separate target in future
 cd googleapis
-# In googleapis/WORKSPACE, find http_archive() rule with name = "gapic_generator_java",
-# and replace with local_repository() rule
-LOCAL_REPO="local_repository(\n    name = \\\"gapic_generator_java\\\",\n    path = \\\"..\/gapic-generator-java\/\\\",\n)"
-perl -0777 -pi -e "s/http_archive\(\n    name \= \"gapic_generator_java\"(.*?)\)/$LOCAL_REPO/s" WORKSPACE
 bazel build //google/cloud/$client_lib_name/v1:"$client_lib_name"_java_gapic
+
 cd -
 
 ## copy spring code to outside


### PR DESCRIPTION
Solves an issue mentioned in a [comment](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1313#issuecomment-1309013396) by @emmileaf in #1313.
Corrects a wrong rebase procedure: Changes from #1315 were successfully added to `generate-one.sh`, but this should be done in `download-repos.sh`