### PR TITLE
codegen: adding documentation items for generated modules

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -66,7 +66,9 @@ Each starter contains all the dependencies and transitive dependencies needed to
 For example, if you wish to write a Spring application with Cloud Pub/Sub, you would include the `spring-cloud-gcp-starter-pubsub` dependency in your project.
 You do *not* need to include the underlying `spring-cloud-gcp-pubsub` dependency, because the `starter` dependency includes it.
 
-A summary of these artifacts are provided below. We also provide additional starters with auto-configurations to a boarder list of Google Client libraries. Refer for the full list https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/generated/README.md[here].
+A summary of these artifacts are provided below.
+
+Aside from these modules, we also provide additional starters with auto-configurations to various Google Client Libraries. Refer for the full list https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/generated/README.md[here].
 
 |===
 | Spring Cloud GCP Starter | Description | Maven Artifact Name

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -66,7 +66,7 @@ Each starter contains all the dependencies and transitive dependencies needed to
 For example, if you wish to write a Spring application with Cloud Pub/Sub, you would include the `spring-cloud-gcp-starter-pubsub` dependency in your project.
 You do *not* need to include the underlying `spring-cloud-gcp-pubsub` dependency, because the `starter` dependency includes it.
 
-A summary of these artifacts are provided below.
+A summary of these artifacts are provided below. We also provide additional starters with auto-configurations to a boarder list of Google Client libraries. Refer for the full list https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/generated/README.md[here].
 
 |===
 | Spring Cloud GCP Starter | Description | Maven Artifact Name

--- a/docs/src/main/md/getting-started.md
+++ b/docs/src/main/md/getting-started.md
@@ -77,7 +77,9 @@ dependency in your project. You do **not** need to include the
 underlying `spring-cloud-gcp-pubsub` dependency, because the `starter`
 dependency includes it.
 
-A summary of these artifacts are provided below. We also provide additional starters with auto-configurations to a boarder list of Google Client libraries. Refer for the full list [here](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/generated/README.md).
+A summary of these artifacts are provided below. 
+
+Aside from these modules, we also provide additional starters with auto-configurations to various Google Client Libraries. Refer for the full list [here](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/generated/README.md).
 
 | Spring Cloud GCP Starter | Description                                                                       | Maven Artifact Name                                                                                    |
 | ------------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |

--- a/docs/src/main/md/getting-started.md
+++ b/docs/src/main/md/getting-started.md
@@ -77,7 +77,7 @@ dependency in your project. You do **not** need to include the
 underlying `spring-cloud-gcp-pubsub` dependency, because the `starter`
 dependency includes it.
 
-A summary of these artifacts are provided below.
+A summary of these artifacts are provided below. We also provide additional starters with auto-configurations to a boarder list of Google Client libraries. Refer for the full list [here](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/generated/README.md).
 
 | Spring Cloud GCP Starter | Description                                                                       | Maven Artifact Name                                                                                    |
 | ------------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |

--- a/generated/README.md
+++ b/generated/README.md
@@ -2,5 +2,5 @@
 
 This is a list of starters we provide with dependencies and auto-configurations to work with corresponding Google Client Libraries.
 
-| Client Library Starter | Description   | Maven Artifact Name |
-|------------------------| ------------- |---------------------|
+| Client Library Starter | Maven Artifact Name |
+|------------------------| --------------------|

--- a/generated/README.md
+++ b/generated/README.md
@@ -1,0 +1,8 @@
+# Spring Boot Starters for Google Client libraries
+
+This is a list of starters we provide with dependencies and auto-configurations to work with corresponding Google Client Libraries.
+
+| Client Library Starter | Description                                                                       | Maven Artifact Name                    |
+|-----------------------------------| --------------------------------------------------------------------------------- |----------------------------------------|
+
+

--- a/generated/README.md
+++ b/generated/README.md
@@ -2,7 +2,5 @@
 
 This is a list of starters we provide with dependencies and auto-configurations to work with corresponding Google Client Libraries.
 
-| Client Library Starter | Description                                                                       | Maven Artifact Name                    |
-|-----------------------------------| --------------------------------------------------------------------------------- |----------------------------------------|
-
-
+| Client Library Starter | Description   | Maven Artifact Name |
+|------------------------| ------------- |---------------------|

--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -73,6 +73,7 @@ else
   # also write to generated/README.md
   # format |name|distribution name|
   echo -e "|$client_lib_name|com.google.cloud:$starter_artifactid|" >> README.md
+  echo "$({(cat README.md | grep -vw ".*:.*");(cat README.md | grep ".*:.*" | sort | uniq)})" > README.md
 
 fi
 

--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -73,7 +73,7 @@ else
   # also write to generated/README.md
   # format |name|distribution name|
   echo -e "|$client_lib_name|com.google.cloud:$starter_artifactid|" >> README.md
-  echo "$({(cat README.md | grep -vw ".*:.*");(cat README.md | grep ".*:.*" | sort | uniq)})" > README.md
+  {(grep -vw ".*:.*" README.md);(grep ".*:.*" README.md| sort | uniq)} > tmpfile && mv tmpfile README.md
 
 fi
 

--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -68,6 +68,9 @@ if [[ found_library_in_pom -eq 0 ]]; then
 else
   echo "adding module $client_lib_name to pom"
   sed -i "/^  <modules>/a\ \ \ \ <module>"$client_lib_name"</module>" pom.xml
+  # also write to generated/README.md
+  # format |name|distribution name|
+  echo -e "|$client_lib_name|$client_lib_groupid:$client_lib_artifactid|" >> README.md
 fi
 
 

--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -24,6 +24,8 @@ echo "Client Library Version: $version";
 echo "Client Library GroupId: $client_lib_groupid";
 echo "Client Library ArtifactId: $client_lib_artifactid";
 
+starter_artifactid="$client_lib_artifactid-spring-starter"
+
 # setup git
 
 ## install bazel - commented out as running on local already with bazel
@@ -70,7 +72,8 @@ else
   sed -i "/^  <modules>/a\ \ \ \ <module>"$client_lib_name"</module>" pom.xml
   # also write to generated/README.md
   # format |name|distribution name|
-  echo -e "|$client_lib_name|$client_lib_groupid:$client_lib_artifactid|" >> README.md
+  echo -e "|$client_lib_name|com.google.cloud:$starter_artifactid|" >> README.md
+
 fi
 
 


### PR DESCRIPTION
As discussed earlier, adding these items in prep for documentation:
- a `README.md` to `generated/` with header for  a list of modules generated.
- list item generation line into script.
- link from documentation page.