### PR TITLE
fix: modify 'if' filter on gh actions to allow non-prs

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -19,7 +19,7 @@ jobs:
     if: |
       github.actor != 'dependabot[bot]' && ((
         github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
-      ) || (github.event_name == 'push'))
+      ) || (github.event_name != 'pull_request'))
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/linkageCheck.yaml
+++ b/.github/workflows/linkageCheck.yaml
@@ -13,7 +13,7 @@ jobs:
     if: |
       ((
         github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
-      ) || (github.event_name == 'push'))
+      ) || (github.event_name != 'pull_request'))
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -15,7 +15,7 @@ jobs:
     if: |
       ((
         github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
-      ) || (github.event_name == 'push'))
+      ) || (github.event_name != 'pull_request'))
     name: Build with Sonar
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
So far the logic allowed either 'push' or 'pull_request' events. This fix allows either a validated 'pull_request' (fork validation) or any other even that is not a PR since these don't require validation