### PR TITLE
Drop table before creating

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-sample/src/main/resources/schema.sql
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-sample/src/main/resources/schema.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS users;
+
 CREATE TABLE users (
   email VARCHAR(255),
   first_name VARCHAR(255),


### PR DESCRIPTION
CloudSQL acquired an annoying flake where the table is sometimes not cleaned up correctly. This change should force table deletion before creation in the db initialization stage.