### PR TITLE
style: update license header check to accept single year pattern

### DIFF
--- a/src/checkstyle/java.header
+++ b/src/checkstyle/java.header
@@ -1,6 +1,6 @@
 ^/\*$
-^ \* Copyright 20\d\d-20\d\d (Google LLC|the original author or authors.)$
-^ \* Copyright 20\d\d-20\d\d Google LLC$
+^ \* Copyright (20\d\d-20\d\d|20\d\d) (Google LLC|the original author or authors.)$
+^ \* Copyright (20\d\d-20\d\d|20\d\d) Google LLC$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the "License"\);$
 ^ \* you may not use this file except in compliance with the License\.$


### PR DESCRIPTION
This PR updates checkstyle to accept single year copyright patterns (e.g.`2022`) in addition to the existing range pattern (e.g. `2022-2022`).