### PR TITLE
fix(codegen): add logic to add spring deps to googleapis/WORKSPACE

### DIFF
--- a/generator/download-repos.sh
+++ b/generator/download-repos.sh
@@ -25,5 +25,9 @@ git checkout f88ca86
 LOCAL_REPO="local_repository(\n    name = \\\"gapic_generator_java\\\",\n    path = \\\"..\/gapic-generator-java\/\\\",\n)"
 perl -0777 -pi -e "s/http_archive\(\n    name \= \"gapic_generator_java\"(.*?)\)/$LOCAL_REPO/s" WORKSPACE
 
+# In googleapis/WORKSPACE, find maven_install() rule with artifacts = PROTOBUF_MAVEN_ARTIFACTS,
+# replace with googleapis-dep-string.txt which adds spring dependencies
+perl -0777 -pi -e "s{maven_install\(\n(.*?)artifacts = PROTOBUF_MAVEN_ARTIFACTS(.*?)\)}{$(cat ../googleapis-dep-string.txt)}s" WORKSPACE
+
 cd -
 

--- a/generator/googleapis-dep-string.txt
+++ b/generator/googleapis-dep-string.txt
@@ -1,0 +1,12 @@
+SPRING_MAVEN_ARTIFACTS = [
+    "org.springframework.boot:spring-boot-starter:2.7.4",
+    "com.google.cloud:spring-cloud-gcp-core:3.4.0",
+]
+
+maven_install(
+    artifacts = PROTOBUF_MAVEN_ARTIFACTS + SPRING_MAVEN_ARTIFACTS,
+    generate_compat_repositories = True,
+    repositories = [
+        "https://repo.maven.apache.org/maven2/,"
+    ],
+)


### PR DESCRIPTION
To account for changes in https://github.com/googleapis/gapic-generator-java/pull/1046, Spring related dependencies needs to be added to [WORKSPACE](https://github.com/googleapis/googleapis/blob/38e8b447d173909d3b2fe8fdc3e6cbb3c85442fd/WORKSPACE#L239-L245).
