### PR TITLE
fix(codegen): modify generator scripts after separation of bazel rules

### DIFF
--- a/generator/download-repos.sh
+++ b/generator/download-repos.sh
@@ -9,7 +9,7 @@ git clone https://github.com/googleapis/googleapis.git
 git clone https://github.com/googleapis/gapic-generator-java.git
 # get into gapic and checkout branch to use
 cd gapic-generator-java
-git checkout c51d51bc495ea1284087b66c369dedf741dd4824
+git checkout autoconfig-gen-draft2
 # go back to previous folder
 cd -
 
@@ -24,6 +24,10 @@ git checkout f88ca86
 # and replace with local_repository() rule
 LOCAL_REPO="local_repository(\n    name = \\\"gapic_generator_java\\\",\n    path = \\\"..\/gapic-generator-java\/\\\",\n)"
 perl -0777 -pi -e "s/http_archive\(\n    name \= \"gapic_generator_java\"(.*?)\)/$LOCAL_REPO/s" WORKSPACE
+
+# In googleapis/repository_rules.bzl, add switch for new spring rule
+JAVA_SPRING_SWITCH="    rules[\\\"java_gapic_spring_library\\\"] = _switch(\n        java and grpc and gapic,\n        \\\"\@gapic_generator_java\/\/rules_java_gapic:java_gapic_spring.bzl\\\",\n    )"
+perl -0777 -pi -e "s/(rules\[\"java_gapic_library\"\] \= _switch\((.*?)\))/\$1\n$JAVA_SPRING_SWITCH/s" repository_rules.bzl
 
 cd -
 

--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -47,14 +47,14 @@ SPRING_RULE_NAME="    \\\"java_gapic_spring_library\\\","
 perl -0777 -pi -e "s/(load\((.*?)\"java_gapic_library\",)/\$1\n$SPRING_RULE_NAME/s" google/cloud/$client_lib_name/v1/BUILD.bazel
 # Duplicate java_gapic_library rule definition
 perl -0777 -pi -e "s/(java_gapic_library\((.*?)\))/\$1\n\n\$1/s" google/cloud/$client_lib_name/v1/BUILD.bazel
-# Update rule name to java_apic_spring_library
+# Update rule name to java_gapic_spring_library
 perl -0777 -pi -e "s/(java_gapic_library\()/java_gapic_spring_library\(/s" google/cloud/$client_lib_name/v1/BUILD.bazel
 # Update name argument to have _spring appended
 perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)name = \"(.*?)\")/java_gapic_spring_library\(\$2name = \"\$3_spring\"/s" google/cloud/$client_lib_name/v1/BUILD.bazel
 # todo: better way to remove the following unused arguments?
-perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    test_deps = \[(.*?)\],))/java_gapic_spring_library\(\$2/s" google/cloud/language/v1/BUILD.bazel
-perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    deps = \[(.*?)\],))/java_gapic_spring_library\(\$2/s" google/cloud/language/v1/BUILD.bazel
-perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    rest_numeric_enums = (.*?),))/java_gapic_spring_library\(\$2/s" google/cloud/language/v1/BUILD.bazel
+perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    test_deps = \[(.*?)\],))/java_gapic_spring_library\(\$2/s" google/cloud/$client_lib_name/v1/BUILD.bazel
+perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    deps = \[(.*?)\],))/java_gapic_spring_library\(\$2/s" google/cloud/$client_lib_name/v1/BUILD.bazel
+perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    rest_numeric_enums = (.*?),))/java_gapic_spring_library\(\$2/s" google/cloud/$client_lib_name/v1/BUILD.bazel
 
 # call bazel target
 bazel build //google/cloud/$client_lib_name/v1:"$client_lib_name"_java_gapic_spring


### PR DESCRIPTION
**This PR:** edits generator scripts given the separation of the `java_gapic_spring_library` rule in https://github.com/googleapis/gapic-generator-java/pull/1065 (please see its description for context of edits).

The script now makes local edits to:
- `googleapis/repository_rules.bzl` (add switch)
- `google/cloud/<client_lib_name>/v1/BUILD.bazel` (add rule name to load, and rule definition using similar arguments as `java_gapic_library`)

**Note for review:** the initial goal of these changes is to have something to unblock the code generation workflow, but there's currently a lot of perl mess so any suggestions on cleaner/more reliable file processing would be welcomed!  