### PR TITLE
fix(codegen): remove version replacement for modules.

### DIFF
--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -12,22 +12,6 @@
   <artifactId>generated-parent</artifactId>
   <packaging>pom</packaging>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>spring-cloud-gcp-core</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter</artifactId>
-        <version>${spring-boot-dependencies.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <modules>
   </modules>
 </project>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -12,6 +12,22 @@
   <artifactId>generated-parent</artifactId>
   <packaging>pom</packaging>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>spring-cloud-gcp-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter</artifactId>
+        <version>${spring-boot-dependencies.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <modules>
   </modules>
 </project>

--- a/generator/generate-all.sh
+++ b/generator/generate-all.sh
@@ -2,6 +2,11 @@
 
 WORKING_DIR=`pwd`
 
+cd ../
+# Compute the project version.
+PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+cd generator
+
 # runs generate-one.sh for each entry in library_list.txt
 # repos are downloaded once before all generation jobs and then removed
 
@@ -12,7 +17,7 @@ while IFS=, read -r library_name googleapis_location coordinates_version; do
   group_id=$(echo $coordinates_version | cut -f1 -d:)
   artifact_id=$(echo $coordinates_version | cut -f2 -d:)
   version=$(echo $coordinates_version | cut -f3 -d:)
-  bash $WORKING_DIR/generate-one.sh -c $library_name -v $version -i $artifact_id -g $group_id
+  bash $WORKING_DIR/generate-one.sh -c $library_name -v $version -i $artifact_id -g $group_id -p $PROJECT_VERSION
 done <<< $libraries
 
 rm -rf googleapis

--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -60,7 +60,6 @@ cat "$client_lib_name"/pom.xml
 sed -i 's/{{client-library-group-id}}/'"$client_lib_groupid"'/' "$client_lib_name"/pom.xml
 sed -i 's/{{client-library-artifact-id}}/'"$client_lib_artifactid"'/' "$client_lib_name"/pom.xml
 sed -i 's/{{client-library-version}}/'"$version"'/' "$client_lib_name"/pom.xml
-sed -i 's/{{starter-version}}/0.0.1-SNAPSHOT/' "$client_lib_name"/pom.xml
 
 # add module to parent, adds after the `<modules>` line, checks for existence
 xmllint --debug --nsclean --xpath  "//*[local-name()='module']/text()" pom.xml | sort | uniq | grep -q $client_lib_name

--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -9,13 +9,14 @@
 
 # by default, do not download repos
 download_repos=0
-while getopts c:v:i:g:d: flag
+while getopts c:v:i:g:d:p: flag
 do
     case "${flag}" in
         c) client_lib_name=${OPTARG};;
         v) version=${OPTARG};;
         i) client_lib_artifactid=${OPTARG};;
         g) client_lib_groupid=${OPTARG};;
+        p) parent_version=${OPTARG};;
         d) download_repos=1;;
     esac
 done
@@ -23,6 +24,7 @@ echo "Client Library Name: $client_lib_name";
 echo "Client Library Version: $version";
 echo "Client Library GroupId: $client_lib_groupid";
 echo "Client Library ArtifactId: $client_lib_artifactid";
+echo "Parent Pom Version: $parent_version";
 
 starter_artifactid="$client_lib_artifactid-spring-starter"
 
@@ -60,6 +62,7 @@ cat "$client_lib_name"/pom.xml
 sed -i 's/{{client-library-group-id}}/'"$client_lib_groupid"'/' "$client_lib_name"/pom.xml
 sed -i 's/{{client-library-artifact-id}}/'"$client_lib_artifactid"'/' "$client_lib_name"/pom.xml
 sed -i 's/{{client-library-version}}/'"$version"'/' "$client_lib_name"/pom.xml
+sed -i 's/{{parent-version}}/'"$parent_version"'/' "$client_lib_name"/pom.xml
 
 # add module to parent, adds after the `<modules>` line, checks for existence
 xmllint --debug --nsclean --xpath  "//*[local-name()='module']/text()" pom.xml | sort | uniq | grep -q $client_lib_name


### PR DESCRIPTION
- Remove version replacement for generated modules, these versions should be inferred from parent pom.
- set parent version to project version.
- [x] Also need to adjust relevant placeholder from gapic-generator-java side. https://github.com/googleapis/gapic-generator-java/pull/1099


Using placeholder for parent version for unblocking generation workflow setup. For future improvements:
- Use `revision` to get versions from spring-cloud-gcp parent pom. This will involve changes for all modules with `spring-cloud-gcp` as parent.
