### PR TITLE
draft(codegen): Allow additional scope to be added when creating DefaultCredentialsProvider

### DIFF
--- a/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/DefaultCredentialsProvider.java
+++ b/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/DefaultCredentialsProvider.java
@@ -79,6 +79,17 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
    */
   public DefaultCredentialsProvider(CredentialsSupplier credentialsSupplier) throws IOException {
     List<String> scopes = resolveScopes(credentialsSupplier.getCredentials().getScopes());
+    setUpWrappedCredentialsProvider(credentialsSupplier, scopes);
+  }
+
+  public DefaultCredentialsProvider(CredentialsSupplier credentialsSupplier, List<String> additionalScopes) throws IOException {
+    List<String> scopes = credentialsSupplier.getCredentials().getScopes();
+    scopes.addAll(additionalScopes);
+    setUpWrappedCredentialsProvider(credentialsSupplier, scopes);
+  }
+
+  private void setUpWrappedCredentialsProvider(CredentialsSupplier credentialsSupplier, List<String> scopes)
+      throws IOException {
     Resource providedLocation = credentialsSupplier.getCredentials().getLocation();
     String encodedKey = credentialsSupplier.getCredentials().getEncodedKey();
 
@@ -122,6 +133,7 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
           ioe);
     }
   }
+
 
   static List<String> resolveScopes(List<String> scopes) {
     if (!ObjectUtils.isEmpty(scopes)) {


### PR DESCRIPTION
This meant to be a followup on https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1308#discussion_r1005882327.
So that when creating the CredentialsProvider bean in autoconfig code e.g. in language, instead of [these lines](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/9d22b0222be796f67291991d81573f92d8667157/generated/language/src/main/java/com/google/cloud/language/v1/spring/LanguageServiceSpringAutoConfiguration.java#L81-L86)
```
  public CredentialsProvider languageServiceCredentials() throws IOException {
    if (this.clientProperties.getCredentials().hasKey()) {
      return ((CredentialsProvider) new DefaultCredentialsProvider(this.clientProperties));
    }
    return ((CredentialsProvider) new DefaultCredentialsProvider(this.globalProperties, 
        Arrays.asList("https://www.googleapis.com/auth/cloud-language",
           "https://www.googleapis.com/auth/cloud-platform")));
  }
```

This way, we should be able to keep the global credential scopes empty and still restrict scopes to the ones used.