### PR TITLE
chore: configure dependabot ignores for major version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,28 @@ updates:
   open-pull-requests-limit: 10
   labels:
     - "dependencies"
+  ignore:
+    # Ignore major version updates - these should be made manually
+    - dependency-name: "*"
+      update-types: [ "version-update:semver-major" ]
+    # Ignore formatter dependency versions used in codegen modules, since they are fixed for Java 8 support
+    - dependency-name: "com.coveo:fmt-maven-plugin"
+    - dependency-name: "com.google.googlejavaformat:google-java-format"
+    # Ignore dependencies that will be manually upgraded with Spring Boot 3.0 support: 
+    # Spring Boot dependencies
+    - dependency-name: "org.springframework.boot:spring-boot-dependencies"
+      versions: ["3.x"]
+    - dependency-name: "org.springframework.boot:spring-boot-starter-parent"
+      versions: ["3.x"]
+    # Spring Cloud dependencies
+    - dependency-name: "org.springframework.cloud:spring-cloud-dependencies"
+      versions: ["2022.x"]
+    - dependency-name: "org.springframework.cloud:spring-cloud-config"
+      versions: ["4.x"]
+    - dependency-name: "org.springframework.cloud:spring-cloud-function"
+      versions: ["4.x"]
+    # spring-cloud-dependencies-parent should be eventually removed per #1294
+    - dependency-name: "org.springframework.cloud:spring-cloud-dependencies-parent"
+      versions: ["4.x"]
+    # Spring Native dependencies: 
+    # Will be superseded by Spring Boot 3 official native support

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,5 +30,8 @@ updates:
     # spring-cloud-dependencies-parent should be eventually removed per #1294
     - dependency-name: "org.springframework.cloud:spring-cloud-dependencies-parent"
       versions: ["4.x"]
+    # Spring Shell dependencies
+    - dependency-name: "org.springframework.shell:spring-shell-starter"
+      versions: ["3.x"]
     # Spring Native dependencies: 
     # Will be superseded by Spring Boot 3 official native support


### PR DESCRIPTION
**This PR:**
* Configures dependabot to ignore major version bumps (which will need manual upgrades)
* Similar to [#846](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/846), tracks some dependencies that we will be suppressing dependabots for while working towards support for Spring Boot 3.0 - see [#1280](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1280)
* Also suppresses dependabots for formatter dependencies brought in as part of codegen - see [#1356](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1356)

Previous manually-invoked dependabot ignores:
* spring-boot-dependencies ([#1357](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1357))
* spring-boot-starter-parent ([#1358](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1358))
* google-java-format ([#1361](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1361))
* fmt-maven-plugin ([#1362](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1362))