### PR TITLE
chore: remove doc mention of generated modules before releasing.

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -68,8 +68,6 @@ You do *not* need to include the underlying `spring-cloud-gcp-pubsub` dependency
 
 A summary of these artifacts are provided below.
 
-Aside from these modules, we also provide additional starters with auto-configurations to various Google Client Libraries. Refer for the full list https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/generated/README.md[here].
-
 |===
 | Spring Cloud GCP Starter | Description | Maven Artifact Name
 

--- a/docs/src/main/md/getting-started.md
+++ b/docs/src/main/md/getting-started.md
@@ -79,8 +79,6 @@ dependency includes it.
 
 A summary of these artifacts are provided below. 
 
-Aside from these modules, we also provide additional starters with auto-configurations to various Google Client Libraries. Refer for the full list [here](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/generated/README.md).
-
 | Spring Cloud GCP Starter | Description                                                                       | Maven Artifact Name                                                                                    |
 | ------------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | Core                     | Automatically configure authentication and Google project settings                | [com.google.cloud:spring-cloud-gcp-starter](core.xml#spring-cloud-gcp-core)                            |


### PR DESCRIPTION
This documentation line was added as part of #1336. 
Now that we are releasing more frequently, I think it makes sense to revert this change temporarily until those modules are ready for release.