### PR TITLE
fix: change expected string to reflect client library behavior change.

### DIFF
--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/DocumentOcrTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/DocumentOcrTemplateIntegrationTests.java
@@ -73,10 +73,10 @@ class DocumentOcrTemplateIntegrationTests {
 
     assertThat(pageContent)
         .containsExactly(
-            "Hello World. Is mayonnaise an instrument?\n",
-            "Page 2 stuff\n",
-            "Page 3 stuff\n",
-            "Page 4 stuff\n");
+            "Hello World. Is mayonnaise an instrument?",
+            "Page 2 stuff",
+            "Page 3 stuff",
+            "Page 4 stuff");
   }
 
   @Test


### PR DESCRIPTION
There seems to be some behavior change on the client library side leading to below test failure in our integration tests.
https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/3655598879/jobs/6177106625

Putting in this temp fix to unblock nightly CI test. For long term, perhaps we should make the test more tolerant to these changes?
```
Error:  Failures: 
Error:    DocumentOcrTemplateIntegrationTests.testDocumentOcrTemplate:75 
Expecting actual:
  ["Hello World. Is mayonnaise an instrument?",
    "Page 2 stuff",
    "Page 3 stuff",
    "Page 4 stuff"]
to contain exactly (and in same order):
  ["Hello World. Is mayonnaise an instrument?
",
    "Page 2 stuff
",
    "Page 3 stuff
",
    "Page 4 stuff
"]
but some elements were not found:
  ["Hello World. Is mayonnaise an instrument?
",
    "Page 2 stuff
",
    "Page 3 stuff
",
    "Page 4 stuff
"]
and others were not expected:
  ["Hello World. Is mayonnaise an instrument?",
    "Page 2 stuff",
    "Page 3 stuff",
    "Page 4 stuff"]

[INFO] 
Error:  Tests run: 5, Failures: 1, Errors: 0, Skipped: 0
```