### PR TITLE
fix(codegen): update pattern matching script for replacing bazel arguments

### DIFF
--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -5,7 +5,7 @@
 # note about space consumption: out-of-space testing on cloud shell instance.
 
 # poc with one specified repo - vision
-#cmd line:: ./generate-one.sh -c vision -v 3.1.2 -i google-cloud-vision -g com.google.cloud -d 1
+#cmd line:: ./generate-one.sh -c vision -v 3.1.2 -i google-cloud-vision -g com.google.cloud -p 3.5.0-SNAPSHOT -d 1
 
 # by default, do not download repos
 download_repos=0
@@ -54,8 +54,8 @@ perl -0777 -pi -e "s/(java_gapic_library\()/java_gapic_spring_library\(/s" googl
 # Update name argument to have _spring appended
 perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)name = \"(.*?)\")/java_gapic_spring_library\(\$2name = \"\$3_spring\"/s" google/cloud/$client_lib_name/v1/BUILD.bazel
 # todo: better way to remove the following unused arguments?
-perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    test_deps = \[(.*?)\],))/java_gapic_spring_library\(\$2/s" google/cloud/$client_lib_name/v1/BUILD.bazel
-perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    deps = \[(.*?)\],))/java_gapic_spring_library\(\$2/s" google/cloud/$client_lib_name/v1/BUILD.bazel
+perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    test_deps = \[(.*?)\](.*?),))/java_gapic_spring_library\(\$2/s" google/cloud/$client_lib_name/v1/BUILD.bazel
+perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    deps = \[(.*?)\](.*?),))/java_gapic_spring_library\(\$2/s" google/cloud/$client_lib_name/v1/BUILD.bazel
 perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    rest_numeric_enums = (.*?),))/java_gapic_spring_library\(\$2/s" google/cloud/$client_lib_name/v1/BUILD.bazel
 
 # call bazel target


### PR DESCRIPTION
Fixes perl modification in script to also capture the following pattern, where deps to remove are not only a single list (E.g. [in aiplatform](https://github.com/googleapis/googleapis/blob/f7f499371afaa6fc236b67148aa4bd41943725a6/google/cloud/aiplatform/v1/BUILD.bazel#L178)).

```
  deps = [ ... ] + _ADDITIONAL_DEPS,
  test_deps = [ ... ] + _ADDITIONAL_TEST_DEPS,
```
@zhumin8 opening this against main since I could not find the `attempt-compile-2` branch, but feel free to cherry-pick or copy this commit to include the fix in your working branch!