### PR TITLE
feat: add helper class and util for RetrySettings configuration

### DIFF
--- a/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Retry.java
+++ b/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Retry.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.core;
+
+import org.threeten.bp.Duration;
+
+/** Retry settings configuration. */
+public class Retry {
+  /**
+   * TotalTimeout has ultimate control over how long the logic should keep trying the remote call
+   * until it gives up completely. The higher the total timeout, the more retries can be attempted.
+   */
+  private Duration totalTimeout;
+  /**
+   * InitialRetryDelay controls the delay before the first retry. Subsequent retries will use this
+   * value adjusted according to the RetryDelayMultiplier.
+   */
+  private Duration initialRetryDelay;
+  /**
+   * RetryDelayMultiplier controls the change in retry delay. The retry delay of the previous call
+   * is multiplied by the RetryDelayMultiplier to calculate the retry delay for the next call.
+   */
+  private Double retryDelayMultiplier;
+  /**
+   * MaxRetryDelay puts a limit on the value of the retry delay, so that the RetryDelayMultiplier
+   * can't increase the retry delay higher than this amount.
+   */
+  private Duration maxRetryDelay;
+  /**
+   * MaxAttempts defines the maximum number of attempts to perform. If this value is greater than 0,
+   * and the number of attempts reaches this limit, the logic will give up retrying even if the
+   * total retry time is still lower than TotalTimeout.
+   */
+  private Integer maxAttempts;
+  /**
+   * InitialRpcTimeout controls the timeout for the initial RPC. Subsequent calls will use this
+   * value adjusted according to the RpcTimeoutMultiplier.
+   */
+  private Duration initialRpcTimeout;
+  /**
+   * RpcTimeoutMultiplier controls the change in RPC timeout. The timeout of the previous call is
+   * multiplied by the RpcTimeoutMultiplier to calculate the timeout for the next call.
+   */
+  private Double rpcTimeoutMultiplier;
+  /**
+   * MaxRpcTimeout puts a limit on the value of the RPC timeout, so that the RpcTimeoutMultiplier
+   * can't increase the RPC timeout higher than this amount.
+   */
+  private Duration maxRpcTimeout;
+
+  public Duration getTotalTimeout() {
+    return totalTimeout;
+  }
+
+  public void setTotalTimeout(java.time.Duration totalTimeout) {
+    this.totalTimeout = Duration.parse(totalTimeout.toString());
+  }
+
+  public Duration getInitialRetryDelay() {
+    return initialRetryDelay;
+  }
+
+  public void setInitialRetryDelay(java.time.Duration initialRetryDelay) {
+    this.initialRetryDelay = Duration.parse(initialRetryDelay.toString());
+  }
+
+  public Double getRetryDelayMultiplier() {
+    return retryDelayMultiplier;
+  }
+
+  public void setRetryDelayMultiplier(Double retryDelayMultiplier) {
+    this.retryDelayMultiplier = retryDelayMultiplier;
+  }
+
+  public Duration getMaxRetryDelay() {
+    return maxRetryDelay;
+  }
+
+  public void setMaxRetryDelay(java.time.Duration maxRetryDelay) {
+    this.maxRetryDelay = Duration.parse(maxRetryDelay.toString());
+  }
+
+  public Integer getMaxAttempts() {
+    return maxAttempts;
+  }
+
+  public void setMaxAttempts(Integer maxAttempts) {
+    this.maxAttempts = maxAttempts;
+  }
+
+  public Duration getInitialRpcTimeout() {
+    return initialRpcTimeout;
+  }
+
+  public void setInitialRpcTimeout(java.time.Duration initialRpcTimeout) {
+    this.initialRpcTimeout = Duration.parse(initialRpcTimeout.toString());
+  }
+
+  public Double getRpcTimeoutMultiplier() {
+    return rpcTimeoutMultiplier;
+  }
+
+  public void setRpcTimeoutMultiplier(Double rpcTimeoutMultiplier) {
+    this.rpcTimeoutMultiplier = rpcTimeoutMultiplier;
+  }
+
+  public Duration getMaxRpcTimeout() {
+    return maxRpcTimeout;
+  }
+
+  public void setMaxRpcTimeout(java.time.Duration maxRpcTimeout) {
+    this.maxRpcTimeout = Duration.parse(maxRpcTimeout.toString());
+  }
+}

--- a/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Retry.java
+++ b/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Retry.java
@@ -16,9 +16,11 @@
 
 package com.google.cloud.spring.core;
 
+import com.google.api.core.InternalApi;
 import org.threeten.bp.Duration;
 
 /** Retry settings configuration. */
+@InternalApi
 public class Retry {
   /**
    * TotalTimeout has ultimate control over how long the logic should keep trying the remote call

--- a/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/util/RetryUtil.java
+++ b/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/util/RetryUtil.java
@@ -16,10 +16,12 @@
 
 package com.google.cloud.spring.core.util;
 
+import com.google.api.core.InternalApi;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.spring.core.Retry;
 
 /** Utility methods for retry settings. */
+@InternalApi
 public class RetryUtil {
 
   private RetryUtil() {}

--- a/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/util/RetryUtil.java
+++ b/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/util/RetryUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.core.util;
+
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.cloud.spring.core.Retry;
+
+/** Utility methods for retry settings. */
+public class RetryUtil {
+
+  private RetryUtil() {}
+
+  /**
+   * Updates a {@link RetrySettings} based on configuration properties.
+   *
+   * @param oldRetrySettings the existing {@link RetrySettings} object to update
+   * @param newRetry the {@link Retry} object containing configured property override values
+   * @return the updated {@link RetrySettings} object
+   */
+  public static RetrySettings updateRetrySettings(
+      RetrySettings oldRetrySettings, Retry newRetry) {
+    RetrySettings.Builder builder = oldRetrySettings.toBuilder();
+    if (newRetry.getTotalTimeout() != null) {
+      builder.setTotalTimeout(newRetry.getTotalTimeout());
+    }
+    if (newRetry.getInitialRetryDelay() != null) {
+      builder.setInitialRetryDelay(newRetry.getInitialRetryDelay());
+    }
+    if (newRetry.getRetryDelayMultiplier() != null) {
+      builder.setRetryDelayMultiplier(newRetry.getRetryDelayMultiplier());
+    }
+    if (newRetry.getMaxRetryDelay() != null) {
+      builder.setMaxRetryDelay(newRetry.getMaxRetryDelay());
+    }
+    if (newRetry.getMaxAttempts() != null) {
+      builder.setMaxAttempts(newRetry.getMaxAttempts());
+    }
+    if (newRetry.getInitialRpcTimeout() != null) {
+      builder.setInitialRpcTimeout(newRetry.getInitialRpcTimeout());
+    }
+    if (newRetry.getRpcTimeoutMultiplier() != null) {
+      builder.setRpcTimeoutMultiplier(newRetry.getRpcTimeoutMultiplier());
+    }
+    if (newRetry.getMaxRpcTimeout() != null) {
+      builder.setMaxRpcTimeout(newRetry.getMaxRpcTimeout());
+    }
+    return builder.build();
+  }
+}

--- a/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/RetryUtilTests.java
+++ b/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/RetryUtilTests.java
@@ -32,6 +32,7 @@ class RetryUtilTests {
   private static final double TEST_MULTIPLIER_FIVE = 5.0;
   private static final double TEST_MULTIPLIER_THREE = 3.0;
   private static final double TEST_MULTIPLIER_ONE = 1.0;
+  private static final int TEST_MAX_ATTEMPTS = 2;
 
   @Test
   void testAllSettingsUpdatedAsExpected() {
@@ -44,6 +45,7 @@ class RetryUtilTests {
     newRetry.setMaxRpcTimeout(TEST_DURATION);
     newRetry.setRpcTimeoutMultiplier(TEST_MULTIPLIER_FIVE);
     newRetry.setTotalTimeout(TEST_DURATION);
+    newRetry.setMaxAttempts(TEST_MAX_ATTEMPTS);
 
     RetrySettings updated = RetryUtil.updateRetrySettings(oldRetrySettings, newRetry);
 
@@ -56,6 +58,7 @@ class RetryUtilTests {
     assertThat(updated.getMaxRpcTimeout()).isEqualTo(TEST_DURATION_BP);
     assertThat(updated.getRpcTimeoutMultiplier()).isEqualTo(TEST_MULTIPLIER_FIVE);
     assertThat(updated.getTotalTimeout()).isEqualTo(TEST_DURATION_BP);
+    assertThat(updated.getMaxAttempts()).isEqualTo(TEST_MAX_ATTEMPTS);
   }
 
   @Test
@@ -86,5 +89,6 @@ class RetryUtilTests {
     assertThat(updated.getRpcTimeoutMultiplier())
         .isEqualTo(oldRetrySettings.getRpcTimeoutMultiplier());
     assertThat(updated.getTotalTimeout()).isEqualTo(oldRetrySettings.getTotalTimeout());
+    assertThat(updated.getMaxAttempts()).isEqualTo(oldRetrySettings.getMaxAttempts());
   }
 }

--- a/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/RetryUtilTests.java
+++ b/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/RetryUtilTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.core.util;
+
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.cloud.spring.core.Retry;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link RetryUtil}. */
+public class RetryUtilTests {
+
+  private static final Duration TEST_DURATION = Duration.ofSeconds(5);
+  private static final org.threeten.bp.Duration TEST_DURATION_BP =
+      org.threeten.bp.Duration.ofSeconds(5);
+  private static final double TEST_MULTIPLIER_FIVE = 5.0;
+  private static final double TEST_MULTIPLIER_THREE = 3.0;
+  private static final double TEST_MULTIPLIER_ONE = 1.0;
+
+  @Test
+  void testAllSettingsUpdatedAsExpected() {
+    RetrySettings oldRetrySettings = RetrySettings.newBuilder().build();
+    Retry newRetry = new Retry();
+    newRetry.setInitialRetryDelay(TEST_DURATION);
+    newRetry.setMaxRetryDelay(TEST_DURATION);
+    newRetry.setRetryDelayMultiplier(TEST_MULTIPLIER_FIVE);
+    newRetry.setInitialRpcTimeout(TEST_DURATION);
+    newRetry.setMaxRpcTimeout(TEST_DURATION);
+    newRetry.setRpcTimeoutMultiplier(TEST_MULTIPLIER_FIVE);
+    newRetry.setTotalTimeout(TEST_DURATION);
+
+    RetrySettings updated = RetryUtil.updateRetrySettings(oldRetrySettings, newRetry);
+
+    // Old RetrySettings should differ from updated object returned
+    assertThat(updated).isNotEqualTo(oldRetrySettings);
+    assertThat(updated.getInitialRetryDelay()).isEqualTo(TEST_DURATION_BP);
+    assertThat(updated.getMaxRetryDelay()).isEqualTo(TEST_DURATION_BP);
+    assertThat(updated.getRetryDelayMultiplier()).isEqualTo(TEST_MULTIPLIER_FIVE);
+    assertThat(updated.getInitialRpcTimeout()).isEqualTo(TEST_DURATION_BP);
+    assertThat(updated.getMaxRpcTimeout()).isEqualTo(TEST_DURATION_BP);
+    assertThat(updated.getRpcTimeoutMultiplier()).isEqualTo(TEST_MULTIPLIER_FIVE);
+    assertThat(updated.getTotalTimeout()).isEqualTo(TEST_DURATION_BP);
+  }
+
+  @Test
+  void testNotConfiguredSettingsNotUpdated() {
+    RetrySettings oldRetrySettings =
+        RetrySettings.newBuilder()
+            .setRetryDelayMultiplier(TEST_MULTIPLIER_THREE)
+            .setRpcTimeoutMultiplier(TEST_MULTIPLIER_THREE)
+            .build();
+    Retry newRetry = new Retry();
+    newRetry.setInitialRetryDelay(TEST_DURATION);
+    newRetry.setMaxRetryDelay(TEST_DURATION);
+    newRetry.setRetryDelayMultiplier(TEST_MULTIPLIER_ONE);
+
+    RetrySettings updated = RetryUtil.updateRetrySettings(oldRetrySettings, newRetry);
+
+    // Old RetrySettings should differ from updated object returned
+    assertThat(updated).isNotEqualTo(oldRetrySettings);
+
+    // Set fields should take on new values
+    assertThat(updated.getInitialRetryDelay()).isEqualTo(TEST_DURATION_BP);
+    assertThat(updated.getMaxRetryDelay()).isEqualTo(TEST_DURATION_BP);
+    assertThat(updated.getRetryDelayMultiplier()).isEqualTo(TEST_MULTIPLIER_ONE);
+
+    // Unset fields should take on values from old RetrySettings object
+    assertThat(updated.getInitialRpcTimeout()).isEqualTo(oldRetrySettings.getInitialRpcTimeout());
+    assertThat(updated.getMaxRpcTimeout()).isEqualTo(oldRetrySettings.getMaxRpcTimeout());
+    assertThat(updated.getRpcTimeoutMultiplier())
+        .isEqualTo(oldRetrySettings.getRpcTimeoutMultiplier());
+    assertThat(updated.getTotalTimeout()).isEqualTo(oldRetrySettings.getTotalTimeout());
+  }
+}

--- a/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/RetryUtilTests.java
+++ b/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/RetryUtilTests.java
@@ -16,12 +16,12 @@
 
 package com.google.cloud.spring.core.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.spring.core.Retry;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link RetryUtil}. */
 public class RetryUtilTests {

--- a/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/RetryUtilTests.java
+++ b/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/util/RetryUtilTests.java
@@ -24,7 +24,7 @@ import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link RetryUtil}. */
-public class RetryUtilTests {
+class RetryUtilTests {
 
   private static final Duration TEST_DURATION = Duration.ofSeconds(5);
   private static final org.threeten.bp.Duration TEST_DURATION_BP =


### PR DESCRIPTION
This PR adds a helper class and util used by https://github.com/googleapis/gapic-generator-java/pull/1140. It defines:
- `Retry` class with getters and setters that enable updating a `RetrySettings` object through spring properties
- `RetryUtil` class that contain merge logic (conditioning to only overwrite fields in the old `RetrySettings` when a new value is configured).