### PR TITLE
Fixes docs related to keeping a background user thread - pub/sub

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -326,7 +326,7 @@ h|subscribeAndConvert(String subscription,
 [NOTE]
 ====
 As of version 1.2, subscribing by itself is not enough to keep an application running.
-For a command-line application, a way to keep the application running is to have a user thread(non-daemon thread). A dummy scheduled task creates a threadpool with non-daemon threads:
+For a command-line application, a way to keep the application running is to have a user thread(non-daemon thread) started up. A dummy scheduled task creates a threadpool with non-daemon threads:
 [source,java,indent=0]
 ----
 @Scheduled (fixedRate = 1, timeUnit = TimeUnit.MINUTES)

--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -323,9 +323,20 @@ h|subscribeAndConvert(String subscription,
  			Class<T> payloadType) | same as `pull`, but converts message payload to `payloadType` using the converter configured in the template
 |===
 
-NOTE: As of version 1.2, subscribing by itself is not enough to keep an application running.
-For a command-line application, you may want to provide your own `ThreadPoolTaskScheduler` bean named `pubsubSubscriberThreadPool`, which by default creates non-daemon threads that will keep an application from stopping.
-This default behavior has been overridden in Spring Framework on Google Cloud for consistency with Cloud Pub/Sub client library, and to avoid holding up command-line applications that would like to shut down once their work is done.
+[NOTE]
+====
+As of version 1.2, subscribing by itself is not enough to keep an application running.
+For a command-line application, a way to keep the application running is to have a user thread(non-daemon thread). A dummy scheduled task creates a threadpool with non-daemon threads:
+[source,java,indent=0]
+----
+@Scheduled (fixedRate = 1, timeUnit = TimeUnit.MINUTES)
+public void dummyScheduledTask() {
+    // do nothing
+}
+----
+Another option is to pull in `spring-boot-starter-web` or `spring-boot-starter-webflux` as a dependency which will start an embedded servlet container or reactive server keeping the application running in the background
+
+====
 
 ==== Pulling messages from a subscription
 

--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -326,11 +326,11 @@ h|subscribeAndConvert(String subscription,
 [NOTE]
 ====
 As of version 1.2, subscribing by itself is not enough to keep an application running.
-For a command-line application, a way to keep the application running is to have a user thread(non-daemon thread) started up. A dummy scheduled task creates a threadpool with non-daemon threads:
+For a command-line application, a way to keep the application running is to have a user thread(non-daemon thread) started up. A fake scheduled task creates a threadpool with non-daemon threads:
 [source,java,indent=0]
 ----
 @Scheduled (fixedRate = 1, timeUnit = TimeUnit.MINUTES)
-public void dummyScheduledTask() {
+public void fakeScheduledTask() {
     // do nothing
 }
 ----

--- a/docs/src/main/md/pubsub.md
+++ b/docs/src/main/md/pubsub.md
@@ -376,16 +376,17 @@ Subscriber subscriber =
 | **subscribeAndConvert(String subscription, Consumer\<ConvertedBasicAcknowledgeablePubsubMessage\<T\>\> messageConsumer, Class\<T\> payloadType)** | same as `pull`, but converts message payload to `payloadType` using the converter configured in the template |
 
 <div class="note">
+As of version 1.2, subscribing by itself is not enough to keep an application running.
+For a command-line application, a way to keep the application running is to have a user thread(non-daemon thread) started up. A dummy scheduled task creates a threadpool with non-daemon threads:
 
-As of version 1.2, subscribing by itself is not enough to keep an
-application running. For a command-line application, you may want to
-provide your own `ThreadPoolTaskScheduler` bean named
-`pubsubSubscriberThreadPool`, which by default creates non-daemon
-threads that will keep an application from stopping. This default
-behavior has been overridden in Spring Framework on Google Cloud for consistency with
-Cloud Pub/Sub client library, and to avoid holding up command-line
-applications that would like to shut down once their work is done.
+```java
+@Scheduled (fixedRate = 1, timeUnit = TimeUnit.MINUTES)
+public void dummyScheduledTask() {
+    // do nothing
+}
+```
 
+Another option is to pull in `spring-boot-starter-web` or `spring-boot-starter-webflux` as a dependency which will start an embedded servlet container or reactive server keeping the application running in the background
 </div>
 
 #### Pulling messages from a subscription

--- a/docs/src/main/md/pubsub.md
+++ b/docs/src/main/md/pubsub.md
@@ -377,11 +377,11 @@ Subscriber subscriber =
 
 <div class="note">
 As of version 1.2, subscribing by itself is not enough to keep an application running.
-For a command-line application, a way to keep the application running is to have a user thread(non-daemon thread) started up. A dummy scheduled task creates a threadpool with non-daemon threads:
+For a command-line application, a way to keep the application running is to have a user thread(non-daemon thread) started up. A fake scheduled task creates a threadpool with non-daemon threads:
 
 ```java
 @Scheduled (fixedRate = 1, timeUnit = TimeUnit.MINUTES)
-public void dummyScheduledTask() {
+public void fakeScheduledTask() {
     // do nothing
 }
 ```


### PR DESCRIPTION
Fixes docs related to keeping a background user thread for command-line applications. This is based on the discussions in #1182 