### PR TITLE
codegen: fix for bazel upgrade issue

### DIFF
--- a/generator/generate-one.sh
+++ b/generator/generate-one.sh
@@ -68,7 +68,7 @@ perl -0777 -pi -e "s/(java_gapic_spring_library\((.*?)(\n    rest_numeric_enums 
 
 echo "CALL BAZEL TARGET"
 # call bazel target
-bazel build //$googleapis_folder:"$client_lib_name"_java_gapic_spring
+bazelisk build //$googleapis_folder:"$client_lib_name"_java_gapic_spring
 
 cd -
 


### PR DESCRIPTION
Based on `gapic-generator-java` and `googleapis` both have bazel version fixed:
- https://github.com/googleapis/gapic-generator-java/pull/1164/files
- https://github.com/googleapis/googleapis/blob/4834b4c97ed2577db072d645df393ee246328ee3/.bazeliskrc#L2

This change should be enough for our script to pickup these versions.