### PR TITLE
fix(codegen): update dependency string replacement

### DIFF
--- a/spring-cloud-generator/googleapis-dep-string.txt
+++ b/spring-cloud-generator/googleapis-dep-string.txt
@@ -1,6 +1,6 @@
 SPRING_MAVEN_ARTIFACTS = [
     "org.springframework.boot:spring-boot-starter:2.7.4",
-    "com.google.cloud:spring-cloud-gcp-core:3.4.0",
+    "com.google.cloud:spring-cloud-gcp-autoconfigure:3.4.1",
 ]
 
 maven_install(


### PR DESCRIPTION
This PR goes together with https://github.com/googleapis/gapic-generator-java/pull/1208 in switching dependency from `spring-cloud-gcp-core` to `spring-cloud-gcp-autoconfigure`.