### PR TITLE
cicd(codegen): Fix sonar ignore

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -49,7 +49,7 @@ jobs:
             --batch-mode \
             --show-version \
             --threads 1.5C \
-            --activate-profiles codecov \
+            --activate-profiles codecov,-default \
             clean \
             install
       - name: Retry Install on Failure
@@ -60,7 +60,7 @@ jobs:
             --batch-mode \
             --show-version \
             --threads 1.5C \
-            --activate-profiles codecov \
+            --activate-profiles codecov,-default \
             clean \
             install
       - name: Build and analyze
@@ -71,7 +71,7 @@ jobs:
         run: |
           ./mvnw \
             --batch-mode \
-            --activate-profiles codecov \
+            --activate-profiles codecov,-default \
             --define sonar.projectKey=GoogleCloudPlatform_spring-cloud-gcp \
             --define sonar.host.url=https://sonarcloud.io \
             --define sonar.organization=googlecloudplatform \
@@ -84,7 +84,7 @@ jobs:
         run: |
           ./mvnw \
             --batch-mode \
-            --activate-profiles codecov \
+            --activate-profiles codecov,-default \
             --define sonar.projectKey=GoogleCloudPlatform_spring-cloud-gcp \
             --define sonar.host.url=https://sonarcloud.io \
             --define sonar.organization=googlecloudplatform \

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -6,8 +6,6 @@ on:
       - 2.x
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-    - 'spring-cloud-previews/**'
   workflow_dispatch:
   schedule:
     - cron: '00 6 * * *' # 06:00 UTC every day

--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,36 @@
 		<!-- Code Coverage -->
 		<profile>
 			<id>codecov</id>
+			<modules>
+
+				<!-- POM Modules-->
+				<module>spring-cloud-gcp-starters</module>
+				<module>spring-cloud-gcp-dependencies</module>
+
+				<!-- Code Modules -->
+				<module>spring-cloud-gcp-autoconfigure</module>
+				<module>spring-cloud-gcp-bigquery</module>
+				<module>spring-cloud-gcp-cloudfoundry</module>
+				<module>spring-cloud-gcp-core</module>
+				<module>spring-cloud-gcp-data-datastore</module>
+				<module>spring-cloud-gcp-data-firestore</module>
+				<module>spring-cloud-gcp-data-spanner</module>
+				<module>spring-cloud-gcp-logging</module>
+				<module>spring-cloud-gcp-pubsub</module>
+				<module>spring-cloud-gcp-pubsub-stream-binder</module>
+				<module>spring-cloud-gcp-security-iap</module>
+				<module>spring-cloud-gcp-storage</module>
+				<module>spring-cloud-gcp-secretmanager</module>
+				<module>spring-cloud-gcp-security-firebase</module>
+				<module>spring-cloud-gcp-vision</module>
+				<module>spring-cloud-gcp-kms</module>
+				<module>spring-cloud-gcp-native-support</module>
+
+				<!-- Docs and Samples -->
+				<module>docs</module>
+				<module>spring-cloud-gcp-samples</module>
+
+			</modules>
 			<build>
 				<plugins>
 					<plugin>
@@ -451,6 +481,7 @@
 							<excludes>
 								<exclude>**/Abstract*.java</exclude>
 								<exclude>${integration-test.pattern}</exclude>
+<!--								<exclude>spring-cloud-previews/**</exclude>-->
 							</excludes>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
**Goal**: to skip sonar checks on `spring-cloud-previews` modules. Do not affect other check on other modules.
**Previous attempt**: #1416 - added to ignore path; 
**Issue**: sonar ignores any changes in `spring-cloud-previews/` folder, but sonar check is set as required to merge into main branch. So PRs with changes in `spring-cloud-previews` modules (manual unit test changes, generated code) won’t be able to merge. (e.g.#1418)
**Solution**: 
- revert `paths-ignore` changes in #1416
- add list of modules to include for `codecov` (copied from `default` profile except `spring-cloud-previews`), and alter `sonar.yaml` to deactivate `default` profile when running.

**Concern**: If new changes existing modules occurs, needs to change both modules in `default` profile and `codecov` profile.