### PR TITLE
feat: use googleapis commitish

### DIFF
--- a/spring-cloud-generator/download-repos.sh
+++ b/spring-cloud-generator/download-repos.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-
 # get googleapis repo
 git clone https://github.com/googleapis/googleapis.git
-
 # Prepare `gapic-generator-java` with Spring generation ability.
 # If keeping a copy in this repo, this is not needed.
 # Checkout `gapic-generator-java`
@@ -10,28 +8,6 @@ git clone https://github.com/googleapis/gapic-generator-java.git
 # get into gapic and checkout branch to use
 cd gapic-generator-java
 git checkout autoconfig-gen-draft2
+git pull origin autoconfig-gen-draft2
 # go back to previous folder
 cd -
-
-
-cd googleapis
-# fix googleapis committish for test/dev purpose
-git checkout f88ca86
-# todo: change to local repo --> gapic
-# very not stable change - todo: change to search and replace.
-
-# In googleapis/WORKSPACE, find http_archive() rule with name = "gapic_generator_java",
-# and replace with local_repository() rule
-LOCAL_REPO="local_repository(\n    name = \\\"gapic_generator_java\\\",\n    path = \\\"..\/gapic-generator-java\/\\\",\n)"
-perl -0777 -pi -e "s/http_archive\(\n    name \= \"gapic_generator_java\"(.*?)\)/$LOCAL_REPO/s" WORKSPACE
-
-# In googleapis/WORKSPACE, find maven_install() rule with artifacts = PROTOBUF_MAVEN_ARTIFACTS,
-# replace with googleapis-dep-string.txt which adds spring dependencies
-perl -0777 -pi -e "s{maven_install\(\n(.*?)artifacts = PROTOBUF_MAVEN_ARTIFACTS(.*?)\)}{$(cat ../googleapis-dep-string.txt)}s" WORKSPACE
-
-# In googleapis/repository_rules.bzl, add switch for new spring rule
-JAVA_SPRING_SWITCH="    rules[\\\"java_gapic_spring_library\\\"] = _switch(\n        java and grpc and gapic,\n        \\\"\@gapic_generator_java\/\/rules_java_gapic:java_gapic_spring.bzl\\\",\n    )"
-perl -0777 -pi -e "s/(rules\[\"java_gapic_library\"\] \= _switch\((.*?)\))/\$1\n$JAVA_SPRING_SWITCH/s" repository_rules.bzl
-
-cd -
-

--- a/spring-cloud-generator/generate-one.sh
+++ b/spring-cloud-generator/generate-one.sh
@@ -7,8 +7,6 @@ set -e
 # poc with one specified repo - vision
 #cmd line:: ./generate-one.sh -c vision -v 3.1.2 -i google-cloud-vision -g com.google.cloud -p 3.5.0-SNAPSHOT -d 1
 
-#set -x
-
 # by default, do not download repos
 download_repos=0
 while getopts c:v:i:g:d:p:f: flag

--- a/spring-cloud-generator/generate-one.sh
+++ b/spring-cloud-generator/generate-one.sh
@@ -47,21 +47,9 @@ if [[ $download_repos -eq 1 ]]; then
   bash download-repos.sh
 fi
 
+bash setup-googleapis-rules.sh -x $googleapis_commitish
+
 cd googleapis
-git reset --hard $googleapis_commitish
-
-# In googleapis/WORKSPACE, find http_archive() rule with name = "gapic_generator_java",
-# and replace with local_repository() rule
-LOCAL_REPO="local_repository(\n    name = \\\"gapic_generator_java\\\",\n    path = \\\"..\/gapic-generator-java\/\\\",\n)"
-perl -0777 -pi -e "s/http_archive\(\n    name \= \"gapic_generator_java\"(.*?)\)/$LOCAL_REPO/s" WORKSPACE
-
-# In googleapis/WORKSPACE, find maven_install() rule with artifacts = PROTOBUF_MAVEN_ARTIFACTS,
-# replace with googleapis-dep-string.txt which adds spring dependencies
-perl -0777 -pi -e "s{maven_install\(\n(.*?)artifacts = PROTOBUF_MAVEN_ARTIFACTS(.*?)\)}{$(cat ../googleapis-dep-string.txt)}s" WORKSPACE
-
-# In googleapis/repository_rules.bzl, add switch for new spring rule
-JAVA_SPRING_SWITCH="    rules[\\\"java_gapic_spring_library\\\"] = _switch(\n        java and grpc and gapic,\n        \\\"\@gapic_generator_java\/\/rules_java_gapic:java_gapic_spring.bzl\\\",\n    )"
-perl -0777 -pi -e "s/(rules\[\"java_gapic_library\"\] \= _switch\((.*?)\))/\$1\n$JAVA_SPRING_SWITCH/s" repository_rules.bzl
 
 ## If $googleapis_folder does not exist, exit
 if [ ! -d "$googleapis_folder" ]

--- a/spring-cloud-generator/setup-googleapis-rules.sh
+++ b/spring-cloud-generator/setup-googleapis-rules.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+while getopts x: flag
+do
+    case "${flag}" in
+        x) googleapis_commitish=${OPTARG};;
+    esac
+done
+
+if [[ -z $googleapis_commitish ]]; then
+  echo 'usage setup-googleapis-rules.sh -x GOOGLEAPIS_COMMITISH'
+  exit 1
+fi
+
+cd googleapis
+git reset --hard $googleapis_commitish
+
+# In googleapis/WORKSPACE, find http_archive() rule with name = "gapic_generator_java",
+# and replace with local_repository() rule
+LOCAL_REPO="local_repository(\n    name = \\\"gapic_generator_java\\\",\n    path = \\\"..\/gapic-generator-java\/\\\",\n)"
+perl -0777 -pi -e "s/http_archive\(\n    name \= \"gapic_generator_java\"(.*?)\)/$LOCAL_REPO/s" WORKSPACE
+
+# In googleapis/WORKSPACE, find maven_install() rule with artifacts = PROTOBUF_MAVEN_ARTIFACTS,
+# replace with googleapis-dep-string.txt which adds spring dependencies
+perl -0777 -pi -e "s{maven_install\(\n(.*?)artifacts = PROTOBUF_MAVEN_ARTIFACTS(.*?)\)}{$(cat ../googleapis-dep-string.txt)}s" WORKSPACE
+
+# In googleapis/repository_rules.bzl, add switch for new spring rule
+JAVA_SPRING_SWITCH="    rules[\\\"java_gapic_spring_library\\\"] = _switch(\n        java and grpc and gapic,\n        \\\"\@gapic_generator_java\/\/rules_java_gapic:java_gapic_spring.bzl\\\",\n    )"
+perl -0777 -pi -e "s/(rules\[\"java_gapic_library\"\] \= _switch\((.*?)\))/\$1\n$JAVA_SPRING_SWITCH/s" repository_rules.bzl
+
+cd -


### PR DESCRIPTION
For each library, a hard reset is performed towards the specified commitish. The repo setup previously done in download-repos.sh was moved to generate-one.sh. The hard reset is also due to WORKSPACE and repository_rules changing between commits.