### PR TITLE
feat: specify bazel version in googleapis

### DIFF
--- a/spring-cloud-generator/generate-one.sh
+++ b/spring-cloud-generator/generate-one.sh
@@ -44,6 +44,8 @@ if [[ $download_repos -eq 1 ]]; then
 fi
 
 cd googleapis
+# tell bazelisk to use bazel version 4.2.2
+echo '4.2.2' > .bazelversion
 
 ## If $googleapis_folder does not exist, exit
 if [ ! -d "$googleapis_folder" ]


### PR DESCRIPTION
Uses a `.bazelversion` file as explained in [bazelisk docs](https://github.com/bazelbuild/bazelisk#how-does-bazelisk-know-which-bazel-version-to-run)