### PR TITLE
chore: cleanup from 1407

### DIFF
--- a/spring-cloud-generator/generate-one.sh
+++ b/spring-cloud-generator/generate-one.sh
@@ -46,6 +46,7 @@ fi
 bash setup-googleapis-rules.sh -x $googleapis_commitish
 
 cd googleapis
+
 ## If $googleapis_folder does not exist, exit
 if [ ! -d "$googleapis_folder" ]
 then

--- a/spring-cloud-generator/generate-one.sh
+++ b/spring-cloud-generator/generate-one.sh
@@ -9,7 +9,7 @@ set -e
 
 # by default, do not download repos
 download_repos=0
-while getopts c:v:i:g:d:p:f: flag
+while getopts c:v:i:g:d:p:f:x: flag
 do
     case "${flag}" in
         c) client_lib_name=${OPTARG};;
@@ -46,7 +46,6 @@ fi
 bash setup-googleapis-rules.sh -x $googleapis_commitish
 
 cd googleapis
-
 ## If $googleapis_folder does not exist, exit
 if [ ! -d "$googleapis_folder" ]
 then
@@ -97,9 +96,10 @@ sed -i 's/{{parent-version}}/'"$parent_version"'/' "$starter_artifactid"/pom.xml
 # add module after line with pattern, check for existence. Also add readme line if $3 is set to 1.
 # args: 1 -  path-to-pom-file; 2 - string-pattern; 3 - 1 if need to generate readme line
 add_module_to_pom () {
-  xmllint --debug --nsclean --xpath  "//*[local-name()='module']/text()" $1 | sort | uniq | grep -q $starter_artifactid
+  xmllint --debug --nsclean --xpath  "//*[local-name()='module']/text()" $1 \
+    | sort | uniq | grep -q $starter_artifactid || module_list_is_empty=1
   found_library_in_pom=$?
-  if [[ found_library_in_pom -eq 0 ]]; then
+  if [[ found_library_in_pom -eq 0 ]] && [[ $module_list_is_empty -ne 1 ]]; then
     echo "module $starter_artifactid already found in $1 modules"
   else
     echo "adding module $starter_artifactid to pom"
@@ -113,7 +113,7 @@ add_module_to_pom () {
   fi
 }
 
-add_module_to_pom pom.xml "^  <modules>" 1
+add_module_to_pom ../spring-cloud-previews/pom.xml "^[[:space:]]*<!-- preview modules -->" 1
 
 # remove downloaded repos
 cd ../spring-cloud-generator

--- a/spring-cloud-generator/generate-one.sh
+++ b/spring-cloud-generator/generate-one.sh
@@ -114,7 +114,7 @@ add_module_to_pom () {
   fi
 }
 
-add_module_to_pom ../spring-cloud-previews/pom.xml "^[[:space:]]*<!-- preview modules -->" 1
+add_module_to_pom pom.xml "^[[:space:]]*<modules>" 1
 
 # remove downloaded repos
 cd ../spring-cloud-generator

--- a/spring-cloud-previews/pom.xml
+++ b/spring-cloud-previews/pom.xml
@@ -13,6 +13,7 @@
   <packaging>pom</packaging>
 
   <modules>
+    <!-- preview modules -->
   </modules>
 
   <build>


### PR DESCRIPTION
This PR cleans up the various changes made in #1407. Two fixes were made

The source of changes was moved to https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1422 for which several PRs were made and
are now either closed or merged (https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1430, https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1428, https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1427, https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1426, https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1425
, https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1424). https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1423 has not been merged as https://github.com/googleapis/gapic-generator-java/pull/1212 will
invalidate this fix

The found (and fixed) errors were:
* the call to `xmllint` did not handle an empty `<modules>` list,
causing the module addition function to fail in `generate-one`
* missing `OPTARG` key `-x`, for commitish in `generate-one`