### PR TITLE
chore: remove unnecessary optarg handling in `generate-library-list.sh`

### DIFF
--- a/spring-cloud-generator/generate-all.sh
+++ b/spring-cloud-generator/generate-all.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 WORKING_DIR=`pwd`
 
-while getopts d: flag
-do
-    case "${flag}" in
-        d) dev_env=1;;
-    esac
-done
-
 cd ../
 # Compute the project version.
 PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/spring-cloud-generator/generate-library-list.sh
+++ b/spring-cloud-generator/generate-library-list.sh
@@ -2,12 +2,6 @@
 
 #cmd line:: ./generate-library-list.sh -c v1.1.0
 
-while getopts c: flag
-do
-    case "${flag}" in
-        c) commitish=${OPTARG};;
-    esac
-done
 echo "monorepo commitish to checkout: $commitish";
 
 

--- a/spring-cloud-generator/generate-library-list.sh
+++ b/spring-cloud-generator/generate-library-list.sh
@@ -2,6 +2,12 @@
 
 #cmd line:: ./generate-library-list.sh -c v1.1.0
 
+while getopts c: flag
+do
+    case "${flag}" in
+        c) commitish=${OPTARG};;
+    esac
+done
 echo "monorepo commitish to checkout: $commitish";
 
 


### PR DESCRIPTION
Initially brought by #1424, intended to handle a dev-env workflow that was later [deleted](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1424/commits/0da05fa43f104c7d74a751dc4c4d08cddadce494) (do `mvn install` in root). This is now unnecessary.