### PR TITLE
Fix typo in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ You can check our project website https://spring.io/projects/spring-cloud-gcp[he
 For a deep dive into the project, refer to the Spring Framework on Google Cloud Reference documentation below or the https://googleapis.dev/java/spring-cloud-gcp/latest/index.html[latest Javadocs].
 
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/reference/html/index.html[Spring Framework on Google Cloud Latest]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.4.0/reference/html/index.html[SSpring Framework on Google Cloud 3.4.0]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.4.0/reference/html/index.html[Spring Framework on Google Cloud 3.4.0]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/2.0.11/reference/html/index.html[Spring Framework on Google Cloud 2.0.11]
 
 If you prefer to learn by doing, try taking a look at the https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples[Spring Framework on Google Cloud sample applications] or the https://codelabs.developers.google.com/spring[Spring on Google Cloud codelabs].


### PR DESCRIPTION
There is an extra 'S' in the link for Spring Framework on Google Cloud 3.4.0