### PR TITLE
test(codegen): set top-level mock credentials for language-starter module unit tests

### DIFF
--- a/spring-cloud-previews/google-cloud-language-spring-starter/src/test/java/com/google/cloud/language/v1/spring/LanguageAutoConfigurationTests.java
+++ b/spring-cloud-previews/google-cloud-language-spring-starter/src/test/java/com/google/cloud/language/v1/spring/LanguageAutoConfigurationTests.java
@@ -61,7 +61,9 @@ class LanguageAutoConfigurationTests {
       new ApplicationContextRunner()
           .withConfiguration(
               AutoConfigurations.of(
-                  GcpContextAutoConfiguration.class, LanguageServiceSpringAutoConfiguration.class));
+                  GcpContextAutoConfiguration.class, LanguageServiceSpringAutoConfiguration.class))
+          .withPropertyValues(
+              "spring.cloud.gcp.credentials.location=file:" + TOP_LEVEL_CREDENTIAL_LOCATION);
 
   @Test
   void testLanguageServiceClientCreated() {
@@ -76,7 +78,6 @@ class LanguageAutoConfigurationTests {
   void testCredentials_fromServicePropertiesIfSpecified() {
     this.contextRunner
         .withPropertyValues(
-            "spring.cloud.gcp.credentials.location=file:" + TOP_LEVEL_CREDENTIAL_LOCATION,
             "com.google.cloud.language.v1.language-service.credentials.location=file:"
                 + SERVICE_CREDENTIAL_LOCATION)
         .run(
@@ -91,17 +92,13 @@ class LanguageAutoConfigurationTests {
 
   @Test
   void testCredentials_fromTopLevelIfNoServiceProperties() {
-    this.contextRunner
-        .withPropertyValues(
-            "spring.cloud.gcp.credentials.location=file:" + TOP_LEVEL_CREDENTIAL_LOCATION)
-        .run(
-            ctx -> {
-              LanguageServiceClient client = ctx.getBean(LanguageServiceClient.class);
-              Credentials credentials =
-                  client.getSettings().getCredentialsProvider().getCredentials();
-              assertThat(((ServiceAccountCredentials) credentials).getClientId())
-                  .isEqualTo(TOP_LEVEL_CREDENTIAL_CLIENT_ID);
-            });
+    this.contextRunner.run(
+        ctx -> {
+          LanguageServiceClient client = ctx.getBean(LanguageServiceClient.class);
+          Credentials credentials = client.getSettings().getCredentialsProvider().getCredentials();
+          assertThat(((ServiceAccountCredentials) credentials).getClientId())
+              .isEqualTo(TOP_LEVEL_CREDENTIAL_CLIENT_ID);
+        });
   }
 
   @Test

--- a/spring-cloud-previews/google-cloud-language-spring-starter/src/test/java/com/google/cloud/language/v1/spring/LanguageAutoConfigurationTests.java
+++ b/spring-cloud-previews/google-cloud-language-spring-starter/src/test/java/com/google/cloud/language/v1/spring/LanguageAutoConfigurationTests.java
@@ -18,6 +18,7 @@ package com.google.cloud.language.v1.spring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.api.gax.core.CredentialsProvider;
@@ -37,8 +38,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
 import org.threeten.bp.Duration;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,7 +64,8 @@ class LanguageAutoConfigurationTests {
       new ApplicationContextRunner()
           .withConfiguration(
               AutoConfigurations.of(
-                  GcpContextAutoConfiguration.class, LanguageServiceSpringAutoConfiguration.class));
+                  GcpContextAutoConfiguration.class, LanguageServiceSpringAutoConfiguration.class))
+          .withUserConfiguration(TestConfiguration.class);
 
   @Test
   void testLanguageServiceClientCreated() {
@@ -363,5 +367,14 @@ class LanguageAutoConfigurationTests {
               assertThat(analyzeSentimentRetrySettings.getMaxAttempts())
                   .isEqualTo(customServiceMaxAttempts);
             });
+  }
+
+  /** Spring Boot config for tests. */
+  @AutoConfigurationPackage
+  static class TestConfiguration {
+    @Bean
+    public CredentialsProvider credentialsProvider() {
+      return () -> mock(Credentials.class);
+    }
   }
 }

--- a/spring-cloud-previews/google-cloud-language-spring-starter/src/test/java/com/google/cloud/language/v1/spring/LanguageAutoConfigurationTests.java
+++ b/spring-cloud-previews/google-cloud-language-spring-starter/src/test/java/com/google/cloud/language/v1/spring/LanguageAutoConfigurationTests.java
@@ -18,7 +18,6 @@ package com.google.cloud.language.v1.spring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.api.gax.core.CredentialsProvider;
@@ -38,10 +37,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 import org.threeten.bp.Duration;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,8 +61,7 @@ class LanguageAutoConfigurationTests {
       new ApplicationContextRunner()
           .withConfiguration(
               AutoConfigurations.of(
-                  GcpContextAutoConfiguration.class, LanguageServiceSpringAutoConfiguration.class))
-          .withUserConfiguration(TestConfiguration.class);
+                  GcpContextAutoConfiguration.class, LanguageServiceSpringAutoConfiguration.class));
 
   @Test
   void testLanguageServiceClientCreated() {
@@ -367,14 +363,5 @@ class LanguageAutoConfigurationTests {
               assertThat(analyzeSentimentRetrySettings.getMaxAttempts())
                   .isEqualTo(customServiceMaxAttempts);
             });
-  }
-
-  /** Spring Boot config for tests. */
-  @AutoConfigurationPackage
-  static class TestConfiguration {
-    @Bean
-    public CredentialsProvider credentialsProvider() {
-      return () -> mock(Credentials.class);
-    }
   }
 }


### PR DESCRIPTION
This PR patches unit tests added in #1355 to all have mock top-level credentials configured. 
@zhumin8 thanks for catching this - feel free to cherry-pick commit 312e42a to unblock your CI testing.
