### PR TITLE
codegen: remove path to ignore for sonar.

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -6,8 +6,6 @@ on:
       - 2.x
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-    - 'spring-cloud-previews/**'
   workflow_dispatch:
   schedule:
     - cron: '00 6 * * *' # 06:00 UTC every day


### PR DESCRIPTION
This reverts change in [cffaa6e](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1416/commits/cffaa6e164c7d39bb0675592f80412d2f46d3b55) to unblock a few prs pending on sonar check.

The above change does not work because sonar check is required to merge into main, and the ignore would result in sonar check pending. (e.g. #1443, #1433)

In the meantime, working on alternatives to set jacoco exclude to skip coverage tests for generated code (#1446).