### PR TITLE
chore: fix generate-docs.sh NoSuchFileException

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,7 +23,7 @@
 		<upload-docs-zip.phase>none</upload-docs-zip.phase>
 
 		<!--maven-resources-plugin:3.2.0:copy-resources fails: https://issues.apache.org/jira/browse/MSHARED-966-->
-		<maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
+		<maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
Reverting the maven-resources-plugin version upgrade to fix the `NoSuchFileException`.