### PR TITLE
chore(ci): Fix CodeQL-Analyze check

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,6 +39,11 @@ jobs:
       id: date
       run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
 
+    - name: Setup Java JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+
     - name: Checkout repository
       uses: actions/checkout@v2
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,6 +42,7 @@ jobs:
     - name: Setup Java JDK
       uses: actions/setup-java@v3
       with:
+        distribution: 'temurin'
         java-version: '17'
 
     - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'java' ]
-        java: [ 17 ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
@@ -38,7 +37,7 @@ jobs:
     steps:
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+      run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
 
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -59,7 +58,6 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        java-version: ${{ matrix.java }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
After a major bump in Spring Cloud GCP, the CodeQL-Analyze check failed with invalid target release. The root cause is Java 11 used to compile the code but Java 17 is required.

In this PR:
- setup Java 17
- setup JDK distribution