### PR TITLE
chore(codegen): additional replacement logic in googleapis workspace file

### DIFF
--- a/spring-cloud-generator/googleapis-gapic-string.txt
+++ b/spring-cloud-generator/googleapis-gapic-string.txt
@@ -1,0 +1,3 @@
+load("\@gapic_generator_java//:repositories.bzl", "gapic_generator_java_repositories")
+
+gapic_generator_java_repositories()

--- a/spring-cloud-generator/setup-googleapis-rules.sh
+++ b/spring-cloud-generator/setup-googleapis-rules.sh
@@ -21,7 +21,16 @@ perl -0777 -pi -e "s/http_archive\(\n    name \= \"gapic_generator_java\"(.*?)\)
 
 # In googleapis/WORKSPACE, find maven_install() rule with artifacts = PROTOBUF_MAVEN_ARTIFACTS,
 # replace with googleapis-dep-string.txt which adds spring dependencies
-perl -0777 -pi -e "s{maven_install\(\n(.*?)artifacts = PROTOBUF_MAVEN_ARTIFACTS(.*?)\)}{$(cat ../googleapis-dep-string.txt)}s" WORKSPACE
+perl -0777 -pi -e "s{maven_install\(\n    artifacts = PROTOBUF_MAVEN_ARTIFACTS(.*?)\)}{$(cat ../googleapis-dep-string.txt)}s" WORKSPACE
+
+# In googleapis/WORKSPACE, find maven_install() rule for gapic-generator-java jar, and remove
+perl -0777 -pi -e "s{maven_install\(\n    artifacts = \[(.*?)_gapic_generator_java_version(.*?)\](.*?)\)}{}s" WORKSPACE
+
+# In googleapis/WORKSPACE, add back lines for gapic_generator_java_repositories() if not found
+if ! grep -q -F "gapic_generator_java_repositories()" WORKSPACE; then
+  perl -0777 -pi -e "s{(grpc_java_repositories\(\))}{\$1\n\n$(cat ../googleapis-gapic-string.txt)}s" WORKSPACE
+fi
+
 
 # In googleapis/repository_rules.bzl, add switch for new spring rule
 JAVA_SPRING_SWITCH="    rules[\\\"java_gapic_spring_library\\\"] = _switch(\n        java and grpc and gapic,\n        \\\"\@gapic_generator_java\/\/rules_java_gapic:java_gapic_spring.bzl\\\",\n    )"


### PR DESCRIPTION
This PR unblocks generation script [errors](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/3953287474) when pointing to more recent googleapis committish. This is due to a change in `googleapis/WORKSPACE` ([d7e8de7](https://github.com/googleapis/googleapis/commit/d7e8de775ab827293821077c6c198b32a51260ff)) that modified this file to maven install the gapic-generator-java jar. The spring codegen workflow still relies on editing this to use a locally installed branch of `gapic_generator_java`. 
- This patch adds logic to remove the  `maven_install()` block and add back `gapic_generator_java_repositories()`. 

Note that the longer-term to address this to migrating the spring generator code out of the `gapic-generator-java` repo, and switching to using the `gapic-generator-java` jar.