### PR TITLE
chore(codegen): remove temp output file and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ mail.properties
 .settings/
 .sts4-cache/
 
+# Ignore to avoid pushing maven wrapper jar as binary artifact
+.mvn/wrapper/maven-wrapper.jar
+
 # Because re-configuring the directory in the share plugin leads to side effect we ignore the file
 dependency-reduced-pom.xml
 .factorypath

--- a/spring-cloud-generator/generate-all.sh
+++ b/spring-cloud-generator/generate-all.sh
@@ -42,6 +42,7 @@ while IFS=, read -r library_name googleapis_location coordinates_version googlea
     -z $monorepo_commitish 2>&1 | tee tmp-generate-one-output || save_error_info $library_name
   set +o pipefail
 done <<< $libraries
+rm tmp-generate-one-output
 
 echo "run google-java-format on generated code"
 cd ../spring-cloud-previews


### PR DESCRIPTION
This PR addresses two cleanup items to go along with the Github Action setup in #1341:

- Updates `.gitignore` to ignore the maven wrapper jar
- Removes `tmp-generate-one-output` at the end of generation script workflow.

