### PR TITLE
chore(deps): restore maven resources plugin

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,7 +23,7 @@
 		<upload-docs-zip.phase>none</upload-docs-zip.phase>
 
 		<!--maven-resources-plugin:3.2.0:copy-resources fails: https://issues.apache.org/jira/browse/MSHARED-966-->
-		<maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
+		<maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
Restore the maven resources plugin to 3.1.0 in `3.x` branch as there's a [bug](https://issues.apache.org/jira/browse/MSHARED-966) in 3.3.0.