### PR TITLE
test(codegen): adjust formatting for unit test

### DIFF
--- a/spring-cloud-previews/google-cloud-language-spring-starter/src/test/java/com/google/cloud/language/v1/spring/LanguageAutoConfigurationTests.java
+++ b/spring-cloud-previews/google-cloud-language-spring-starter/src/test/java/com/google/cloud/language/v1/spring/LanguageAutoConfigurationTests.java
@@ -50,7 +50,8 @@ class LanguageAutoConfigurationTests {
   private static final String SERVICE_CREDENTIAL_CLIENT_ID = "45678";
   private static final String TOP_LEVEL_CREDENTIAL_CLIENT_ID = "12345";
   private static final String SERVICE_OVERRIDE_CLIENT_ID = "56789";
-  private static final String TRANSPORT_CHANNEL_PROVIDER_QUALIFIER_NAME = "defaultLanguageServiceTransportChannelProvider";
+  private static final String TRANSPORT_CHANNEL_PROVIDER_QUALIFIER_NAME =
+      "defaultLanguageServiceTransportChannelProvider";
 
   @Mock private TransportChannel mockTransportChannel;
   @Mock private ApiCallContext mockApiCallContext;
@@ -110,10 +111,9 @@ class LanguageAutoConfigurationTests {
             () -> mockTransportChannelProvider)
         .run(
             ctx -> {
-              assertThat(ctx.getBeanNamesForType(
-                  TransportChannelProvider.class)).containsExactlyInAnyOrder(
-                  "anotherTransportChannelProvider",
-                  TRANSPORT_CHANNEL_PROVIDER_QUALIFIER_NAME);
+              assertThat(ctx.getBeanNamesForType(TransportChannelProvider.class))
+                  .containsExactlyInAnyOrder(
+                      "anotherTransportChannelProvider", TRANSPORT_CHANNEL_PROVIDER_QUALIFIER_NAME);
               LanguageServiceClient client = ctx.getBean(LanguageServiceClient.class);
               TransportChannelProvider transportChannelProviderBean =
                   (TransportChannelProvider) ctx.getBean(TRANSPORT_CHANNEL_PROVIDER_QUALIFIER_NAME);
@@ -123,7 +123,6 @@ class LanguageAutoConfigurationTests {
               assertThat(transportChannelProvider).isNotSameAs(mockTransportChannelProvider);
             });
   }
-
 
   @Test
   void testShouldUseDefaultTransportChannelProvider() {


### PR DESCRIPTION
This PR fixes formatting of the manually written unit test file so that it is consistent with the formatter run for generated modules. This way, the process of generation will not introduce modification to this file. The corresponding change is removed from the auto-generated PR #1517 in [731923a](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1517/commits/731923af4f40427e3cc083b36b3a7de5ce092f4c).