### PR TITLE
chore: update dependabot PR title

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     interval: daily
   commit-message:
     # Prefix all commit messages with "deps: "
-    prefix: "deps: "
+    prefix: "deps"
   open-pull-requests-limit: 10
   labels:
     - "dependencies"
@@ -26,7 +26,7 @@ updates:
     interval: daily
   commit-message:
     # Prefix all commit messages with "deps: "
-    prefix: "deps: "
+    prefix: "deps"
   open-pull-requests-limit: 10
   target-branch: "3.x"
   labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     interval: daily
   commit-message:
     # Prefix all commit messages with "deps: "
-    prefix: "deps"
+    prefix: "deps: "
   open-pull-requests-limit: 10
   labels:
     - "dependencies"
@@ -26,7 +26,7 @@ updates:
     interval: daily
   commit-message:
     # Prefix all commit messages with "deps: "
-    prefix: "deps"
+    prefix: "deps: "
   open-pull-requests-limit: 10
   target-branch: "3.x"
   labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  commit-message:
+    # Prefix all commit messages with "deps: "
+    prefix: "deps"
   open-pull-requests-limit: 10
   labels:
     - "dependencies"
@@ -21,6 +24,9 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  commit-message:
+    # Prefix all commit messages with "deps: "
+    prefix: "deps"
   open-pull-requests-limit: 10
   target-branch: "3.x"
   labels:


### PR DESCRIPTION
For dependabot-generated PRs, change the title prefix to `deps: `. 