### PR TITLE
chore(codegen): fix script issues with readme and residual files

### DIFF
--- a/spring-cloud-generator/generate-all.sh
+++ b/spring-cloud-generator/generate-all.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 WORKING_DIR=`pwd`
 
-mkdir -p run-sanity-check
-touch run-sanity-check/generate-all-started
 monorepo_commitish="v$(bash compute-monorepo-tag.sh)"
 
 cd ../

--- a/spring-cloud-generator/generate-one.sh
+++ b/spring-cloud-generator/generate-one.sh
@@ -112,7 +112,7 @@ add_module_to_pom () {
     if [[ ${3:-1} -eq 1 ]]; then
       # we need to remove any previously existing entries so the entry points to the
       # right $monorepo_commitish's readme
-      sed -i "/$starter_artifactid/d" README.md
+      sed -i "/com.google.cloud:$starter_artifactid/d" README.md
       # also write to spring-cloud-previews/README.md
       # format |name|distribution name|
       echo -e "|[$monorepo_folder](https://github.com/googleapis/google-cloud-java/blob/$monorepo_commitish/$monorepo_folder/README.md)|com.google.cloud:$starter_artifactid|" >> README.md

--- a/spring-cloud-generator/generate-one.sh
+++ b/spring-cloud-generator/generate-one.sh
@@ -110,9 +110,6 @@ add_module_to_pom () {
     echo "adding module $starter_artifactid to pom"
     sed -i "/$2/a\ \ \ \ <module>"$starter_artifactid"</module>" $1
     if [[ ${3:-1} -eq 1 ]]; then
-      # we need to remove any previously existing entries so the entry points to the
-      # right $monorepo_commitish's readme
-      sed -i "/com.google.cloud:$starter_artifactid/d" README.md
       # also write to spring-cloud-previews/README.md
       # format |name|distribution name|
       echo -e "|[$monorepo_folder](https://github.com/googleapis/google-cloud-java/blob/$monorepo_commitish/$monorepo_folder/README.md)|com.google.cloud:$starter_artifactid|" >> README.md

--- a/spring-cloud-generator/spring-cloud-previews-template/README.md
+++ b/spring-cloud-generator/spring-cloud-previews-template/README.md
@@ -2,9 +2,9 @@
 
 Please see below for a list of additional preview starters provided, with dependencies and auto-configurations to work with corresponding Google Client Libraries.
 
-These starters are not included in the Spring Framework on Google Cloud Bill of Materials (BOM),
-and should be explicitly added as dependencies. For example, to use the starter for Cloud Natural Language,
-add the following dependency to your `pom.xml`:
+These starters are not included in the Spring Framework on Google Cloud Bill of Materials (BOM), 
+and should be explicitly added as dependencies. For example, to use the starter for Cloud Natural Language, 
+add the following dependency to your `pom.xml`.
 
 ```xml
   <dependency>

--- a/spring-cloud-previews/README.md
+++ b/spring-cloud-previews/README.md
@@ -4,7 +4,7 @@ Please see below for a list of additional preview starters provided, with depend
 
 These starters are not included in the Spring Framework on Google Cloud Bill of Materials (BOM), 
 and should be explicitly added as dependencies. For example, to use the starter for Cloud Natural Language, 
-add the following dependency to your `pom.xml`:
+add the following dependency to your `pom.xml`.
 
 ```xml
   <dependency>


### PR DESCRIPTION
This PR fixes [two items](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1528#issue-1558203562) that needed to be manually patched in the latest generated PR (#1528):

- Residual file from earlier sanity check WIP (#1498)
- Two places where updating README breaks given the current pattern matching logic:
  * Removing entries by matching on `$starter_artifactid` alone also removes the line that contains it in the sample dependency snippet above
  * Sorting entries pattern-matched on lines containing `:`, which caused issue when lines containing `:` were added in the descriptive section of the readme. Replaced this punctuation as a quick fix, but will need to look into a replacement for the regex going forward.
  
Added context for each change in in-line comments below.
