### PR TITLE
chore: copy missing metadata from parent pom to spring-cloud-gcp-dependencies pom

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -17,6 +17,11 @@
 		<tag>HEAD</tag>
 	</scm>
 
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues</url>
+	</issueManagement>
+
 	<distributionManagement>
 		<snapshotRepository>
 			<id>ossrh</id>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -7,7 +7,15 @@
 	<version>4.0.0-SNAPSHOT</version><!-- {x-version-update:spring-cloud-gcp:current} -->
 	<name>Spring Framework on Google Cloud Dependencies</name>
 	<description>Spring Framework on Google Cloud Dependencies</description>
+	<url>https://spring.io/projects/spring-cloud-gcp</url>
 	<packaging>pom</packaging>
+
+	<scm>
+		<url>https://github.com/GoogleCloudPlatform/spring-cloud-gcp</url>
+		<connection>scm:git:git://github.com/GoogleCloudPlatform/spring-cloud-gcp.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/GoogleCloudPlatform/spring-cloud-gcp.git</developerConnection>
+		<tag>HEAD</tag>
+	</scm>
 
 	<distributionManagement>
 		<snapshotRepository>


### PR DESCRIPTION
After removal of [spring-cloud-dependencies as parent](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/482c2f586533010ee3c0d92b0d733bcd9d47d044/spring-cloud-gcp-dependencies/pom.xml#L5-L10), copy over scm, url, and issueManagement metadata from root pom.

```
[ERROR]   Rule "pom-staging" failures
[ERROR]     * Invalid POM: /com/google/cloud/spring-cloud-gcp-dependencies/4.0.0/spring-cloud-gcp-dependencies-4.0.0.pom: Project URL missing, SCM URL missing
```