### PR TITLE
chore(codegen): update auto-generated commit and pr title by gh action

### DIFF
--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -110,7 +110,7 @@ jobs:
         run: |
           set -x
           # stashes the source branch with generated libs 
-          MESSAGE=`echo "chore(codegen): update starter modules in spring-cloud-preview"`
+          MESSAGE=`echo "chore: update starter modules in spring-cloud-preview"`
           git stash push -- spring-cloud-previews/
           git reset --hard
           git remote update

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -110,7 +110,7 @@ jobs:
         run: |
           set -x
           # stashes the source branch with generated libs 
-          MESSAGE=`echo "feat(generated): Generate new autoconfig libraries"`
+          MESSAGE=`echo "chore(codegen): update starter modules in spring-cloud-preview"`
           git stash push -- spring-cloud-previews/
           git reset --hard
           git remote update


### PR DESCRIPTION
A small change to update the commit message and PR title generated by the codegen github action, since future PRs will be updating the modules existing in main. 
- Defaulting prefix to chore, reviewer of the generated PR can override if needed.

Note: this PR is not a blocker for the 4.0.0 release.