### PR TITLE
ci: workaround for kotlin sample by specifying system properties

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -12,7 +12,7 @@ on:
 
 env:
   # Workaround for kotlin sample multithreading issue: https://youtrack.jetbrains.com/issue/KT-43894
-  MAVEN_OPTS: "-Didea.home.path=${{ runner.temp }} -Didea.ignore.disabled.plugins=true"
+  MAVEN_OPTS: "-Didea.home.path=${{ vars.RUNNER_TEMP }} -Didea.ignore.disabled.plugins=true"
 jobs:
   sonar:
     name: Build with Sonar

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '00 6 * * *' # 06:00 UTC every day
 
+env:
+  # Workaround for kotlin sample multithreading issue: https://youtrack.jetbrains.com/issue/KT-43894
+  MAVEN_OPTS: "-Didea.home.path=${{ env.RUNNER_TEMP }} -Didea.ignore.disabled.plugins=true"
 jobs:
   sonar:
     name: Build with Sonar

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -12,7 +12,7 @@ on:
 
 env:
   # Workaround for kotlin sample multithreading issue: https://youtrack.jetbrains.com/issue/KT-43894
-  MAVEN_OPTS: "-Didea.home.path=${{ env.RUNNER_TEMP }} -Didea.ignore.disabled.plugins=true"
+  MAVEN_OPTS: "-Didea.home.path=${{ runner.temp }} -Didea.ignore.disabled.plugins=true"
 jobs:
   sonar:
     name: Build with Sonar

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -12,7 +12,7 @@ on:
 
 env:
   # Workaround for kotlin sample multithreading issue: https://youtrack.jetbrains.com/issue/KT-43894
-  MAVEN_OPTS: "-Didea.home.path=${{ env.RUNNER_TEMP }} -Didea.ignore.disabled.plugins=true"
+  MAVEN_OPTS: "-Didea.home.path=${{ runner.temp }} -Didea.ignore.disabled.plugins=true"
 jobs:
   unitTests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -12,7 +12,7 @@ on:
 
 env:
   # Workaround for kotlin sample multithreading issue: https://youtrack.jetbrains.com/issue/KT-43894
-  MAVEN_OPTS: "-Didea.home.path=${{ runner.temp }} -Didea.ignore.disabled.plugins=true"
+  MAVEN_OPTS: "-Didea.home.path=${{ vars.RUNNER_TEMP }} -Didea.ignore.disabled.plugins=true"
 jobs:
   unitTests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -10,7 +10,9 @@ on:
   schedule:
     - cron: '05 7 * * *' # 07:00 UTC every day
 
-
+env:
+  # Workaround for kotlin sample multithreading issue: https://youtrack.jetbrains.com/issue/KT-43894
+  MAVEN_OPTS: "-Didea.home.path=${{ env.RUNNER_TEMP }} -Didea.ignore.disabled.plugins=true"
 jobs:
   unitTests:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Fixes #1537 (hopefully).

We have been observing these flakes more consistently in unitTest and sonar workflows. From discussion in https://youtrack.jetbrains.com/issue/KT-43894, it seems like our multi-threaded mvn commands for unit test and sonar workflows are leading to a race condition on system properties, between the behaviour of [kotlin-maven-plugin](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/dccc57c6619734a98201bcafdc0aa12197161903/spring-cloud-gcp-samples/spring-cloud-gcp-kotlin-samples/pom.xml#L29) and [maven-surefire-plugin](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/dccc57c6619734a98201bcafdc0aa12197161903/spring-cloud-gcp-samples/pom.xml#L141) in the kotlin samples.

This PR adds a suggested workaround from the discussion (I've also triggered a few extra workflow run iterations from the presubmits).