### PR TITLE
chore: update publish_javadoc.sh

### DIFF
--- a/.kokoro/publish_javadoc.cfg
+++ b/.kokoro/publish_javadoc.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
 }
 
 env_vars: {

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -5,7 +5,8 @@ if [[ -z "${CREDENTIALS}" ]]; then
   CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
 fi
 
-pyenv versions 
+pyenv install 3.7.2
+pyenv global 3.7.2
 
 # # Get into the spring-cloud-gcp repo directory
 # dir=$(dirname "$0")

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -5,37 +5,37 @@ if [[ -z "${CREDENTIALS}" ]]; then
   CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
 fi
 
-pyenv global 3.7.2
+pyenv -v 
 
-# Get into the spring-cloud-gcp repo directory
-dir=$(dirname "$0")
-pushd $dir/../
+# # Get into the spring-cloud-gcp repo directory
+# dir=$(dirname "$0")
+# pushd $dir/../
 
-# change to release version
-./mvnw versions:set --batch-mode -DremoveSnapshot -DprocessAllModules
+# # change to release version
+# ./mvnw versions:set --batch-mode -DremoveSnapshot -DprocessAllModules
 
-# Compute the project version.
-PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+# # Compute the project version.
+# PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
 
-# Install docuploader package
-python3 -m pip install --upgrade six
-python3 -m pip install --upgrade protobuf
-python3 -m pip install gcp-docuploader
+# # Install docuploader package
+# python3 -m pip install --upgrade six
+# python3 -m pip install --upgrade protobuf
+# python3 -m pip install gcp-docuploader
 
-# Build the javadocs
-./mvnw clean javadoc:aggregate -Drelease=true
+# # Build the javadocs
+# ./mvnw clean javadoc:aggregate -Drelease=true
 
-# Move into generated docs directory
-pushd target/site/apidocs/
+# # Move into generated docs directory
+# pushd target/site/apidocs/
 
-python3 -m docuploader create-metadata \
-    --name spring-cloud-gcp \
-    --version ${PROJECT_VERSION} \
-    --language java
+# python3 -m docuploader create-metadata \
+#     --name spring-cloud-gcp \
+#     --version ${PROJECT_VERSION} \
+#     --language java
 
-python3 -m docuploader upload . \
-    --credentials ${CREDENTIALS} \
-    --staging-bucket docs-staging
+# python3 -m docuploader upload . \
+#     --credentials ${CREDENTIALS} \
+#     --staging-bucket docs-staging
 
-popd
-popd
+# popd
+# popd

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -8,35 +8,32 @@ fi
 pyenv install 3.7.2
 pyenv global 3.7.2
 
-# # Get into the spring-cloud-gcp repo directory
-# dir=$(dirname "$0")
-# pushd $dir/../
+# Get into the spring-cloud-gcp repo directory
+dir=$(dirname "$0")
+pushd $dir/../
 
-# # change to release version
-# ./mvnw versions:set --batch-mode -DremoveSnapshot -DprocessAllModules
+# Compute the project version.
+PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
 
-# # Compute the project version.
-# PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+# Install docuploader package
+python3 -m pip install --upgrade six
+python3 -m pip install --upgrade protobuf
+python3 -m pip install gcp-docuploader
 
-# # Install docuploader package
-# python3 -m pip install --upgrade six
-# python3 -m pip install --upgrade protobuf
-# python3 -m pip install gcp-docuploader
+# Build the javadocs
+./mvnw clean javadoc:aggregate -Drelease=true
 
-# # Build the javadocs
-# ./mvnw clean javadoc:aggregate -Drelease=true
+# Move into generated docs directory
+pushd target/site/apidocs/
 
-# # Move into generated docs directory
-# pushd target/site/apidocs/
+python3 -m docuploader create-metadata \
+     --name spring-cloud-gcp \
+     --version ${PROJECT_VERSION} \
+     --language java
 
-# python3 -m docuploader create-metadata \
-#     --name spring-cloud-gcp \
-#     --version ${PROJECT_VERSION} \
-#     --language java
+python3 -m docuploader upload . \
+     --credentials ${CREDENTIALS} \
+     --staging-bucket docs-staging
 
-# python3 -m docuploader upload . \
-#     --credentials ${CREDENTIALS} \
-#     --staging-bucket docs-staging
-
-# popd
-# popd
+popd
+popd

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -5,9 +5,6 @@ if [[ -z "${CREDENTIALS}" ]]; then
   CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
 fi
 
-pyenv install 3.7.2
-pyenv global 3.7.2
-
 # Get into the spring-cloud-gcp repo directory
 dir=$(dirname "$0")
 pushd $dir/../
@@ -21,19 +18,19 @@ python3 -m pip install --upgrade protobuf
 python3 -m pip install gcp-docuploader
 
 # Build the javadocs
-./mvnw clean javadoc:aggregate -Drelease=true
-
-# Move into generated docs directory
-pushd target/site/apidocs/
-
-python3 -m docuploader create-metadata \
-     --name spring-cloud-gcp \
-     --version ${PROJECT_VERSION} \
-     --language java
-
-python3 -m docuploader upload . \
-     --credentials ${CREDENTIALS} \
-     --staging-bucket docs-staging
+#./mvnw clean javadoc:aggregate -Drelease=true
+#
+## Move into generated docs directory
+#pushd target/site/apidocs/
+#
+#python3 -m docuploader create-metadata \
+#     --name spring-cloud-gcp \
+#     --version ${PROJECT_VERSION} \
+#     --language java
+#
+#python3 -m docuploader upload . \
+#     --credentials ${CREDENTIALS} \
+#     --staging-bucket docs-staging
 
 popd
 popd

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -5,7 +5,7 @@ if [[ -z "${CREDENTIALS}" ]]; then
   CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
 fi
 
-pyenv -v 
+pyenv versions 
 
 # # Get into the spring-cloud-gcp repo directory
 # dir=$(dirname "$0")

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -18,19 +18,19 @@ python3 -m pip install --upgrade protobuf
 python3 -m pip install gcp-docuploader
 
 # Build the javadocs
-#./mvnw clean javadoc:aggregate -Drelease=true
-#
+./mvnw clean javadoc:aggregate -Drelease=true
+
 ## Move into generated docs directory
-#pushd target/site/apidocs/
-#
-#python3 -m docuploader create-metadata \
-#     --name spring-cloud-gcp \
-#     --version ${PROJECT_VERSION} \
-#     --language java
-#
-#python3 -m docuploader upload . \
-#     --credentials ${CREDENTIALS} \
-#     --staging-bucket docs-staging
+pushd target/site/apidocs/
+
+python3 -m docuploader create-metadata \
+     --name spring-cloud-gcp \
+     --version ${PROJECT_VERSION} \
+     --language java
+
+python3 -m docuploader upload . \
+     --credentials ${CREDENTIALS} \
+     --staging-bucket docs-staging
 
 popd
 popd


### PR DESCRIPTION
Current `publish_javadoc.sh` was complaining about pyenv 3.7.2 not installed. 

![image](https://user-images.githubusercontent.com/90280028/215828520-d61e8b82-2be8-4afb-95ea-3dfa430b91b7.png)

Default pyenv version on the image is 2.3.9

![image](https://user-images.githubusercontent.com/90280028/215829339-f272de63-9b2e-4d0b-be6c-9adba5864482.png)

The changes here include installing pyenv 3.7.2 and using it. 

I've also skipped the remove snapshot step that we don't need anymore - 
`./mvnw versions:set --batch-mode -DremoveSnapshot -DprocessAllModules` 
