### PR TITLE
chore: updating image to java17 for javadoc publishing

### DIFF
--- a/.kokoro/publish_javadoc.cfg
+++ b/.kokoro/publish_javadoc.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java17"
 }
 
 env_vars: {


### PR DESCRIPTION
The build failed. We need jdk17 for this build too.

![image](https://user-images.githubusercontent.com/90280028/215865620-a6c1cc23-4e1a-4513-bd5c-f894a26cde63.png)
