### PR TITLE
feat: enable `SecretManagerTemplate` bean by default

### DIFF
--- a/docs/src/main/asciidoc/migration-guide-3.x.adoc
+++ b/docs/src/main/asciidoc/migration-guide-3.x.adoc
@@ -64,7 +64,7 @@ Replaced `ListenableFuture` and `SettableListenableFuture` with `CompletableFutu
 Change to functional model as annotation-based model is removed from Spring Cloud Stream 4.0.0.
 
 ==== Secret Manager
-To enable the application to fetch a secret from SecretManager, add `spring.config.import=sm://` in the `application.properties` or `application.yml` files and inject the secret into the application by adding `application.secret=${sm://your-secret-name}`.
+Inject the secret into the application by adding `application.secret=${sm://your-secret-name}` in the `application.properties` or `application.yml` files.
 Do not write secret values in the file.
 
 Please also remove `spring.cloud.gcp.secretmanager.enabled` and `spring.cloud.gcp.secretmanager.legacy` in `bootstrap.yml` or `bootstrap.properties` files.

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -101,6 +101,7 @@ The `SecretManagerTemplate` class simplifies operations of creating, updating, a
 
 To begin using this class, you may inject an instance of the class using `@Autowired` after adding the starter dependency to your project.
 
+Note that you should add `spring.config.import=sm://` in your `application.properties` file to enable `SecretManagerTemplate` bean creation.
 [source, java]
 ----
 @Autowired

--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -49,8 +49,6 @@ If set to `true`, `null` will be returned when accessing a non-existent secret; 
 
 The Spring Framework on Google Cloud integration for Google Cloud Secret Manager enables you to use Secret Manager as a bootstrap property source.
 
-This allows you to specify and load secrets from Google Cloud Secret Manager as properties into the application context during the https://cloud.spring.io/spring-cloud-commons/reference/html/#the-bootstrap-application-context[Bootstrap Phase], which refers to the initial phase when a Spring application is being loaded.
-
 The Secret Manager property source uses the following syntax to specify secrets:
 
 [source]
@@ -82,7 +80,6 @@ You can use this syntax in the following places:
 [source]
 ----
 # Example of the project-secret long-form syntax.
-spring.config.import=sm://
 spring.datasource.password=${sm://projects/my-gcp-project/secrets/my-secret}
 ----
 The former is used to enable https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4[Spring Boot's Config Data API].
@@ -101,7 +98,6 @@ The `SecretManagerTemplate` class simplifies operations of creating, updating, a
 
 To begin using this class, you may inject an instance of the class using `@Autowired` after adding the starter dependency to your project.
 
-Note that you should add `spring.config.import=sm://` in your `application.properties` file to enable `SecretManagerTemplate` bean creation.
 [source, java]
 ----
 @Autowired

--- a/docs/src/main/md/migration-guide-3.x.md
+++ b/docs/src/main/md/migration-guide-3.x.md
@@ -65,7 +65,7 @@ Replaced `ListenableFuture` and `SettableListenableFuture` with `CompletableFutu
 Change to functional model as annotation-based model is removed from Spring Cloud Stream 4.0.0.
 
 #### Secret Manager
-To enable the application to fetch a secret from SecretManager, add `spring.config.import=sm://` in the `application.properties` or `application.yml` files and inject the secret into the application by adding `application.secret=${sm://your-secret-name}`.
+Inject the secret into the application by adding `application.secret=${sm://your-secret-name}` in the `application.properties` or `application.yml` files.
 Do not write secret values in the file.
 
 Please also remove `spring.cloud.gcp.secretmanager.enabled` and `spring.cloud.gcp.secretmanager.legacy` in `bootstrap.yml` or `bootstrap.properties` files.

--- a/docs/src/main/md/secretmanager.md
+++ b/docs/src/main/md/secretmanager.md
@@ -56,12 +56,6 @@ authentication properties.
 The Spring Framework on Google Cloud integration for Google Cloud Secret Manager enables
 you to use Secret Manager as a bootstrap property source.
 
-This allows you to specify and load secrets from Google Cloud Secret
-Manager as properties into the application context during the [Bootstrap
-Phase](https://cloud.spring.io/spring-cloud-commons/reference/html/#the-bootstrap-application-context),
-which refers to the initial phase when a Spring application is being
-loaded.
-
 The Secret Manager property source uses the following syntax to specify
 secrets:
 
@@ -89,7 +83,6 @@ You can use this syntax in the following places:
 1. In your `application.properties` file:
     
         # Example of the project-secret long-form syntax.
-        spring.config.import=sm://
         spring.datasource.password=${sm://projects/my-gcp-project/secrets/my-secret}
    The former is used to enable [Spring Boot's Config Data API](https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4).
 
@@ -105,8 +98,6 @@ updating, and reading secrets.
 
 To begin using this class, you may inject an instance of the class using
 `@Autowired` after adding the starter dependency to your project.
-
-Note that you should add `spring.config.import=sm://` in your `application.properties` file to enable `SecretManagerTemplate` bean creation.
 
 ``` java
 @Autowired

--- a/docs/src/main/md/secretmanager.md
+++ b/docs/src/main/md/secretmanager.md
@@ -106,6 +106,8 @@ updating, and reading secrets.
 To begin using this class, you may inject an instance of the class using
 `@Autowired` after adding the starter dependency to your project.
 
+Note that you should add `spring.config.import=sm://` in your `application.properties` file to enable `SecretManagerTemplate` bean creation.
+
 ``` java
 @Autowired
 private SecretManagerTemplate secretManagerTemplate;

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -263,7 +263,6 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-secretmanager</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <!-- KMS -->

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/kms/KmsAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/kms/KmsAutoConfigurationTests.java
@@ -35,6 +35,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 /** Unit tests for {@link GcpKmsAutoConfiguration}. */
 class KmsAutoConfigurationTests {
@@ -128,6 +129,7 @@ class KmsAutoConfigurationTests {
       return () -> mockUserCredential;
     }
 
+    @Primary
     @Bean
     public static GcpProjectIdProvider gcpProjectIdProvider() {
       return () -> CORE_PROJECT_NAME;

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerEnvironmentPostProcessorUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerEnvironmentPostProcessorUnitTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.secretmanager;
+
+import static com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerEnvironmentPostProcessor.IMPORT_PROPERTY;
+import static com.google.cloud.spring.autoconfigure.secretmanager.SecretManagerConfigDataLocationResolver.PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+public class GcpSecretManagerEnvironmentPostProcessorUnitTests {
+  private SpringApplicationBuilder application;
+
+  @BeforeEach
+  void init() {
+    application = new SpringApplicationBuilder(SecretManagerCompatibilityTests.class)
+        .web(WebApplicationType.NONE)
+        .properties("spring.cloud.gcp.sql.enabled=false");
+  }
+
+  @Test
+  void testDefaultConfigLocations() {
+    try (ConfigurableApplicationContext applicationContext = application.run()) {
+      ConfigurableEnvironment environment = applicationContext.getEnvironment();
+      assertThat(environment.getProperty(IMPORT_PROPERTY)).isEqualTo(PREFIX);
+    }
+  }
+
+  @Test
+  void testCustomConfigLocations() {
+    application.properties("spring.config.import=file:./");
+    try (ConfigurableApplicationContext applicationContext = application.run()) {
+      ConfigurableEnvironment environment = applicationContext.getEnvironment();
+      assertThat(environment.getProperty(IMPORT_PROPERTY)).contains(";" + PREFIX);
+    }
+  }
+
+  @Test
+  void testSecretManagerTemplateExistsByDefault() {
+    try (ConfigurableApplicationContext applicationContext = application.run()) {
+      assertThat(applicationContext.getBean(SecretManagerTemplate.class)).isNotNull();
+    }
+  }
+
+  @Test
+  void testSecretManagerTemplateDoesNotExistIfDisabled() {
+    application.properties("spring.cloud.gcp.secretmanager.enabled=false");
+    try (ConfigurableApplicationContext applicationContext = application.run()) {
+      assertThatThrownBy(() -> applicationContext.getBean(SecretManagerTemplate.class))
+          .isExactlyInstanceOf(NoSuchBeanDefinitionException.class);
+    }
+  }
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spring.autoconfigure.secretmanager;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,14 +82,12 @@ class SecretManagerCompatibilityTests {
    */
   @Test
   void testConfigurationWhenDefaultSecretIsNotAllowed() {
-    application.properties(
-            "spring.config.import=sm://")
-        .addBootstrapRegistryInitializer(
+    application.addBootstrapRegistryInitializer(
             (registry) -> registry.registerIfAbsent(
                 SecretManagerServiceClient.class,
                 InstanceSupplier.of(client)
             )
-        );
+    );
     try (ConfigurableApplicationContext applicationContext = application.run()) {
       ConfigurableEnvironment environment = applicationContext.getEnvironment();
       assertThat(environment.getProperty("sm://my-secret")).isEqualTo("newSecret");
@@ -85,8 +99,7 @@ class SecretManagerCompatibilityTests {
   @Test
   void testConfigurationWhenDefaultSecretIsAllowed() {
     application.properties(
-            "spring.cloud.gcp.secretmanager.allow-default-secret=true",
-            "spring.config.import=sm://")
+            "spring.cloud.gcp.secretmanager.allow-default-secret=true")
         .addBootstrapRegistryInitializer(
             (registry) -> registry.registerIfAbsent(
                 SecretManagerServiceClient.class,

--- a/spring-cloud-gcp-autoconfigure/src/test/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/test/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.cloud.bootstrap.BootstrapConfiguration=\
-com.google.cloud.spring.autoconfigure.secretmanager.SecretManagerBootstrapConfigurationTests.TestBootstrapConfiguration

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -10,8 +10,10 @@
 # example.secret=${MY_ENV_VARIABLE:${sm://application-secret/latest}}
 
 management.endpoints.web.exposure.include=refresh
-# enable external resource from GCP Secret Manager.
-spring.config.import=sm://
+
+# enable external resource from GCP Secret Manager, this property exists by default.
+#spring.config.import=sm://
+
 application.secret=${sm://application-secret}
 # enable default secret value when accessing non-exited secret.
 spring.cloud.gcp.secretmanager.allow-default-secret=true


### PR DESCRIPTION
Fix https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/1551.

Enable `SecretManagerTemplate` bean by default, i.e., without specifying `spring.config.import` in `application.properties`.