### PR TITLE
feat: add an encoder bean in Trace auto-configuration

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -252,7 +252,7 @@ public class StackdriverTraceAutoConfiguration {
     return BaggagePropagation.newFactoryBuilder(StackdriverTracePropagation.newFactory(primary));
   }
 
-  // Add this bean to supress other encoding schema, e.g., JSON.
+  // Add this bean to suppress other encoding schema, e.g., JSON.
   @Bean
   @ConditionalOnMissingBean
   public BytesEncoder<Span> spanBytesEncoder() {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -50,6 +50,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import zipkin2.CheckResult;
 import zipkin2.Span;
+import zipkin2.codec.BytesEncoder;
+import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Reporter;
 import zipkin2.reporter.ReporterMetrics;
@@ -248,6 +250,13 @@ public class StackdriverTraceAutoConfiguration {
     Propagation.Factory primary =
         B3Propagation.newFactoryBuilder().injectFormat(B3Propagation.Format.MULTI).build();
     return BaggagePropagation.newFactoryBuilder(StackdriverTracePropagation.newFactory(primary));
+  }
+
+  // Add this bean to supress other encoding schema, e.g., JSON.
+  @Bean
+  @ConditionalOnMissingBean
+  public BytesEncoder<Span> spanBytesEncoder() {
+    return SpanBytesEncoder.PROTO3;
   }
 
   @PreDestroy

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -59,6 +59,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import zipkin2.Call;
 import zipkin2.CheckResult;
+import zipkin2.codec.BytesEncoder;
 import zipkin2.codec.Encoding;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.AsyncReporter;
@@ -100,6 +101,15 @@ class StackdriverTraceAutoConfigurationTests {
                   .isNotNull();
               assertThat(context.getBean(ManagedChannel.class)).isNotNull();
             });
+  }
+
+  @Test
+  void testEncodingSchema() {
+    this.contextRunner
+        .run(
+            context -> assertThat(
+                context.getBean(BytesEncoder.class))
+                .isEqualTo(SpanBytesEncoder.PROTO3));
   }
 
   @Test

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/java/com/example/Application.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/src/main/java/com/example/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -48,7 +47,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /** Sample spring boot application. */
 @AutoConfiguration
-@SpringBootApplication(exclude = ZipkinAutoConfiguration.class)
+@SpringBootApplication
 public class Application implements WebMvcConfigurer {
   private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
 


### PR DESCRIPTION
Fix https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/1554

Add a span encoder bean in trace so that `ZipkinAutoConfiguration` doesn't provide encoders with incompatible encoding schema, e.g., JSON.

As a result, customers don't need to exclude `ZipkinAutoConfiguration` in their applications.