### PR TITLE
chore: add workaround for sonatype issue with Java 17

### DIFF
--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -28,6 +28,9 @@ MAVEN_SETTINGS_FILE=$(realpath .)/settings.xml
 setup_environment_secrets
 create_settings_xml_file $MAVEN_SETTINGS_FILE
 
+# workaround for nexus maven plugin issue with Java 16+: https://issues.sonatype.org/browse/OSSRH-66257
+export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
+
 # run unit tests
   mvn verify --show-version --batch-mode -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS
 


### PR DESCRIPTION
To try resolving the promote-step issue observed in our last release, this PR adds the `MAVEN_OPTS` workaround as suggested by @ddixit14.

Reference to error from `nexus-staging-maven-plugin`: https://issues.sonatype.org/browse/OSSRH-66257

```
[ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:release (default-cli) on project spring-cloud-previews: Execution default-cli of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:release failed: No converter available
[ERROR] ---- Debugging information ----
[ERROR] message             : No converter available
[ERROR] type                : java.util.Arrays$ArrayList
[ERROR] converter           : com.thoughtworks.xstream.converters.reflection.ReflectionConverter
[ERROR] message[1]          : Unable to make field protected transient int java.util.AbstractList.modCount accessible: module java.base does not "opens java.util" to unnamed module @4052c8c2
```