### PR TITLE
chore(dep): change mysql connector coordinate in auto-configuration

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -86,8 +86,8 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <optional>true</optional>
             <!-- protobuf-java:2.6.0 included by MySQL Connector J is not compatible with
                  Google Cloud Java libraries. -->


### PR DESCRIPTION
Fix https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/1577

Apart from https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1578, there's another `mysql-connector-java` dependency used in auto-configuration module.