### PR TITLE
Revert "deps: bump r2dbc-postgresql from 1.0.0.RELEASE to 1.0.1.RELEASE"

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -37,7 +37,7 @@
 		<gcp-libraries-bom.version>26.7.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.10.0</cloud-sql-socket-factory.version>
 		<guava.version>31.1-jre</guava.version>
-		<r2dbc-postgres-driver.version>1.0.1.RELEASE</r2dbc-postgres-driver.version>
+		<r2dbc-postgres-driver.version>1.0.0.RELEASE</r2dbc-postgres-driver.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
Reverts GoogleCloudPlatform/spring-cloud-gcp#1598. (To check if related to newly observed IT failures in [bigquery](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/4255440521/jobs/7403055622) and [spanner](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/4255440521/jobs/7403058463))