### PR TITLE
Revert "deps: bump micrometer-tracing-bom from 1.0.1 to 1.0.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
 		<zipkin-gcp.version>1.0.4</zipkin-gcp.version>
 		<java-cfenv.version>2.4.1</java-cfenv.version>
-		<micrometer-tracing.verison>1.0.2</micrometer-tracing.verison>
+		<micrometer-tracing.verison>1.0.1</micrometer-tracing.verison>
 
 		<!-- Plugin versions -->
 		<maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>


### PR DESCRIPTION
Reverts GoogleCloudPlatform/spring-cloud-gcp#1595. (To check if related to newly observed IT failures in [pubsub-integration](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/4255432097/jobs/7403037773))