### PR TITLE
chore: turn on ci workflows on push to 3.x branch

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -3,7 +3,8 @@ name: Integration Tests
 on:
   push:
     branches:
-      - 'main'
+      - main
+      - 3.x
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 3.x
       - 2.x
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 3.x
       - 2.x
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
Turning on some checks on push to 3.x branch.

Context: currently troubleshooting some IT failures in the v3.4.5 release PR (https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1609) - I think having associated checks for each pushed commit (since dependabot PRs don't run ITs on presubmit) would be helpful in the future.
 