### PR TITLE
chore: update AbbreviationAsWordInName checkstyle suppression to blanket for preview modules

### DIFF
--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -36,22 +36,7 @@
 
     <!--  Temporary suppress for spring-cloud-previews modules,
       for lowerCamelCase abbreviation handling limitations in generated code -->
-    <suppress checks="AbbreviationAsWordInName"
-              files="/spring-cloud-previews/google-cloud-os-config-spring-starter/.*OsConfigZonalServiceSpringAutoConfiguration.java"/>
-    <suppress checks="AbbreviationAsWordInName"
-              files="/spring-cloud-previews/google-cloud-os-config-spring-starter/.*OsConfigZonalServiceSpringProperties.java"/>
-    <suppress checks="AbbreviationAsWordInName"
-              files="/spring-cloud-previews/google-cloud-ids-spring-starter/.*IDSSpringProperties.java"/>
-    <suppress checks="AbbreviationAsWordInName"
-              files="/spring-cloud-previews/google-cloud-iamcredentials-spring-starter/.*IAMCredentialsSpringProperties.java"/>
-    <suppress checks="AbbreviationAsWordInName"
-              files="/spring-cloud-previews/google-iam-admin-spring-starter/.*IAMSpringProperties.java"/>
-    <suppress checks="AbbreviationAsWordInName"
-              files="/spring-cloud-previews/google-cloud-gsuite-addons-spring-starter/.*GSuiteAddOnsSpringProperties.java"/>
-    <suppress checks="AbbreviationAsWordInName"
-              files="/spring-cloud-previews/google-cloud-container-spring-starter/.*ClusterManagerSpringAutoConfiguration.java"/>
-    <suppress checks="AbbreviationAsWordInName"
-              files="/spring-cloud-previews/google-cloud-container-spring-starter/.*ClusterManagerSpringProperties.java"/>
+    <suppress checks="AbbreviationAsWordInName" files="/spring-cloud-previews/"/>
     <suppress checks="[MethodName|ParameterName]"
               files="/spring-cloud-previews/google-cloud-ids-spring-starter/.*IDSSpringAutoConfiguration.java"/>
     <suppress checks="[MethodName|ParameterName]"


### PR DESCRIPTION
Revisiting the discussion back in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1455 and applying this specific suppression blanketly instead of per-module.

There has been additional methods with this violation from client library/proto changes that are tripping up the [newest update run](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/4256631603/jobs/7405755097): 

```
src/main/java/com/google/devtools/artifactregistry/v1/spring/ArtifactRegistrySpringProperties.java:[468,47] (naming) AbbreviationAsWordInName: Abbreviation in name 'updateVPCSCConfigRetry' must contain no more than '1' consecutive capital letters.
src/main/java/com/google/devtools/artifactregistry/v1/spring/ArtifactRegistrySpringAutoConfiguration.java:[319,21] (naming) AbbreviationAsWordInName: Abbreviation in name 'getVPCSCConfigRetrySettings' must contain no more than '1' consecutive capital letters.
```