### PR TITLE
chore: update generateAutoConfigs action to run on pr event

### DIFF
--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -1,5 +1,11 @@
 name: Generate Spring Auto-Configurations
-on: workflow_dispatch
+on:
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - 'dependabot/maven/com.google.cloud-libraries-bom*'
+  workflow_dispatch:
 jobs:
   generateLibraries:
     runs-on: ubuntu-20.04
@@ -10,7 +16,13 @@ jobs:
         continue-on-error: false
         run: |
           set -x
-          echo "BASE_BRANCH_NAME=$GITHUB_REF_NAME" >> $GITHUB_OUTPUT
+          if ${{ github.event_name == 'pull_request' }}; then
+            echo "Branch name from PR event: $GITHUB_HEAD_REF"
+            echo "BASE_BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_OUTPUT
+          else
+            echo "Branch name from manual trigger: $GITHUB_REF_NAME"
+            echo "BASE_BRANCH_NAME=$GITHUB_REF_NAME" >> $GITHUB_OUTPUT
+          fi
       - name: Fail if not dependabot branch
         continue-on-error: false
         if: ${{ !startsWith(steps.get_branch_name.outputs.BASE_BRANCH_NAME, 'dependabot/maven/com.google.cloud-libraries-bom') }}


### PR DESCRIPTION
This PR allows the action for updating generated modules to auto-trigger on dependabot PRs to update libraries-bom (pattern matching on branch name`dependabot/maven/com.google.cloud-libraries-bom*`).

I couldn't figure out how to test this without merging in the changes to main, but the workflow's existing manual trigger from branch name is still available, and tested in a mock branch (4b6c7437ef4e2e0d559d12bce6b245f6bfe3b75a).
