### PR TITLE
chore: add dnm label as part of generateAutoConfigs workflow

### DIFF
--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -30,6 +30,19 @@ jobs:
           echo "This workflow should only be triggered from a dependabot branch to update libraries-bom"
           echo "Stopping workflow triggered from branch: ${{ steps.get_branch_name.outputs.BASE_BRANCH_NAME }}"
           exit 1
+      - name: Add DNM label to PR
+          continue-on-error: true
+          if: ${{ github.event_name == 'pull_request' }}
+          uses: actions/github-script@v6
+          with:
+            github-token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+            script: |
+              github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: ['do not merge']
+              });
       - name: Setup Java 17
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Opening this PR to test if having the `generatedLibraries` required check blocks other PRs from getting merged.

This PR is also a quick implementation of adding dnm label as alternative, as follow-up to https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1653#pullrequestreview-1346042969.