### PR TITLE
chore: move branch filtering to if condition in generateLibraries job

### DIFF
--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -3,11 +3,11 @@ on:
   pull_request_target:
     types:
       - opened
-    branches:
-      - 'dependabot/maven/com.google.cloud-libraries-bom*'
   workflow_dispatch:
 jobs:
   generateLibraries:
+    # Run job if manually triggered, or on PR with matching branch condition
+    if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'dependabot/maven/com.google.cloud-libraries-bom')) }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -16,7 +16,7 @@ jobs:
         continue-on-error: false
         run: |
           set -x
-          if ${{ github.event_name == 'pull_request' }}; then
+          if ${{ github.event_name == 'pull_request_target' }}; then
             echo "Branch name from PR event: $GITHUB_HEAD_REF"
             echo "BASE_BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Try switching to if condition within job instead of workflow branch filtering, to see if check can show up as skipped for PRs instead of pending.
 
Ref: [handling skipped but required checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks)