### PR TITLE
chore: fixes for generateAutoConfigs action on pull requests

### DIFF
--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -1,13 +1,11 @@
 name: Generate Spring Auto-Configurations
 on:
-  pull_request_target:
-    types:
-      - opened
+  pull_request:
   workflow_dispatch:
 jobs:
   generateLibraries:
     # Run job if manually triggered, or on PR with matching branch condition
-    if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'dependabot/maven/com.google.cloud-libraries-bom')) }}
+    if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/maven/com.google.cloud-libraries-bom') && github.event.action == 'opened') }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -16,7 +14,7 @@ jobs:
         continue-on-error: false
         run: |
           set -x
-          if ${{ github.event_name == 'pull_request_target' }}; then
+          if ${{ github.event_name == 'pull_request' }}; then
             echo "Branch name from PR event: $GITHUB_HEAD_REF"
             echo "BASE_BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
This PR contains two follow-up fixes after https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1656:

- Also moves `type: “opened”` into the if condition, so that the check can be triggered and skipped on synchronize/re-open for existing PRs 
- Switches to use `pull_request` event instead of `pull_request_target`, since we only expect running this workflow on branches within the repo, and not external forks. (Looking into this a bit more, [`pull_request_target`](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows) gives more privileged read/write/secret permissions to the workflow, and runs the action from the trusted target branch instead of the pull request branch. This doesn't work with the existing action unless we additionally checkout and make modifications from pull request head, which is probably not a good idea in combination with the additional permissions allowed by this event.)
