### PR TITLE
chore: both branches should not get major version bumps (renovate bot)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,6 @@
 	"extends": [
 	"config:base"
 	],
-	"baseBranches": ["main", "3.x"],
-	"useBaseBranchConfig": "merge",
 	"packageRules": [{
 		"matchPackageNames": [
 			"com.coveo:fmt-maven-plugin",


### PR DESCRIPTION
This config should work for both `main` and `3.x` branches.