### PR TITLE
fix: fix secret manager docs

### DIFF
--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -67,7 +67,7 @@ sm://<project-id>/<secret-id>/<version-id>
 # 4. Short form - default project; specify secret + version
 #
 # The project is inferred from the spring.cloud.gcp.secretmanager.project-id setting
-# in your bootstrap.properties (see Configuration) or from application-default credentials if
+# in your application.properties (see Configuration) or from application-default credentials if
 # this is not set.
 sm://<secret-id>/<version>
 

--- a/docs/src/main/md/secretmanager.md
+++ b/docs/src/main/md/secretmanager.md
@@ -68,7 +68,7 @@ The Secret Manager config data resource uses the following syntax to specify sec
     # 4. Short form - default project; specify secret + version
     #
     # The project is inferred from the spring.cloud.gcp.secretmanager.project-id setting
-    # in your bootstrap.properties (see Configuration) or from application-default credentials if
+    # in your application.properties (see Configuration) or from application-default credentials if
     # this is not set.
     sm://<secret-id>/<version>
     


### PR DESCRIPTION
Remove `bootstrap.properties` in Secret Manager docs as this file is deprecated in Spring 3.x.