### PR TITLE
chore: remove links configuration for external packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -676,10 +676,6 @@
 								<!-- Exclude samples and classes in the Firestore Google Client library packages -->
 								com.google.cloud.firestore
 							</excludePackageNames>
-							<links>
-								<link>https://javadoc.io/doc/com.google.cloud/google-cloud-vision/latest/</link>
-								<link>https://javadoc.io/doc/com.google.cloud/google-cloud-spanner/latest/</link>
-							</links>
 						</configuration>
 					</plugin>
 					<plugin>


### PR DESCRIPTION
See #1442 - these links were previously pointing to `https://googleapis.dev` URLs and stopped working, and were temporarily switched to equivalents hosted on `javadocs.io`.

