### PR TITLE
property to effectively disable TraceAutoConfigurationFilter 

### DIFF
--- a/docs/src/main/md/trace.md
+++ b/docs/src/main/md/trace.md
@@ -93,24 +93,25 @@ that sends the Micrometer’s trace information to Cloud Trace.
 
 All configurations are optional:
 
-|                                                     |                                                                                                                                  |          |               |
-| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
-| Name                                                | Description                                                                                                                      | Required | Default value |
-| `spring.cloud.gcp.trace.enabled`                    | Auto-configure Micrometer to send traces to Cloud Trace.                                                                | No       | `true`        |
-| `spring.cloud.gcp.trace.project-id`                 | Overrides the project ID from the [Spring Framework on Google Cloud Module](#spring-framework-on-google-cloud-core)                                              | No       |               |
-| `spring.cloud.gcp.trace.credentials.location`       | Overrides the credentials location from the [Spring Framework on Google Cloud Module](#spring-framework-on-google-cloud-core)                                    | No       |               |
-| `spring.cloud.gcp.trace.credentials.encoded-key`    | Overrides the credentials encoded key from the [Spring Framework on Google Cloud Module](#spring-framework-on-google-cloud-core)                                 | No       |               |
-| `spring.cloud.gcp.trace.credentials.scopes`         | Overrides the credentials scopes from the [Spring Framework on Google Cloud Module](#spring-framework-on-google-cloud-core)                                      | No       |               |
-| `spring.cloud.gcp.trace.num-executor-threads`       | Number of threads used by the Trace executor                                                                                     | No       | 4             |
-| `spring.cloud.gcp.trace.authority`                  | HTTP/2 authority the channel claims to be connecting to.                                                                         | No       |               |
-| `spring.cloud.gcp.trace.compression`                | Name of the compression to use in Trace calls                                                                                    | No       |               |
-| `spring.cloud.gcp.trace.deadline-ms`                | Call deadline in milliseconds                                                                                                    | No       |               |
-| `spring.cloud.gcp.trace.max-inbound-size`           | Maximum size for inbound messages                                                                                                | No       |               |
-| `spring.cloud.gcp.trace.max-outbound-size`          | Maximum size for outbound messages                                                                                               | No       |               |
-| `spring.cloud.gcp.trace.wait-for-ready`             | [Waits for the channel to be ready](https://github.com/grpc/grpc/blob/main/doc/wait-for-ready.md) in case of a transient failure | No       | `false`       |
-| `spring.cloud.gcp.trace.messageTimeout`             | Timeout in seconds before pending spans will be sent in batches to GCP Cloud Trace. (previously `spring.zipkin.messageTimeout`)  | No       | 1             |
-| `spring.cloud.gcp.trace.server-response-timeout-ms` | Server response timeout in millis.                                                                                               | No       | `5000`        |
-| `spring.cloud.gcp.trace.pubsub.enabled`             | (Experimental) Auto-configure Pub/Sub instrumentation for Trace.                                                                 | No       | `false`       |
+|                                                         |                                                                                                                                  |          |               |
+|---------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| Name                                                    | Description                                                                                                                      | Required | Default value |
+| `spring.cloud.gcp.trace.enabled`                        | Auto-configure Micrometer to send traces to Cloud Trace.                                                                         | No       | `true`        |
+| `spring.cloud.gcp.trace.project-id`                     | Overrides the project ID from the [Spring Framework on Google Cloud Module](#spring-framework-on-google-cloud-core)              | No       |               |
+| `spring.cloud.gcp.trace.credentials.location`           | Overrides the credentials location from the [Spring Framework on Google Cloud Module](#spring-framework-on-google-cloud-core)    | No       |               |
+| `spring.cloud.gcp.trace.credentials.encoded-key`        | Overrides the credentials encoded key from the [Spring Framework on Google Cloud Module](#spring-framework-on-google-cloud-core) | No       |               |
+| `spring.cloud.gcp.trace.credentials.scopes`             | Overrides the credentials scopes from the [Spring Framework on Google Cloud Module](#spring-framework-on-google-cloud-core)      | No       |               |
+| `spring.cloud.gcp.trace.num-executor-threads`           | Number of threads used by the Trace executor                                                                                     | No       | 4             |
+| `spring.cloud.gcp.trace.authority`                      | HTTP/2 authority the channel claims to be connecting to.                                                                         | No       |               |
+| `spring.cloud.gcp.trace.compression`                    | Name of the compression to use in Trace calls                                                                                    | No       |               |
+| `spring.cloud.gcp.trace.deadline-ms`                    | Call deadline in milliseconds                                                                                                    | No       |               |
+| `spring.cloud.gcp.trace.max-inbound-size`               | Maximum size for inbound messages                                                                                                | No       |               |
+| `spring.cloud.gcp.trace.max-outbound-size`              | Maximum size for outbound messages                                                                                               | No       |               |
+| `spring.cloud.gcp.trace.wait-for-ready`                 | [Waits for the channel to be ready](https://github.com/grpc/grpc/blob/main/doc/wait-for-ready.md) in case of a transient failure | No       | `false`       |
+| `spring.cloud.gcp.trace.messageTimeout`                 | Timeout in seconds before pending spans will be sent in batches to GCP Cloud Trace. (previously `spring.zipkin.messageTimeout`)  | No       | 1             |
+| `spring.cloud.gcp.trace.server-response-timeout-ms`     | Server response timeout in millis.                                                                                               | No       | `5000`        |
+| `spring.cloud.gcp.trace.pubsub.enabled`                 | (Experimental) Auto-configure Pub/Sub instrumentation for Trace.                                                                 | No       | `false`       |
+| `spring.cloud.gcp.trace.disable-spring-boot-autoconfig` | Allows to disable Spring Boot's build-in tracing auto-configuration.                                                             | No       | `true`        |
 
 You can use core Micrometer properties to control Micrometer’s
 sampling rate, etc. Read [Spring Boot Tracing documentation](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#actuator.micrometer-tracing) for more

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -71,31 +71,26 @@ import zipkin2.reporter.stackdriver.StackdriverSender.Builder;
 @AutoConfigureBefore(BraveAutoConfiguration.class)
 public class StackdriverTraceAutoConfiguration {
 
-  private static final Log LOGGER = LogFactory.getLog(StackdriverTraceAutoConfiguration.class);
-
   /**
    * Stackdriver reporter bean name. Name of the bean matters for supporting multiple tracing
    * systems.
    */
   public static final String REPORTER_BEAN_NAME = "stackdriverReporter";
-
   /**
    * Stackdriver sender bean name. Name of the bean matters for supporting multiple tracing systems.
    */
   public static final String SENDER_BEAN_NAME = "stackdriverSender";
-
   /**
    * Stackdriver span handler bean name. Name of the bean matters for supporting multiple tracing
    * systems.
    */
   public static final String SPAN_HANDLER_BEAN_NAME = "stackdriverSpanHandler";
-
   /**
    * Stackdriver customizer bean name. Name of the bean matters for supporting multiple tracing
    * systems.
    */
   public static final String CUSTOMIZER_BEAN_NAME = "stackdriverTracingCustomizer";
-
+  private static final Log LOGGER = LogFactory.getLog(StackdriverTraceAutoConfiguration.class);
   private final GcpProjectIdProvider finalProjectIdProvider;
 
   private final CredentialsProvider finalCredentialsProvider;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/TraceAutoConfigurationFilter.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/TraceAutoConfigurationFilter.java
@@ -16,30 +16,54 @@
 
 package com.google.cloud.spring.autoconfigure.trace;
 
+import java.util.Arrays;
 import java.util.Set;
 import org.springframework.boot.autoconfigure.AutoConfigurationImportFilter;
 import org.springframework.boot.autoconfigure.AutoConfigurationMetadata;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
 
 /**
- * Exclude Spring Boot AutoConfiguration classes as they provide incompatible beans
- * when using Cloud Trace.
+ * Exclude Spring Boot AutoConfiguration classes as they provide incompatible beans when using Cloud
+ * Trace.
  *
  * @since 4.1.2
  */
-public class TraceAutoConfigurationFilter implements AutoConfigurationImportFilter {
+public class TraceAutoConfigurationFilter
+    implements AutoConfigurationImportFilter, EnvironmentAware {
 
-  private static final Set<String> SHOULD_SKIP = Set.of(
-      "org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration");
+  private static final String DISABLE_SPRING_BOOT_PROPERTY_NAME =
+      "spring.cloud.gcp.trace.disable-spring-boot-autoconfig";
+
+  private static final Set<String> SHOULD_SKIP =
+      Set.of(
+          "org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration");
+
+  private boolean skipImportFilter = false;
 
   @Override
-  public boolean[] match(String[] autoConfigurationClasses,
-      AutoConfigurationMetadata autoConfigurationMetadata) {
+  public boolean[] match(
+      String[] autoConfigurationClasses, AutoConfigurationMetadata autoConfigurationMetadata) {
     boolean[] matches = new boolean[autoConfigurationClasses.length];
 
-    for (int i = 0; i < autoConfigurationClasses.length; i++) {
-      matches[i] = autoConfigurationClasses[i] == null
-          || !SHOULD_SKIP.contains(autoConfigurationClasses[i]);
+    if (skipImportFilter) {
+      Arrays.fill(matches, true);
+    } else {
+      for (int i = 0; i < autoConfigurationClasses.length; i++) {
+        matches[i] =
+            autoConfigurationClasses[i] == null
+                || !SHOULD_SKIP.contains(autoConfigurationClasses[i]);
+      }
     }
+
     return matches;
+  }
+
+  @Override
+  public void setEnvironment(Environment environment) {
+    // The default behavior is to disable the spring boot tracing autoconfiguration
+    boolean shouldDisableSpringBootAutoconfiguration =
+        environment.getProperty(DISABLE_SPRING_BOOT_PROPERTY_NAME, Boolean.class, true);
+    this.skipImportFilter = !shouldDisableSpringBootAutoconfiguration;
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -109,6 +109,12 @@
       "defaultValue": true
     },
     {
+      "name": "spring.cloud.gcp.trace.disable-spring-boot-autoconfig",
+      "type": "java.lang.Boolean",
+      "description": "Whether to disable Spring Boot's build-in tracing auto-configuration.",
+      "defaultValue": true
+    },
+    {
       "name": "spring.cloud.gcp.trace.pubsub.enabled",
       "type": "java.lang.Boolean",
       "description": "Auto-configure trace instrumentation of Pub/Sub components.",

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/TraceAutoConfigurationFilterTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/TraceAutoConfigurationFilterTests.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurationMetadata;
+import org.springframework.mock.env.MockEnvironment;
 
 class TraceAutoConfigurationFilterTests {
 
@@ -25,10 +26,29 @@ class TraceAutoConfigurationFilterTests {
 
   @Test
   void testZipkinAutoConfigurationShouldNotMatch() {
-    assertThat(filter.match(new String[]{
-        "org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration"},
-        mock(AutoConfigurationMetadata.class)))
+    assertThat(
+            filter.match(
+                new String[] {
+                  "org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration"
+                },
+                mock(AutoConfigurationMetadata.class)))
         .hasSize(1)
         .contains(false);
+  }
+
+  @Test
+  void testZipkinAutoConfigurationShouldMatchWhenGcpTracingIsDisabled() {
+    MockEnvironment environment = new MockEnvironment();
+    environment.setProperty("spring.cloud.gcp.trace.disable-spring-boot-autoconfig", "false");
+    filter.setEnvironment(environment);
+
+    assertThat(
+            filter.match(
+                new String[] {
+                  "org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration"
+                },
+                mock(AutoConfigurationMetadata.class)))
+        .hasSize(1)
+        .contains(true);
   }
 }


### PR DESCRIPTION
While application property `spring.cloud.gcp.trace.enabled` is disabling the
cloud trace auto-configuration, `TraceAutoConfigurationFilter` remains present
and filters out Spring Boot's Zipkin auto-configuration.

I could not find a way to conditionally register/unregister the
`TraceAutoConfigurationFilter` bean, so I opted-in for an effective noop.

Fix #1693
