### PR TITLE
chore: update generateAutoConfigs action to work with forking-renovate

### DIFF
--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -43,6 +43,8 @@ jobs:
         # This step differs slightly depending on whether the workflow is triggered for a forked repo.
         run: |
           set -x
+          sudo apt-get update
+          sudo apt-get install libxml2-utils
           if ${{ github.event.inputs.forked_repo != '' }}; then
             git fetch https://github.com/${{ github.event.inputs.forked_repo }}.git ${{ github.event.inputs.branch_name }}
             git checkout FETCH_HEAD -- spring-cloud-gcp-dependencies/pom.xml
@@ -79,8 +81,6 @@ jobs:
         run: |
           set -x
           set -e
-          sudo apt-get update
-          sudo apt-get install libxml2-utils
           echo "MONOREPO_TAG=v$(bash compute-monorepo-tag.sh -v $LIBRARIES_BOM_VERSION)" >> $GITHUB_OUTPUT
           echo "Monorepo tag: $MONOREPO_TAG"
           bash generate-library-list.sh -c $MONOREPO_TAG
@@ -161,7 +161,7 @@ jobs:
             git commit -m "chore: update starter modules in spring-cloud-previews"
             git push -u origin ${{ github.event.inputs.branch_name }}
           fi
-          
+
         env:
           GITHUB_ACTOR_EMAIL: ${{ steps.determine_workflow_author_email.outputs.GITHUB_ACTOR_EMAIL }}
           GITHUB_ACTOR_NAME: ${{ steps.determine_workflow_author_email.outputs.GITHUB_ACTOR_NAME }}

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -76,6 +76,7 @@ jobs:
           set -x
           bash reset-previews-folder.sh
       - name: Generate library list
+        id: generate_library_list
         continue-on-error: false
         working-directory: spring-cloud-generator
         run: |
@@ -84,8 +85,10 @@ jobs:
           echo "Libraries BOM version: $LIBRARIES_BOM_VERSION"
           echo "MONOREPO_TAG=v$(bash compute-monorepo-tag.sh -v $LIBRARIES_BOM_VERSION)" >> $GITHUB_OUTPUT
           bash generate-library-list.sh -c $MONOREPO_TAG
+          cat library_list.txt
         env:
           LIBRARIES_BOM_VERSION: ${{ steps.get_libraries_bom_version.outputs.LIBRARIES_BOM_VERSION }}
+          MONOREPO_TAG: ${{ steps.generate_library_list.outputs.MONOREPO_TAG }}
       - name: Compile non-autogen libraries
         continue-on-error: false
         run: |
@@ -103,7 +106,9 @@ jobs:
         run: |
           set -x
           set -e
-          bash generate-all.sh
+          bash generate-all.sh -m $MONOREPO_TAG
+        env:
+          MONOREPO_TAG: ${{ steps.generate_library_list.outputs.MONOREPO_TAG }}
       - name: Check for generation errors
         continue-on-error: false
         working-directory: spring-cloud-generator
@@ -153,8 +158,8 @@ jobs:
             git stash pop
             git add ./spring-cloud-previews
             git commit -m "chore: update starter modules in spring-cloud-previews"
-            # git push https://github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
-            git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
+            git push https://github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
+            # git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
           else
             git fetch origin ${{ github.event.inputs.branch_name }}
             git checkout ${{ github.event.inputs.branch_name }}

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -153,16 +153,15 @@ jobs:
             git stash pop
             git add ./spring-cloud-previews
             git commit -m "chore: update starter modules in spring-cloud-previews"
-            git push https://github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
-            # git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
+            # git push https://github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
+            git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
           else
             git fetch origin ${{ github.event.inputs.branch_name }}
-            git checkout origin/${{ github.event.inputs.branch_name }}
+            git checkout ${{ github.event.inputs.branch_name }}
             git reset --hard
             git stash pop
             git add ./spring-cloud-previews
             git commit -m "chore: update starter modules in spring-cloud-previews"
-            # git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
             git push -u origin ${{ github.event.inputs.branch_name }}
           fi
 

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -52,7 +52,6 @@ jobs:
             git checkout ${{ github.event.inputs.branch_name }} -- spring-cloud-gcp-dependencies/pom.xml
           fi
           echo "LIBRARIES_BOM_VERSION=$(xmllint --xpath "string(//*[local-name()='gcp-libraries-bom.version'])" spring-cloud-gcp-dependencies/pom.xml)" >> $GITHUB_OUTPUT
-          echo "Libraries BOM version: ${{ steps.get_libraries_bom_version.outputs.LIBRARIES_BOM_VERSION }}"
       - name: Setup Java 17
         uses: actions/setup-java@v1
         with:
@@ -81,8 +80,8 @@ jobs:
         run: |
           set -x
           set -e
+          echo "Libraries BOM version: $LIBRARIES_BOM_VERSION"
           echo "MONOREPO_TAG=v$(bash compute-monorepo-tag.sh -v $LIBRARIES_BOM_VERSION)" >> $GITHUB_OUTPUT
-          echo "Monorepo tag: $MONOREPO_TAG"
           bash generate-library-list.sh -c $MONOREPO_TAG
         env:
           LIBRARIES_BOM_VERSION: ${{ steps.get_libraries_bom_version.outputs.LIBRARIES_BOM_VERSION }}

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -7,8 +7,8 @@ on:
         required: true
         default: "renovate/main-gcp-libraries-bom.version"
       forked_repo:
-        description: PR repo name (if fork)
-        required: false
+        description: Fork name (enter none if repo branch)
+        required: true
         default: "renovate-bot/GoogleCloudPlatform-_-spring-cloud-gcp"
   pull_request:
     types: [opened]
@@ -45,7 +45,7 @@ jobs:
           set -x
           sudo apt-get update
           sudo apt-get install libxml2-utils
-          if [[ ${{ github.event.inputs.forked_repo }} != "" ]]; then
+          if [[ ${{ github.event.inputs.forked_repo }} != "none" ]]; then
             git fetch https://github.com/${{ github.event.inputs.forked_repo }}.git ${{ github.event.inputs.branch_name }}
             git checkout FETCH_HEAD -- spring-cloud-gcp-dependencies/pom.xml
           else 
@@ -146,7 +146,7 @@ jobs:
           git config --global user.email "cloud-java-bot@google.com"
           
           # push changes to branch
-          if [[ ${{ github.event.inputs.forked_repo }} != "" ]]; then
+          if [[ ${{ github.event.inputs.forked_repo }} != "none" ]]; then
             git fetch https://github.com/${{ github.event.inputs.forked_repo }}.git ${{ github.event.inputs.branch_name }}
             git checkout FETCH_HEAD
             git stash pop

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -45,7 +45,7 @@ jobs:
           set -x
           sudo apt-get update
           sudo apt-get install libxml2-utils
-          if ${{ github.event.inputs.forked_repo != '' }}; then
+          if [[ ${{ github.event.inputs.forked_repo }} != "" ]]; then
             git fetch https://github.com/${{ github.event.inputs.forked_repo }}.git ${{ github.event.inputs.branch_name }}
             git checkout FETCH_HEAD -- spring-cloud-gcp-dependencies/pom.xml
           else 
@@ -146,18 +146,20 @@ jobs:
           git config --global user.email "cloud-java-bot@google.com"
           
           # push changes to branch
-          if ${{ github.event.inputs.forked_repo != '' }}; then
+          if [[ ${{ github.event.inputs.forked_repo }} != "" ]]; then
             git fetch https://github.com/${{ github.event.inputs.forked_repo }}.git ${{ github.event.inputs.branch_name }}
             git checkout FETCH_HEAD
             git stash pop
             git add ./spring-cloud-previews
             git commit -m "chore: update starter modules in spring-cloud-previews"
             git push https://github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
+            # git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
           else
             git checkout ${{ github.event.inputs.branch_name }}
             git stash pop
             git add ./spring-cloud-previews
             git commit -m "chore: update starter modules in spring-cloud-previews"
+            # git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
             git push -u origin ${{ github.event.inputs.branch_name }}
           fi
 

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -52,7 +52,7 @@ jobs:
             git checkout ${{ github.event.inputs.branch_name }} -- spring-cloud-gcp-dependencies/pom.xml
           fi
           echo "LIBRARIES_BOM_VERSION=$(xmllint --xpath "string(//*[local-name()='gcp-libraries-bom.version'])" spring-cloud-gcp-dependencies/pom.xml)" >> $GITHUB_OUTPUT
-          echo "Libraries BOM version: ${LIBRARIES_BOM_VERSION}"
+          echo "Libraries BOM version: ${{ steps.get_libraries_bom_version.outputs.LIBRARIES_BOM_VERSION }}"
       - name: Setup Java 17
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -1,33 +1,56 @@
 name: Generate Spring Auto-Configurations
 on:
-  pull_request:
   workflow_dispatch:
+    inputs:
+      branch_name:
+        description: PR branch name
+        required: true
+        default: "renovate/main-gcp-libraries-bom.version"
+      forked_repo:
+        description: PR repo name (if fork)
+        required: false
+        default: "renovate-bot/GoogleCloudPlatform-_-spring-cloud-gcp"
+  pull_request:
+    types: [opened]
 jobs:
   generateLibraries:
-    # Run job if manually triggered, or on PR with matching branch condition
-    if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/maven/com.google.cloud-libraries-bom') && github.event.action == 'opened') }}
+    # Run this if workflow is manually triggered
+    # On initial opening of renovate or dependabot PR with matching branch condition,
+    # log information required for manually triggering workflow and exit with error to block PR
+    if: ${{ (github.event_name == 'workflow_dispatch') || startsWith(github.head_ref, 'renovate/main-gcp-libraries-bom.version') || startsWith(github.head_ref, 'dependabot/maven/com.google.cloud-libraries-bom') }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Get branch name
-        id: get_branch_name
+      - name: Get PR info
+        id: get_pr_info
         continue-on-error: false
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "Please trigger update workflow manually. The following information may be helpful: "
+          echo "PR head repo full name: $HEAD_REPO_NAME"
+          echo "PR base repo full name: $BASE_REPO_NAME"
+          echo "PR branch name: $PR_BRANCH_NAME"
+          echo "Actor from PR event: $GITHUB_ACTOR"
+          exit 1
+        env:
+          HEAD_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO_NAME: ${{ github.event.pull_request.base.repo.full_name }}
+          PR_BRANCH_NAME: ${{ github.head_ref }}
+      - name: Get libraries bom version
+        id: get_libraries_bom_version
+        continue-on-error: false
+        # Fetch updated pom file with the new libraries-bom version.
+        # This step differs slightly depending on whether the workflow is triggered for a forked repo.
         run: |
           set -x
-          if ${{ github.event_name == 'pull_request' }}; then
-            echo "Branch name from PR event: $GITHUB_HEAD_REF"
-            echo "BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_OUTPUT
-          else
-            echo "Branch name from manual trigger: $GITHUB_REF_NAME"
-            echo "BRANCH_NAME=$GITHUB_REF_NAME" >> $GITHUB_OUTPUT
+          if ${{ github.event.inputs.forked_repo != '' }}; then
+            git fetch https://github.com/${{ github.event.inputs.forked_repo }}.git ${{ github.event.inputs.branch_name }}
+            git checkout FETCH_HEAD -- spring-cloud-gcp-dependencies/pom.xml
+          else 
+            git checkout ${{ github.event.inputs.branch_name }} -- spring-cloud-gcp-dependencies/pom.xml
           fi
-      - name: Fail if not dependabot branch
-        continue-on-error: false
-        if: ${{ !startsWith(steps.get_branch_name.outputs.BRANCH_NAME, 'dependabot/maven/com.google.cloud-libraries-bom') }}
-        run: |
-          echo "This workflow should only be triggered from a dependabot branch to update libraries-bom"
-          echo "Stopping workflow triggered from branch: ${{ steps.get_branch_name.outputs.BRANCH_NAME }}"
-          exit 1
+          echo "LIBRARIES_BOM_VERSION=$(xmllint --xpath "string(//*[local-name()='gcp-libraries-bom.version'])" spring-cloud-gcp-dependencies/pom.xml)" >> $GITHUB_OUTPUT
+          echo "Libraries BOM version: ${LIBRARIES_BOM_VERSION}"
       - name: Setup Java 17
         uses: actions/setup-java@v1
         with:
@@ -58,7 +81,11 @@ jobs:
           set -e
           sudo apt-get update
           sudo apt-get install libxml2-utils
-          bash generate-library-list.sh
+          echo "MONOREPO_TAG=v$(bash compute-monorepo-tag.sh -v $LIBRARIES_BOM_VERSION)" >> $GITHUB_OUTPUT
+          echo "Monorepo tag: $MONOREPO_TAG"
+          bash generate-library-list.sh -c $MONOREPO_TAG
+        env:
+          LIBRARIES_BOM_VERSION: ${{ steps.get_libraries_bom_version.outputs.LIBRARIES_BOM_VERSION }}
       - name: Compile non-autogen libraries
         continue-on-error: false
         run: |
@@ -91,17 +118,6 @@ jobs:
             cat failed-library-generations/$failed_lib_name
           done
           exit 1
-      - name: Check for compilation errors
-        continue-on-error: false
-        working-directory: spring-cloud-previews
-        run: |
-          ../mvnw \
-            --batch-mode \
-            --show-version \
-            --threads 1.5C \
-            --define maven.test.skip=true \
-            --define maven.javadoc.skip=true \
-            install
       #Compares the current contents of spring-cloud-previews with the new generated libraries
       - name: Detect changes
         id: detect_changes
@@ -122,27 +138,31 @@ jobs:
         if: steps.detect_changes.outputs.CHANGED_FILES > 0
         run: |
           set -x
+          
           # stashes the changes from generated libs
           git stash push -- spring-cloud-previews/
-          git reset --hard
-          git remote update
-
-          # pops the changes in branch
-          git checkout $BRANCH_NAME
-          git stash pop
-          git add ./spring-cloud-previews
-
+          
           # configure author
           git config --global user.name "Cloud Java Bot"
           git config --global user.email "cloud-java-bot@google.com"
-
-          # commit
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
-          git commit -m "chore: update starter modules in spring-cloud-previews"
-          git push --set-upstream origin $BRANCH_NAME
-
+          
+          # push changes to branch
+          if ${{ github.event.inputs.forked_repo != '' }}; then
+            git fetch https://github.com/${{ github.event.inputs.forked_repo }}.git ${{ github.event.inputs.branch_name }}
+            git checkout FETCH_HEAD
+            git stash pop
+            git add ./spring-cloud-previews
+            git commit -m "chore: update starter modules in spring-cloud-previews"
+            git push https://github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
+          else
+            git checkout ${{ github.event.inputs.branch_name }}
+            git stash pop
+            git add ./spring-cloud-previews
+            git commit -m "chore: update starter modules in spring-cloud-previews"
+            git push -u origin ${{ github.event.inputs.branch_name }}
+          fi
+          
         env:
-          BRANCH_NAME: ${{ steps.get_branch_name.outputs.BRANCH_NAME }}
           GITHUB_ACTOR_EMAIL: ${{ steps.determine_workflow_author_email.outputs.GITHUB_ACTOR_EMAIL }}
           GITHUB_ACTOR_NAME: ${{ steps.determine_workflow_author_email.outputs.GITHUB_ACTOR_NAME }}
           GITHUB_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -49,7 +49,7 @@ jobs:
             git fetch https://github.com/${{ github.event.inputs.forked_repo }}.git ${{ github.event.inputs.branch_name }}
             git checkout FETCH_HEAD -- spring-cloud-gcp-dependencies/pom.xml
           else 
-            git checkout ${{ github.event.inputs.branch_name }} -- spring-cloud-gcp-dependencies/pom.xml
+            git checkout origin/${{ github.event.inputs.branch_name }} -- spring-cloud-gcp-dependencies/pom.xml
           fi
           echo "LIBRARIES_BOM_VERSION=$(xmllint --xpath "string(//*[local-name()='gcp-libraries-bom.version'])" spring-cloud-gcp-dependencies/pom.xml)" >> $GITHUB_OUTPUT
       - name: Setup Java 17

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -49,7 +49,8 @@ jobs:
             git fetch https://github.com/${{ github.event.inputs.forked_repo }}.git ${{ github.event.inputs.branch_name }}
             git checkout FETCH_HEAD -- spring-cloud-gcp-dependencies/pom.xml
           else 
-            git checkout origin/${{ github.event.inputs.branch_name }} -- spring-cloud-gcp-dependencies/pom.xml
+            git fetch origin ${{ github.event.inputs.branch_name }}
+            git checkout ${{ github.event.inputs.branch_name }} -- spring-cloud-gcp-dependencies/pom.xml
           fi
           echo "LIBRARIES_BOM_VERSION=$(xmllint --xpath "string(//*[local-name()='gcp-libraries-bom.version'])" spring-cloud-gcp-dependencies/pom.xml)" >> $GITHUB_OUTPUT
       - name: Setup Java 17

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -83,12 +83,12 @@ jobs:
           set -x
           set -e
           echo "Libraries BOM version: $LIBRARIES_BOM_VERSION"
-          echo "MONOREPO_TAG=v$(bash compute-monorepo-tag.sh -v $LIBRARIES_BOM_VERSION)" >> $GITHUB_OUTPUT
+          MONOREPO_TAG=v$(bash compute-monorepo-tag.sh -v $LIBRARIES_BOM_VERSION)
+          echo "MONOREPO_COMMITISH=$MONOREPO_TAG" >> $GITHUB_OUTPUT
           bash generate-library-list.sh -c $MONOREPO_TAG
           cat library_list.txt
         env:
           LIBRARIES_BOM_VERSION: ${{ steps.get_libraries_bom_version.outputs.LIBRARIES_BOM_VERSION }}
-          MONOREPO_TAG: ${{ steps.generate_library_list.outputs.MONOREPO_TAG }}
       - name: Compile non-autogen libraries
         continue-on-error: false
         run: |
@@ -106,9 +106,9 @@ jobs:
         run: |
           set -x
           set -e
-          bash generate-all.sh -m $MONOREPO_TAG
+          bash generate-all.sh -m $MONOREPO_COMMITISH
         env:
-          MONOREPO_TAG: ${{ steps.generate_library_list.outputs.MONOREPO_TAG }}
+          MONOREPO_COMMITISH: ${{ steps.generate_library_list.outputs.MONOREPO_COMMITISH }}
       - name: Check for generation errors
         continue-on-error: false
         working-directory: spring-cloud-generator

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -156,7 +156,9 @@ jobs:
             git push https://github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
             # git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
           else
-            git checkout ${{ github.event.inputs.branch_name }}
+            git fetch origin ${{ github.event.inputs.branch_name }}
+            git checkout origin/${{ github.event.inputs.branch_name }}
+            git reset --hard
             git stash pop
             git add ./spring-cloud-previews
             git commit -m "chore: update starter modules in spring-cloud-previews"

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -159,7 +159,6 @@ jobs:
             git add ./spring-cloud-previews
             git commit -m "chore: update starter modules in spring-cloud-previews"
             git push https://github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
-            # git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.event.inputs.forked_repo }}.git HEAD:${{ github.event.inputs.branch_name }}
           else
             git fetch origin ${{ github.event.inputs.branch_name }}
             git checkout ${{ github.event.inputs.branch_name }}

--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -50,7 +50,7 @@ jobs:
             git checkout FETCH_HEAD -- spring-cloud-gcp-dependencies/pom.xml
           else 
             git fetch origin ${{ github.event.inputs.branch_name }}
-            git checkout ${{ github.event.inputs.branch_name }} -- spring-cloud-gcp-dependencies/pom.xml
+            git checkout origin/${{ github.event.inputs.branch_name }} -- spring-cloud-gcp-dependencies/pom.xml
           fi
           echo "LIBRARIES_BOM_VERSION=$(xmllint --xpath "string(//*[local-name()='gcp-libraries-bom.version'])" spring-cloud-gcp-dependencies/pom.xml)" >> $GITHUB_OUTPUT
       - name: Setup Java 17

--- a/spring-cloud-generator/compute-monorepo-tag.sh
+++ b/spring-cloud-generator/compute-monorepo-tag.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-libraries_bom_version=$(xmllint --xpath "string(//*[local-name()='gcp-libraries-bom.version'])" ../spring-cloud-gcp-dependencies/pom.xml)
+
+while getopts v: flag
+do
+    case "${flag}" in
+        v) libraries_bom_version=${OPTARG};;
+    esac
+done
+echo "Libraries BOM Version: $libraries_bom_version";
+
 gapic_libraries_groupId='com.google.cloud'
 gapic_libraries_artifactId='gapic-libraries-bom'
 curl -s "https://raw.githubusercontent.com/googleapis/java-cloud-bom/v$libraries_bom_version/google-cloud-bom/pom.xml" > libraries-bom-pom

--- a/spring-cloud-generator/compute-monorepo-tag.sh
+++ b/spring-cloud-generator/compute-monorepo-tag.sh
@@ -6,7 +6,6 @@ do
         v) libraries_bom_version=${OPTARG};;
     esac
 done
-echo "Libraries BOM Version: $libraries_bom_version";
 
 gapic_libraries_groupId='com.google.cloud'
 gapic_libraries_artifactId='gapic-libraries-bom'

--- a/spring-cloud-generator/generate-all.sh
+++ b/spring-cloud-generator/generate-all.sh
@@ -6,7 +6,13 @@ set -o pipefail
 set -e
 WORKING_DIR=`pwd`
 
-monorepo_commitish="v$(bash compute-monorepo-tag.sh)"
+while getopts m: flag
+do
+    case "${flag}" in
+        m) monorepo_commitish=${OPTARG};;
+    esac
+done
+echo "Monorepo commitish: $monorepo_commitish";
 
 cd ../
 # Compute the project version.

--- a/spring-cloud-generator/generate-library-list.sh
+++ b/spring-cloud-generator/generate-library-list.sh
@@ -16,11 +16,7 @@ git clone https://github.com/googleapis/google-cloud-java.git
 
 # switch to the specified release commitish
 cd ./google-cloud-java
-if [ -z "$commitish" ];
-  then echo "No commitish provided, using HEAD.";
-  else git checkout $commitish;
-fi
-
+git checkout $commitish
 cd -
 
 # start file, always override is present

--- a/spring-cloud-generator/generate-library-list.sh
+++ b/spring-cloud-generator/generate-library-list.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
-#cmd line:: ./generate-library-list.sh
-commitish="v$(bash compute-monorepo-tag.sh)"
-echo "monorepo commitish to checkout: $commitish";
-
+while getopts c: flag
+do
+    case "${flag}" in
+        c) commitish=${OPTARG};;
+    esac
+done
+echo "Monorepo tag: $commitish";
 
 # install jq for json parsing if not already installed
 sudo apt-get -y install jq


### PR DESCRIPTION
This PR makes some changes to the current `generateAutoConfigs` action so that it can work with the spring-cloud-gcp’s new setup of using forking-renovate instead of dependabot.
- `workflow_dispatch`: support manually triggering the workflow given branch and optional fork repo name (auto-populated with expected forking-renovate values, so the manual effort will just be clicking the `run workflow` button, but these inputs are also customizable if needed) 

- `pull_request`: a check workflow will trigger upon matching dependabot or renovate bot PR when they open, and fail with error to indicate further action needed. It will also logs branch/fork information about the PR in case inputs for the manual trigger need to be adjusted.   

Looking to merge this before #1686 to unblock this release cycle, and I will resolve any conflicts in the latter PR accordingly.

----
Side note: below are some attempts to test the updated workflow, though it's hard to verify until we receive the actual renovate bot PR this cycle. This action update tries to allow flexibility with triggering options in the meanwhile. 

[Mock workflow run](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/4737615294) for repo branch: 
```
gh workflow run .github/workflows/generateAutoConfigs.yaml --ref codegen-renovate-update  -f branch_name=renovate/main-gcp-libraries-bom.version-mock -f forked_repo=none
```
[Mock workflow run](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/4737422785) for forked branch:
```
gh workflow run .github/workflows/generateAutoConfigs.yaml --ref codegen-renovate-update  -f branch_name=renovate/main-gcp-libraries-bom.version-mock -f forked_repo=emmileaf/spring-cloud-gcp
```



