### PR TITLE
chore: replace deprecated command with environment file

### DIFF
--- a/.github/workflows/compatibilityCheck.yaml
+++ b/.github/workflows/compatibilityCheck.yaml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v2
       - name: Read inputs
         run: |

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v2
       - name: Setup Java 17
         uses: actions/setup-java@v1

--- a/.github/workflows/linkageCheck.yaml
+++ b/.github/workflows/linkageCheck.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+      run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
 
     - uses: actions/checkout@v2
 
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+      run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
     - uses: actions/checkout@v2
     - run: |
         git config user.name github-actions


### PR DESCRIPTION
## Description

Resolve #1732 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
```

**TO-BE**

```yaml
run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
```