### PR TITLE
ci: Track released artifacts for EO 14028 compliance.

### DIFF
--- a/.kokoro/stage.cfg
+++ b/.kokoro/stage.cfg
@@ -15,6 +15,15 @@ action {
   }
 }
 
+# Save artifacts for EO 14028
+action {
+  define_artifacts {
+    regex: "**/target/*.jar"
+    regex: "**/target/*.pom"
+    strip_prefix: "github/spring-cloud-gcp"
+  }
+}
+
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"


### PR DESCRIPTION
This updates the stage job to record the build artifacts so that Kokoro can generate
an SBOM.