### PR TITLE
ci: Track released artifacts for EO 14028 compliance. (backport of #1774)

### DIFF
--- a/.kokoro/stage.cfg
+++ b/.kokoro/stage.cfg
@@ -1,3 +1,12 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 build_file: "spring-cloud-gcp/.kokoro/stage.sh"
+
+# Save artifacts for EO 14028
+action {
+  define_artifacts {
+    regex: "**/target/*.jar"
+    regex: "**/target/*.pom"
+    strip_prefix: "github/spring-cloud-gcp"
+  }
+}


### PR DESCRIPTION
This is a backport of #1774 from `main` to the stage job configs on `3.x` branch, since we are also making releases from this branch (e.g. #1727).