### PR TITLE
chore: update generator version and add to extraFiles for release-please configuration

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,7 +1,10 @@
 primaryBranch: main
 releaseType: java-yoshi
 handleGHRelease: true
-extraFiles: ["README.adoc"]
+extraFiles: [
+  "README.adoc",
+  "spring-cloud-generator/scripts/resources/googleapis_modification_string.txt"
+]
 branches:
   - releaseType: java-yoshi
     handleGHRelease: true

--- a/spring-cloud-generator/scripts/resources/googleapis_modification_string.txt
+++ b/spring-cloud-generator/scripts/resources/googleapis_modification_string.txt
@@ -1,4 +1,4 @@
-_spring_cloud_generator_version = "4.2.1-SNAPSHOT" # {x-version-update:spring-cloud-gcp:current}
+_spring_cloud_generator_version = "4.3.1-SNAPSHOT" # {x-version-update:spring-cloud-gcp:current}
 
 maven_install(
     artifacts = [


### PR DESCRIPTION
Follow-up to https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1686, the generator SNAPSHOT version used to modify `googleapis/WORKSPACE` did not get updated after the latest spring-cloud-gcp release

Fixes: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1498#discussion_r1186323967