### PR TITLE
chore: remove links configuration for external packages (backport of #1689)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -711,10 +711,6 @@
 								<!-- Exclude samples and classes in the Firestore Google Client library packages -->
 								com.google.cloud.firestore
 							</excludePackageNames>
-							<links>
-								<link>https://javadoc.io/doc/com.google.cloud/google-cloud-vision/latest/</link>
-								<link>https://javadoc.io/doc/com.google.cloud/google-cloud-spanner/latest/</link>
-							</links>
 						</configuration>
 					</plugin>
 					<plugin>


### PR DESCRIPTION
Please see https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1689 for context on this javadoc links removal. Backporting this change to 3.x branch since I had missed it earlier.