### PR TITLE
fix: add spring-boot-configuration-processor to maven-compiler-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,6 +546,11 @@
 								</compilerArgs>
 								<annotationProcessorPaths>
 									<path>
+										<groupId>org.springframework.boot</groupId>
+										<artifactId>spring-boot-configuration-processor</artifactId>
+										<version>${spring-boot-dependencies.version}</version>
+									</path>
+									<path>
 										<groupId>com.google.errorprone</groupId>
 										<artifactId>error_prone_core</artifactId>
 										<version>${errorprone.version}</version>


### PR DESCRIPTION
Fixes #1842.

As follow-up to https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1775 which fixed the maven-compiler-plugin artifact id, this PR adds `spring-boot-configuration-processor `explicitly under `annotationProcessorPaths` configuration for `maven-compiler-plugin`, so that `spring-cloud-gcp-autoconfigure/target/META-INF/spring-configuration-metadata.json` gets generated at compile-time.