### PR TITLE
test: revert back to blanket sonar exclusion on spring-cloud-previews

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<integration-test.pattern>**/*IntegrationTest*</integration-test.pattern>
 		<!-- exclude preview module code from sonar cloud analysis -->
-		<sonar.exclusions>spring-cloud-previews/!(google-cloud-language-spring-starter)/**</sonar.exclusions>
+		<sonar.exclusions>spring-cloud-previews/**/*</sonar.exclusions>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
This PR reverts the sonar exclusion change from https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1816 to unblock CI.
 
I must have missed something in the exclusion glob pattern, and sonar analysis failed on main after merge ([details](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/runs/13494665939)). Seems like the analysis is picking up on code from generated modules (new in last 30 days: [google-cloud-dataproc-metastore-spring-starter](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-previews/google-cloud-dataproc-metastore-spring-starter)) when they intend to be excluded.

Going to verify this configuration out a bit more on a branch and retry the change (or possibly relocate the tests as suggested).