### PR TITLE
fix: Wiring `bigQueryThreadPoolTaskScheduler ` with `writeJsonStream`

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
@@ -147,6 +147,7 @@ public class GcpBigQueryAutoConfiguration {
     Map<String, Object> bqInitSettings = new HashMap<>();
     bqInitSettings.put("DATASET_NAME", this.datasetName);
     bqInitSettings.put("JSON_WRITER_BATCH_SIZE", this.jsonWriterBatchSize);
+    bqInitSettings.put("JSON_WRITER_THREAD_POOL_SIZE", this.threadPoolSize);
     return new BigQueryTemplate(
         bigQuery,
         bigQueryWriteClient,

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
@@ -138,7 +138,6 @@ public class GcpBigQueryAutoConfiguration {
     Map<String, Object> bqInitSettings = new HashMap<>();
     bqInitSettings.put("DATASET_NAME", this.datasetName);
     bqInitSettings.put("JSON_WRITER_BATCH_SIZE", this.jsonWriterBatchSize);
-    bqInitSettings.put("JSON_WRITER_THREAD_POOL_SIZE", this.threadPoolSize);
     return new BigQueryTemplate(
         bigQuery, bigQueryWriteClient, bqInitSettings, bigQueryThreadPoolTaskScheduler);
   }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
@@ -29,8 +29,6 @@ import com.google.cloud.spring.core.UserAgentHeaderProvider;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -121,12 +119,6 @@ public class GcpBigQueryAutoConfiguration {
   }
 
   @Bean
-  @ConditionalOnMissingBean(name = "jsonWriterExecutorService")
-  public ExecutorService jsonWriterExecutorService() {
-    return Executors.newFixedThreadPool(threadPoolSize);
-  }
-
-  @Bean
   @ConditionalOnMissingBean(name = "bigQueryThreadPoolTaskScheduler")
   public ThreadPoolTaskScheduler bigQueryThreadPoolTaskScheduler() {
     ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
@@ -142,17 +134,12 @@ public class GcpBigQueryAutoConfiguration {
       BigQuery bigQuery,
       BigQueryWriteClient bigQueryWriteClient,
       @Qualifier("bigQueryThreadPoolTaskScheduler")
-      ThreadPoolTaskScheduler bigQueryThreadPoolTaskScheduler,
-      @Qualifier("jsonWriterExecutorService") ExecutorService jsonWriterExecutorService) {
+      ThreadPoolTaskScheduler bigQueryThreadPoolTaskScheduler) {
     Map<String, Object> bqInitSettings = new HashMap<>();
     bqInitSettings.put("DATASET_NAME", this.datasetName);
     bqInitSettings.put("JSON_WRITER_BATCH_SIZE", this.jsonWriterBatchSize);
     bqInitSettings.put("JSON_WRITER_THREAD_POOL_SIZE", this.threadPoolSize);
     return new BigQueryTemplate(
-        bigQuery,
-        bigQueryWriteClient,
-        bqInitSettings,
-        bigQueryThreadPoolTaskScheduler,
-        jsonWriterExecutorService);
+        bigQuery, bigQueryWriteClient, bqInitSettings, bigQueryThreadPoolTaskScheduler);
   }
 }

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
@@ -319,7 +319,11 @@ public class BigQueryTemplate implements BigQueryOperations {
     writeApiFutureResponse.whenComplete(
         (writeApiResponse, exception) -> {
           if (exception != null || !writeApiResponse.isSuccessful()) {
-            logger.error("asyncTask interrupted");
+            if (exception != null) {
+              logger.error("asyncTask interrupted", exception);
+            } else {
+              logger.warn("Write operation failed");
+            }
             return;
           }
           logger.info("Data successfully written");

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
@@ -83,14 +83,15 @@ public class BigQueryTemplate implements BigQueryOperations {
   private static final int DEFAULT_JSON_STREAM_WRITER_BATCH_SIZE =
       1000; // write records in batches of 1000
 
-  private int jsonWriterThreadPoolSize = 10; // default pool size per instance of BigQueryTemplate
+  private static final int DEFAULT_JSON_WRITER_THREAD_POOL_SIZE =
+      10; // default pool size per instance of BigQueryTemplate
 
   private static final int MIN_JSON_STREAM_WRITER_BATCH_SIZE = 10; // minimum batch size
 
   private final Logger logger = LoggerFactory.getLogger(BigQueryTemplate.class);
 
   private final int jsonWriterBatchSize;
-  private ExecutorService jsonWriterExecutorService;
+  private final ExecutorService jsonWriterExecutorService;
 
   /**
    * A constructor which creates the {@link BigQuery} template with the default
@@ -108,8 +109,15 @@ public class BigQueryTemplate implements BigQueryOperations {
       BigQueryWriteClient bigQueryWriteClient,
       Map<String, Object> bqInitSettings,
       TaskScheduler taskScheduler) {
-    this(bigQuery, bigQueryWriteClient, bqInitSettings, taskScheduler, null);
-    this.jsonWriterExecutorService = Executors.newFixedThreadPool(jsonWriterThreadPoolSize);
+    this(
+        bigQuery,
+        bigQueryWriteClient,
+        bqInitSettings,
+        taskScheduler,
+        Executors.newFixedThreadPool(
+            (Integer)
+                bqInitSettings.getOrDefault(
+                    "JSON_WRITER_THREAD_POOL_SIZE", DEFAULT_JSON_WRITER_THREAD_POOL_SIZE)));
   }
 
   /**
@@ -135,6 +143,7 @@ public class BigQueryTemplate implements BigQueryOperations {
     Assert.notNull(bqDatasetName, "Dataset name must not be null");
     Assert.notNull(taskScheduler, "TaskScheduler must not be null");
     Assert.notNull(bigQueryWriteClient, "BigQueryWriteClient must not be null");
+    Assert.notNull(jsonWriterExecutorService, "ExecutorService must not be null");
     jsonWriterBatchSize =
         (Integer)
             bqInitSettings.getOrDefault(

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
@@ -48,8 +48,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -93,11 +91,9 @@ public class BigQueryTemplate implements BigQueryOperations {
   private final Logger logger = LoggerFactory.getLogger(BigQueryTemplate.class);
 
   private final int jsonWriterBatchSize;
-  private final ExecutorService jsonWriterExecutorService;
 
   /**
-   * A constructor which creates the {@link BigQuery} template with the default
-   * jsonWriterExecutorService
+   * A Full constructor which creates the {@link BigQuery} template.
    *
    * @param bigQuery the underlying client object used to interface with BigQuery
    * @param bigQueryWriteClient the underlying BigQueryWriteClient reference use to connect with
@@ -111,41 +107,11 @@ public class BigQueryTemplate implements BigQueryOperations {
       BigQueryWriteClient bigQueryWriteClient,
       Map<String, Object> bqInitSettings,
       TaskScheduler taskScheduler) {
-    this(
-        bigQuery,
-        bigQueryWriteClient,
-        bqInitSettings,
-        taskScheduler,
-        Executors.newFixedThreadPool(
-            (Integer)
-                bqInitSettings.getOrDefault(
-                    "JSON_WRITER_THREAD_POOL_SIZE", DEFAULT_JSON_WRITER_THREAD_POOL_SIZE)));
-  }
-
-  /**
-   * A Full constructor which creates the {@link BigQuery} template.
-   *
-   * @param bigQuery the underlying client object used to interface with BigQuery
-   * @param bigQueryWriteClient the underlying BigQueryWriteClient reference use to connect with
-   *     BigQuery Storage Write Client
-   * @param bqInitSettings Properties required for initialisation of this class
-   * @param taskScheduler the {@link TaskScheduler} used to poll for the status of long-running
-   *     BigQuery operations
-   * @param jsonWriterExecutorService the {@link ExecutorService} used to run the thread required
-   *     for the BigQuery JSON Writer
-   */
-  public BigQueryTemplate(
-      BigQuery bigQuery,
-      BigQueryWriteClient bigQueryWriteClient,
-      Map<String, Object> bqInitSettings,
-      TaskScheduler taskScheduler,
-      ExecutorService jsonWriterExecutorService) {
     String bqDatasetName = (String) bqInitSettings.get("DATASET_NAME");
     Assert.notNull(bigQuery, "BigQuery client object must not be null.");
     Assert.notNull(bqDatasetName, "Dataset name must not be null");
     Assert.notNull(taskScheduler, "TaskScheduler must not be null");
     Assert.notNull(bigQueryWriteClient, "BigQueryWriteClient must not be null");
-    Assert.notNull(jsonWriterExecutorService, "ExecutorService must not be null");
     jsonWriterBatchSize =
         (Integer)
             bqInitSettings.getOrDefault(
@@ -154,7 +120,6 @@ public class BigQueryTemplate implements BigQueryOperations {
     this.datasetName = bqDatasetName;
     this.taskScheduler = taskScheduler;
     this.bigQueryWriteClient = bigQueryWriteClient;
-    this.jsonWriterExecutorService = jsonWriterExecutorService;
   }
 
   /**

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
@@ -83,8 +83,7 @@ public class BigQueryTemplate implements BigQueryOperations {
   private static final int DEFAULT_JSON_STREAM_WRITER_BATCH_SIZE =
       1000; // write records in batches of 1000
 
-  private int jsonWriterThreadPoolSize =
-      10; // default pool size per instance of BigQueryTemplate. Use setter to override this
+  private int jsonWriterThreadPoolSize = 10; // default pool size per instance of BigQueryTemplate
 
   private static final int MIN_JSON_STREAM_WRITER_BATCH_SIZE = 10; // minimum batch size
 
@@ -110,17 +109,7 @@ public class BigQueryTemplate implements BigQueryOperations {
       Map<String, Object> bqInitSettings,
       TaskScheduler taskScheduler) {
     this(bigQuery, bigQueryWriteClient, bqInitSettings, taskScheduler, null);
-    this.jsonWriterExecutorService = getDefaultJsonWriterExecutorService();
-  }
-
-  private ExecutorService getDefaultJsonWriterExecutorService() {
-    return Executors.newFixedThreadPool(jsonWriterThreadPoolSize);
-  }
-
-  public void setJsonWriterThreadPoolSize(
-      int jsonWriterThreadPoolSize) { // this can be used for overriding the
-    // jsonWriterThreadPoolSize
-    this.jsonWriterThreadPoolSize = jsonWriterThreadPoolSize;
+    this.jsonWriterExecutorService = Executors.newFixedThreadPool(jsonWriterThreadPoolSize);
   }
 
   /**

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
@@ -259,15 +259,11 @@ public class BigQueryTemplate implements BigQueryOperations {
           try {
             WriteApiResponse apiResponse = getWriteApiResponse(tableName, jsonInputStream);
             writeApiFutureResponse.complete(apiResponse);
-          } catch (DescriptorValidationException | IOException e) {
-            writeApiFutureResponse.completeExceptionally(e);
-            Thread.currentThread().interrupt();
-            logger.warn(String.format("Error: %s %n", e.getMessage()), e);
           } catch (Exception e) {
             writeApiFutureResponse.completeExceptionally(e);
             // Restore interrupted state in case of an InterruptedException
             Thread.currentThread().interrupt();
-            logger.warn(String.format("Error: %s %n", e.getMessage()), e);
+            logger.warn("Unable to get write API response.", e);
           }
         };
 
@@ -278,7 +274,7 @@ public class BigQueryTemplate implements BigQueryOperations {
     writeApiFutureResponse.whenComplete(
         (writeApiResponse, exception) -> {
           if (exception != null || !writeApiResponse.isSuccessful()) {
-            logger.error("asyncTask interrupted", exception);
+            logger.error("asyncTask interrupted");
             return;
           }
           logger.info("Data successfully written");

--- a/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
+++ b/spring-cloud-gcp-bigquery/src/main/java/com/google/cloud/spring/bigquery/core/BigQueryTemplate.java
@@ -91,10 +91,11 @@ public class BigQueryTemplate implements BigQueryOperations {
   private final Logger logger = LoggerFactory.getLogger(BigQueryTemplate.class);
 
   private final int jsonWriterBatchSize;
-  private final ExecutorService jsonWriterExecutorService;
+  private ExecutorService jsonWriterExecutorService;
 
   /**
-   * A Full constructor which creates the {@link BigQuery} template.
+   * A constructor which creates the {@link BigQuery} template with the default
+   * jsonWriterExecutorService
    *
    * @param bigQuery the underlying client object used to interface with BigQuery
    * @param bigQueryWriteClient the underlying BigQueryWriteClient reference use to connect with
@@ -108,19 +109,7 @@ public class BigQueryTemplate implements BigQueryOperations {
       BigQueryWriteClient bigQueryWriteClient,
       Map<String, Object> bqInitSettings,
       TaskScheduler taskScheduler) {
-    String bqDatasetName = (String) bqInitSettings.get("DATASET_NAME");
-    Assert.notNull(bigQuery, "BigQuery client object must not be null.");
-    Assert.notNull(bqDatasetName, "Dataset name must not be null");
-    Assert.notNull(taskScheduler, "TaskScheduler must not be null");
-    Assert.notNull(bigQueryWriteClient, "BigQueryWriteClient must not be null");
-    jsonWriterBatchSize =
-        (Integer)
-            bqInitSettings.getOrDefault(
-                "JSON_WRITER_BATCH_SIZE", DEFAULT_JSON_STREAM_WRITER_BATCH_SIZE);
-    this.bigQuery = bigQuery;
-    this.datasetName = bqDatasetName;
-    this.taskScheduler = taskScheduler;
-    this.bigQueryWriteClient = bigQueryWriteClient;
+    this(bigQuery, bigQueryWriteClient, bqInitSettings, taskScheduler, null);
     this.jsonWriterExecutorService = getDefaultJsonWriterExecutorService();
   }
 

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
@@ -239,40 +239,44 @@ class BigQueryTemplateTest {
   }
 
   @Test
-  void writeJsonStreamNegativeTest()
-      throws DescriptorValidationException, IOException, InterruptedException, ExecutionException {
-    InputStream jsonInputStream = new ByteArrayInputStream(newLineSeperatedJson.getBytes());
-    WriteApiResponse apiResponse = new WriteApiResponse();
-    apiResponse.setSuccessful(false);
-    doReturn(apiResponse)
-        .when(bqTemplateSpy)
-        .getWriteApiResponse(any(String.class), any(InputStream.class));
+  void writeJsonStreamNegativeTest() {
+    try (InputStream jsonInputStream = new ByteArrayInputStream(newLineSeperatedJson.getBytes())) {
+      WriteApiResponse apiResponse = new WriteApiResponse();
+      apiResponse.setSuccessful(false);
+      doReturn(apiResponse)
+          .when(bqTemplateSpy)
+          .getWriteApiResponse(any(String.class), any(InputStream.class));
 
-    CompletableFuture<WriteApiResponse> futRes =
-        bqTemplateSpy.writeJsonStream(TABLE, jsonInputStream);
-    WriteApiResponse apiRes = futRes.get();
-    assertThat(apiRes.isSuccessful()).isFalse();
-    assertEquals(0, apiRes.getErrors().size());
+      CompletableFuture<WriteApiResponse> futRes =
+          bqTemplateSpy.writeJsonStream(TABLE, jsonInputStream);
+      WriteApiResponse apiRes = futRes.get();
+      assertThat(apiRes.isSuccessful()).isFalse();
+      assertEquals(0, apiRes.getErrors().size());
+    } catch (Exception e) {
+      fail("Error initialising the InputStream");
+    }
   }
 
   @Test
-  void writeJsonStreamThrowTest()
-      throws DescriptorValidationException, IOException, InterruptedException, ExecutionException {
-    InputStream jsonInputStream = new ByteArrayInputStream(newLineSeperatedJson.getBytes());
-    String failureMsg = "Operation failed";
-    Exception ioException = new IOException(failureMsg);
-    doThrow(ioException)
-        .when(bqTemplateSpy)
-        .getWriteApiResponse(any(String.class), any(InputStream.class));
+  void writeJsonStreamThrowTest() {
+    try (InputStream jsonInputStream = new ByteArrayInputStream(newLineSeperatedJson.getBytes())) {
+      String failureMsg = "Operation failed";
+      Exception ioException = new IOException(failureMsg);
+      doThrow(ioException)
+          .when(bqTemplateSpy)
+          .getWriteApiResponse(any(String.class), any(InputStream.class));
 
-    CompletableFuture<WriteApiResponse> futRes =
-        bqTemplateSpy.writeJsonStream(TABLE, jsonInputStream);
-    try {
-      futRes.get();
-      fail();
-    } catch (Exception ex) {
-      assertThat(ex.getCause() instanceof IOException).isTrue();
-      assertThat(ex.getCause().getMessage()).isEqualTo(failureMsg);
+      CompletableFuture<WriteApiResponse> futRes =
+          bqTemplateSpy.writeJsonStream(TABLE, jsonInputStream);
+      try {
+        futRes.get();
+        fail();
+      } catch (Exception ex) {
+        assertThat(ex.getCause() instanceof IOException).isTrue();
+        assertThat(ex.getCause().getMessage()).isEqualTo(failureMsg);
+      }
+    } catch (Exception e) {
+      fail("Error initialising the InputStream");
     }
   }
 

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
@@ -117,11 +117,7 @@ class BigQueryTemplateTest {
     bqTemplateSpy = Mockito.spy(bqTemplate);
     BigQueryTemplate bqTemplateDefaultPool =
         new BigQueryTemplate(
-            bigquery,
-            bigQueryWriteClientMock,
-            bqInitSettings,
-            getThreadPoolTaskScheduler(),
-            getDefaultExecutor());
+            bigquery, bigQueryWriteClientMock, bqInitSettings, getThreadPoolTaskScheduler());
     bqTemplateDefaultPool.setJsonWriterThreadPoolSize(10);
     bqTemplateDefaultPoolSpy = Mockito.spy(bqTemplateDefaultPool);
   }

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
@@ -118,7 +118,6 @@ class BigQueryTemplateTest {
     BigQueryTemplate bqTemplateDefaultPool =
         new BigQueryTemplate(
             bigquery, bigQueryWriteClientMock, bqInitSettings, getThreadPoolTaskScheduler());
-    bqTemplateDefaultPool.setJsonWriterThreadPoolSize(10);
     bqTemplateDefaultPoolSpy = Mockito.spy(bqTemplateDefaultPool);
   }
 

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
@@ -126,6 +126,7 @@ class BigQueryTemplateTest {
     scheduler.initialize();
     return scheduler;
   }
+
   @Test
   void getDatasetNameTest() {
     assertThat(bqTemplateSpy.getDatasetName()).isEqualTo(DATASET);

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
@@ -56,6 +56,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -106,8 +108,16 @@ class BigQueryTemplateTest {
     bqInitSettings.put("JSON_WRITER_BATCH_SIZE", JSON_WRITER_BATCH_SIZE);
     BigQueryTemplate bqTemplate =
         new BigQueryTemplate(
-            bigquery, bigQueryWriteClientMock, bqInitSettings, getThreadPoolTaskScheduler());
+            bigquery,
+            bigQueryWriteClientMock,
+            bqInitSettings,
+            getThreadPoolTaskScheduler(),
+            getDefaultExecutor());
     bqTemplateSpy = Mockito.spy(bqTemplate);
+  }
+
+  private ExecutorService getDefaultExecutor() {
+    return Executors.newFixedThreadPool(10);
   }
 
   private BigQueryOptions createBigQueryOptionsForProject(BigQueryRpcFactory rpcFactory) {

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
@@ -56,8 +56,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -109,20 +107,12 @@ class BigQueryTemplateTest {
     bqInitSettings.put("JSON_WRITER_BATCH_SIZE", JSON_WRITER_BATCH_SIZE);
     BigQueryTemplate bqTemplate =
         new BigQueryTemplate(
-            bigquery,
-            bigQueryWriteClientMock,
-            bqInitSettings,
-            getThreadPoolTaskScheduler(),
-            getDefaultExecutor());
+            bigquery, bigQueryWriteClientMock, bqInitSettings, getThreadPoolTaskScheduler());
     bqTemplateSpy = Mockito.spy(bqTemplate);
     BigQueryTemplate bqTemplateDefaultPool =
         new BigQueryTemplate(
             bigquery, bigQueryWriteClientMock, bqInitSettings, getThreadPoolTaskScheduler());
     bqTemplateDefaultPoolSpy = Mockito.spy(bqTemplateDefaultPool);
-  }
-
-  private ExecutorService getDefaultExecutor() {
-    return Executors.newFixedThreadPool(10);
   }
 
   private BigQueryOptions createBigQueryOptionsForProject(BigQueryRpcFactory rpcFactory) {

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/core/BigQueryTestConfiguration.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/core/BigQueryTestConfiguration.java
@@ -24,7 +24,6 @@ import com.google.cloud.spring.bigquery.integration.outbound.BigQueryFileMessage
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.config.EnableIntegration;
@@ -53,20 +52,12 @@ public class BigQueryTestConfiguration {
 
   @Bean
   public BigQueryTemplate bigQueryTemplate(
-      BigQuery bigQuery,
-      BigQueryWriteClient bigQueryWriteClient,
-      TaskScheduler taskScheduler,
-      ExecutorService jsonWriterExecutorService) {
+      BigQuery bigQuery, BigQueryWriteClient bigQueryWriteClient, TaskScheduler taskScheduler) {
     Map<String, Object> bqInitSettings = new HashMap<>();
     bqInitSettings.put("DATASET_NAME", DATASET_NAME);
     bqInitSettings.put("JSON_WRITER_BATCH_SIZE", JSON_WRITER_BATCH_SIZE);
     BigQueryTemplate bigQueryTemplate =
-        new BigQueryTemplate(
-            bigQuery,
-            bigQueryWriteClient,
-            bqInitSettings,
-            taskScheduler,
-            jsonWriterExecutorService);
+        new BigQueryTemplate(bigQuery, bigQueryWriteClient, bqInitSettings, taskScheduler);
     bigQueryTemplate.setWriteDisposition(WriteDisposition.WRITE_TRUNCATE);
     return bigQueryTemplate;
   }

--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/core/BigQueryTestConfiguration.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/core/BigQueryTestConfiguration.java
@@ -24,6 +24,7 @@ import com.google.cloud.spring.bigquery.integration.outbound.BigQueryFileMessage
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.config.EnableIntegration;
@@ -52,12 +53,20 @@ public class BigQueryTestConfiguration {
 
   @Bean
   public BigQueryTemplate bigQueryTemplate(
-      BigQuery bigQuery, BigQueryWriteClient bigQueryWriteClient, TaskScheduler taskScheduler) {
+      BigQuery bigQuery,
+      BigQueryWriteClient bigQueryWriteClient,
+      TaskScheduler taskScheduler,
+      ExecutorService jsonWriterExecutorService) {
     Map<String, Object> bqInitSettings = new HashMap<>();
     bqInitSettings.put("DATASET_NAME", DATASET_NAME);
     bqInitSettings.put("JSON_WRITER_BATCH_SIZE", JSON_WRITER_BATCH_SIZE);
     BigQueryTemplate bigQueryTemplate =
-        new BigQueryTemplate(bigQuery, bigQueryWriteClient, bqInitSettings, taskScheduler);
+        new BigQueryTemplate(
+            bigQuery,
+            bigQueryWriteClient,
+            bqInitSettings,
+            taskScheduler,
+            jsonWriterExecutorService);
     bigQueryTemplate.setWriteDisposition(WriteDisposition.WRITE_TRUNCATE);
     return bigQueryTemplate;
   }


### PR DESCRIPTION
This PR Wires `ThreadPoolTaskScheduler` with `writeJsonStream`. 

User can use `bigQueryThreadPoolTaskScheduler` in order to avoid `java.lang.OutOfMemoryError` which was arising due to too many concurrent write threads working. 

Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/1599