### PR TITLE
fix(deps): Revert "fix(deps): update dependency com.google.cloud:libraries-bom to v26.15.0 (main)"

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -34,7 +34,7 @@
 	</distributionManagement>
 
 	<properties>
-		<gcp-libraries-bom.version>26.15.0</gcp-libraries-bom.version>
+		<gcp-libraries-bom.version>26.14.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.11.1</cloud-sql-socket-factory.version>
 		<guava.version>31.1-jre</guava.version>
 		<r2dbc-postgres-driver.version>1.0.1.RELEASE</r2dbc-postgres-driver.version>


### PR DESCRIPTION
Reverts GoogleCloudPlatform/spring-cloud-gcp#1857

This is to retry the libraries-bom update, per https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1808#issuecomment-1550166581. 