### PR TITLE
deps: update protobuf version used to compile generator test protos to 3.23.1

### DIFF
--- a/spring-cloud-generator/pom.xml
+++ b/spring-cloud-generator/pom.xml
@@ -18,7 +18,7 @@
         <gapic-generator-java-bom.version>2.20.0</gapic-generator-java-bom.version>
         <!-- [gapic-test]: protobuf.version for compiling protos used in unit testing
              this should be consistent with version in gapic-generator-java-bom -->
-        <protobuf.version>3.21.12</protobuf.version>
+        <protobuf.version>3.23.1</protobuf.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Follow-up to https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1895:

* Update `protobuf version` (for compiling test protos) from 3.21.12 to 3.23.1, for consistency with version in `gapic-generator-java-bom`, which was updated in the latest [2.20.0 release](https://github.com/googleapis/sdk-platform-java/releases/tag/v2.20.0).
