### PR TITLE
chore(docs): update spring-cloud-build to 4.0.3 and override inherited versions not available in maven central

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>3.1.7</version>
+		<version>4.0.3</version>
 		<relativePath/>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
@@ -24,28 +24,11 @@
 
 		<!--maven-resources-plugin:3.2.0:copy-resources fails: https://issues.apache.org/jira/browse/MSHARED-966-->
 		<maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+		<!-- override version inherited from spring-cloud-build parent to one that is available on Maven Central -->
+		<spring-asciidoctor-backends.version>0.0.4</spring-asciidoctor-backends.version>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>spring-releases</id>
-			<name>Spring Releases</name>
-			<url>https://repo.spring.io/release</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-releases</id>
-			<name>Spring Releases</name>
-			<url>https://repo.spring.io/release</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
+
 
 	<profiles>
 		<profile>


### PR DESCRIPTION
Attempt at a workaround for https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/1909, following @zhumin8's investigation:
* Update spring-cloud-build version to 4.0.3 ([spring-asciidoctor-backends 0.0.3](https://github.com/spring-cloud/spring-cloud-build/blob/8420504e81493ba1f4630bad9f2b85302a160fdb/pom.xml#L36) is inherited but only available in spring releases repo, so an override is added for this to a later version (0.0.4) available in [maven central](https://mvnrepository.com/artifact/io.spring.asciidoctor.backends/spring-asciidoctor-backends). 