### PR TITLE
chore(docs): update spring-cloud-build to 4.0.3 and override inherited versions not in maven central (backport of #1910)

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>3.1.7</version>
+		<version>4.0.3</version>
 		<relativePath/>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
@@ -24,28 +24,11 @@
 
 		<!--maven-resources-plugin:3.2.0:copy-resources fails: https://issues.apache.org/jira/browse/MSHARED-966-->
 		<maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+		<!-- override version inherited from spring-cloud-build parent to one that is available on Maven Central -->
+		<spring-asciidoctor-backends.version>0.0.4</spring-asciidoctor-backends.version>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>spring-releases</id>
-			<name>Spring Releases</name>
-			<url>https://repo.spring.io/release</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-releases</id>
-			<name>Spring Releases</name>
-			<url>https://repo.spring.io/release</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
+
 
 	<profiles>
 		<profile>


### PR DESCRIPTION
This is a backport of https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1910 to unblock refdocs publishing on the 3.x branch. See issue https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/1909 for details.