### PR TITLE
chore: migrate vision it test to JUnit5 (backport #1871)

### DIFF
--- a/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-vision/src/test/java/com/google/cloud/spring/vision/it/CloudVisionTemplateIntegrationTests.java
@@ -1,36 +1,27 @@
 package com.google.cloud.spring.vision.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.google.cloud.spring.vision.CloudVisionTemplate;
 import java.util.List;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@EnabledIfSystemProperty(named = "it.vision", matches = "true")
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {VisionTestConfiguration.class})
-public class CloudVisionTemplateIntegrationTests {
+class CloudVisionTemplateIntegrationTests {
 
   @Autowired private CloudVisionTemplate cloudVisionTemplate;
 
-  @BeforeClass
-  public static void prepare() {
-    assumeThat(System.getProperty("it.vision"))
-        .as(
-            "Vision Sample integration tests are disabled. "
-                + "Please use '-Dit.vision=true' to enable them.")
-        .isEqualTo("true");
-  }
-
   @Test
-  public void testExtractTextFromSinglePagePdf() {
+  void testExtractTextFromSinglePagePdf() {
     Resource dummyPdf = new ClassPathResource("documents/single-page-dummy.pdf");
 
     List<String> extractedTexts = cloudVisionTemplate.extractTextFromPdf(dummyPdf);
@@ -39,7 +30,7 @@ public class CloudVisionTemplateIntegrationTests {
   }
 
   @Test
-  public void testExtractTextFromMultiPagePdf() {
+  void testExtractTextFromMultiPagePdf() {
     Resource dummyPdf = new ClassPathResource("documents/multi-page-dummy.pdf");
 
     List<String> extractedTexts = cloudVisionTemplate.extractTextFromPdf(dummyPdf);


### PR DESCRIPTION
This `CloudVisionTemplateIntegrationTests.java` was missed in #1027.  Migrating it to JUnit5 for consistency.