### PR TITLE
chore: adding profiles for native compile testings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
 			<dependency>
 				<groupId>org.junit.platform</groupId>
 				<artifactId>junit-platform-launcher</artifactId>
-				<version>1.9.2</version>
+				<version>1.9.3</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>
@@ -363,13 +363,13 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>${maven-surefire-plugin.version}</version>
 					<configuration>
 						<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
 						<excludes combine.self="override" />
 						<includes>
 							<!--including all integration tests for testing purposes. -->
-							<include>**/*IntegrationTests.java</include>
+							<include>${integration-test.pattern}</include>
 						</includes>
 						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
 						<systemPropertyVariables>
@@ -380,7 +380,7 @@
 				<plugin>
 					<groupId>org.graalvm.buildtools</groupId>
 					<artifactId>native-maven-plugin</artifactId>
-					<version>0.9.20</version>
+					<version>0.9.22</version>
 					<configuration>
 						<buildArgs>
 							<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
@@ -404,7 +404,7 @@
 				<plugin>
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-maven-plugin</artifactId>
-					<version>3.0.5</version>
+					<version>3.0.7</version>
 					<executions>
 						<execution>
 							<id>process-test-aot</id>

--- a/pom.xml
+++ b/pom.xml
@@ -336,10 +336,88 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.graalvm.buildtools</groupId>
+				<artifactId>native-maven-plugin</artifactId>
+				<version>0.9.20</version>
+				<extensions>true</extensions>
+			</plugin>
 		</plugins>
 	</build>
 
 	<profiles>
+	<profile>
+		<id>spring-native</id>
+
+		<dependencies>
+			<dependency>
+				<groupId>org.junit.platform</groupId>
+				<artifactId>junit-platform-launcher</artifactId>
+				<version>1.9.2</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.0.0</version>
+					<configuration>
+						<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
+						<excludes combine.self="override" />
+						<includes>
+							<!--including all integration tests for testing purposes. -->
+							<include>**/*IntegrationTests.java</include>
+						</includes>
+						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+						<systemPropertyVariables>
+						<!--integration tests are not invoked unless the relevant system property is set to true here. -->
+						</systemPropertyVariables>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.graalvm.buildtools</groupId>
+					<artifactId>native-maven-plugin</artifactId>
+					<version>0.9.20</version>
+					<configuration>
+						<buildArgs>
+							<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
+							<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+						</buildArgs>
+						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+						<metadataRepository>
+							<enabled>true</enabled>
+						</metadataRepository>
+					</configuration>
+					<executions>
+						<execution>
+							<id>native-test</id>
+							<goals>
+								<goal>test</goal>
+							</goals>
+							<phase>test</phase>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-maven-plugin</artifactId>
+					<version>3.0.5</version>
+					<executions>
+						<execution>
+							<id>process-test-aot</id>
+							<goals>
+								<goal>process-test-aot</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</build>
+	</profile>
+
 		<profile>
 			<id>default</id>
 			<activation>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
 		<checkstyle-rules.version>9.3</checkstyle-rules.version>
 		<asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
 		<errorprone.version>2.19.1</errorprone.version>
+		<native-maven-plugin.version>0.9.22</native-maven-plugin.version>
 
 		<!-- All checks except for javadoc enforced by default -->
 		<skip.failsafe.tests>${skipTests}</skip.failsafe.tests>
@@ -340,7 +341,7 @@
 			<plugin>
 				<groupId>org.graalvm.buildtools</groupId>
 				<artifactId>native-maven-plugin</artifactId>
-				<version>0.9.20</version>
+				<version>${native-maven-plugin.version}</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>
@@ -380,7 +381,7 @@
 				<plugin>
 					<groupId>org.graalvm.buildtools</groupId>
 					<artifactId>native-maven-plugin</artifactId>
-					<version>0.9.22</version>
+					<version>${native-maven-plugin.version}</version>
 					<configuration>
 						<buildArgs>
 							<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
@@ -404,7 +405,6 @@
 				<plugin>
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-maven-plugin</artifactId>
-					<version>3.0.7</version>
 					<executions>
 						<execution>
 							<id>process-test-aot</id>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -79,56 +79,19 @@
 
 	<profiles>
 		<profile>
-			<id>native-sample</id>
-			<dependencies>
-				<dependency>
-					<groupId>org.junit.platform</groupId>
-					<artifactId>junit-platform-launcher</artifactId>
-					<version>1.9.3</version>
-					<scope>test</scope>
-				</dependency>
-			</dependencies>
+			<id>native-sample-config</id>
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<version>${maven-surefire-plugin.version}</version>
-						<configuration>
-							<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
-							<excludes combine.self="override" />
-							<includes>
-								<!--including all integration tests for testing purposes.-->
-								<include>${integration-test.pattern}</include>
-							</includes>
-							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
-							<systemPropertyVariables>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-					<plugin>
 						<groupId>org.graalvm.buildtools</groupId>
 						<artifactId>native-maven-plugin</artifactId>
-						<version>0.9.22</version>
-						<extensions>true</extensions>
 						<configuration>
 							<buildArgs>
 								<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
 								<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
 							</buildArgs>
-							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
-							<metadataRepository>
-								<enabled>true</enabled>
-							</metadataRepository>
 						</configuration>
 						<executions>
-							<execution>
-								<id>native-test</id>
-								<goals>
-									<goal>test</goal>
-								</goals>
-								<phase>test</phase>
-							</execution>
 							<execution>
 								<id>build-native</id>
 								<goals>
@@ -138,18 +101,28 @@
 							</execution>
 						</executions>
 					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>nativeTest</id>
+			<build>
+				<plugins>
 					<plugin>
-						<groupId>org.springframework.boot</groupId>
-						<artifactId>spring-boot-maven-plugin</artifactId>
-						<version>3.0.7</version>
-						<executions>
-							<execution>
-								<id>process-test-aot</id>
-								<goals>
-									<goal>process-test-aot</goal>
-								</goals>
-							</execution>
-						</executions>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
+							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+							<excludes combine.self="override" />
+							<includes>
+								<!--including all integration tests for testing purposes.-->
+								<include>${integration-test.pattern}</include>
+							</includes>
+							<systemPropertyVariables>
+								<it.logging>true</it.logging>
+							</systemPropertyVariables>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -84,7 +84,7 @@
 				<dependency>
 					<groupId>org.junit.platform</groupId>
 					<artifactId>junit-platform-launcher</artifactId>
-					<version>1.9.2</version>
+					<version>1.9.3</version>
 					<scope>test</scope>
 				</dependency>
 			</dependencies>
@@ -93,7 +93,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>3.0.0</version>
+						<version>${maven-surefire-plugin.version}</version>
 						<configuration>
 							<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
 							<excludes combine.self="override" />
@@ -110,7 +110,7 @@
 					<plugin>
 						<groupId>org.graalvm.buildtools</groupId>
 						<artifactId>native-maven-plugin</artifactId>
-						<version>0.9.20</version>
+						<version>0.9.22</version>
 						<extensions>true</extensions>
 						<configuration>
 							<buildArgs>
@@ -142,7 +142,7 @@
 					<plugin>
 						<groupId>org.springframework.boot</groupId>
 						<artifactId>spring-boot-maven-plugin</artifactId>
-						<version>3.0.5</version>
+						<version>3.0.7</version>
 						<executions>
 							<execution>
 								<id>process-test-aot</id>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -103,7 +103,6 @@
 							</includes>
 							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
 							<systemPropertyVariables>
-								<it.logging>true</it.logging>
 							</systemPropertyVariables>
 						</configuration>
 					</plugin>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -79,6 +79,83 @@
 
 	<profiles>
 		<profile>
+			<id>native-sample</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.junit.platform</groupId>
+					<artifactId>junit-platform-launcher</artifactId>
+					<version>1.9.2</version>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>3.0.0</version>
+						<configuration>
+							<!-- https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#integration-tests.no-starter-parent -->
+							<excludes combine.self="override" />
+							<includes>
+								<!--including all integration tests for testing purposes.-->
+								<include>${integration-test.pattern}</include>
+							</includes>
+							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+							<systemPropertyVariables>
+								<it.logging>true</it.logging>
+							</systemPropertyVariables>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>0.9.20</version>
+						<extensions>true</extensions>
+						<configuration>
+							<buildArgs>
+								<buildArg>--trace-class-initialization=org.apache.commons.logging.LogFactoryService</buildArg>
+								<buildArg>--initialize-at-build-time=org.apache.commons.logging.LogFactory</buildArg>
+							</buildArgs>
+							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+							<metadataRepository>
+								<enabled>true</enabled>
+							</metadataRepository>
+						</configuration>
+						<executions>
+							<execution>
+								<id>native-test</id>
+								<goals>
+									<goal>test</goal>
+								</goals>
+								<phase>test</phase>
+							</execution>
+							<execution>
+								<id>build-native</id>
+								<goals>
+									<goal>compile-no-fork</goal>
+								</goals>
+								<phase>package</phase>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<version>3.0.5</version>
+						<executions>
+							<execution>
+								<id>process-test-aot</id>
+								<goals>
+									<goal>process-test-aot</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>spring-cloud-gcp-ci-it</id>
 			<build>
 				<plugins>
@@ -116,6 +193,12 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.graalvm.buildtools</groupId>
+					<artifactId>native-maven-plugin</artifactId>
+					<version>0.9.20</version>
+					<extensions>true</extensions>
+				</plugin>
 				<plugin>
 					<groupId>com.google.cloud.tools</groupId>
 					<artifactId>appengine-maven-plugin</artifactId>


### PR DESCRIPTION
Based off https://github.com/mpeddada1/spring-cloud-gcp-current/pull/1, adding `spring-native` for parent pom, and `native-sample` for samples pom.
These added profile should not have any affect on existing workflows.
To be followed by #1933 .

Install and use GraalVM compiler and install native image extension with `gu install native-image`.
To package and run sample as native, instead of `mvn spring-boot:run`:
` mvn clean package -Pnative-sample -DskipTests` then execute the target built.
To run integration tests of sample as native, add relevant system property to `systemPropertyVariables` :
` mvn -Pnative-sample clean test`
