### PR TITLE
chore: manual upgrade maven-surefire-plugin.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
 		<maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
 		<maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+		<maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 		<nexus-staging-plugin.version>1.6.13</nexus-staging-plugin.version>


### PR DESCRIPTION
Noticed maven-surefire-plugin in pom haven't upgraded since [Oct.2020](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/e47582ec714c2a85a83641d0e7544b52f7f1d7ef), while `maven-failsafe-plugin` is picked up by bot and upgraded (latest [pr](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1927) to 3.1.2).
From dependabot report, it is ignored due to a setup to ignore major version upgrade in `.github/dependabot.yml` added in #1367:
```
updater | 2023/06/08 05:01:36 INFO <job_675192547> Checking if org.apache.maven.plugins:maven-surefire-plugin 2.22.2 needs updating
updater | 2023/06/08 05:01:36 INFO <job_675192547> Ignored versions:
updater | 2023/06/08 05:01:36 INFO <job_675192547> version-update:semver-major - from .github/dependabot.yml
proxy | 2023/06/08 05:01:36 [488] GET https://repo.maven.apache.org:443/maven2/org/apache/maven/plugins/maven-surefire-plugin/maven-metadata.xml
proxy | 2023/06/08 05:01:36 [488] 200 https://repo.maven.apache.org:443/maven2/org/apache/maven/plugins/maven-surefire-plugin/maven-metadata.xml
updater | 2023/06/08 05:01:36 INFO <job_675192547> All updates for org.apache.maven.plugins:maven-surefire-plugin were ignored

```
This change was introduced late 2022 and major version 3.0.0 came out in 2023.([ref](https://deps.dev/maven/org.apache.maven.plugins%3Amaven-surefire-plugin/3.1.2/versions))

@emmileaf Dependabot silently ignoring major version bumps may leave our non-major dependency outdated without us noticing it. we may want to rethink about this ignore strategy?