### PR TITLE
chore(deps): update gapic-generator-java-bom.version to v2.21.0 

### DIFF
--- a/spring-cloud-generator/pom.xml
+++ b/spring-cloud-generator/pom.xml
@@ -15,7 +15,7 @@
     <description>Spring Code Generator for Google Cloud</description>
 
     <properties>
-        <gapic-generator-java-bom.version>2.20.1</gapic-generator-java-bom.version>
+        <gapic-generator-java-bom.version>2.21.0</gapic-generator-java-bom.version>
         <!-- [gapic-test]: protobuf.version for compiling protos used in unit testing
              this should be consistent with version in gapic-generator-java-bom -->
         <protobuf.version>3.21.12</protobuf.version>

--- a/spring-cloud-generator/pom.xml
+++ b/spring-cloud-generator/pom.xml
@@ -18,7 +18,7 @@
         <gapic-generator-java-bom.version>2.21.0</gapic-generator-java-bom.version>
         <!-- [gapic-test]: protobuf.version for compiling protos used in unit testing
              this should be consistent with version in gapic-generator-java-bom -->
-        <protobuf.version>3.21.12</protobuf.version>
+        <protobuf.version>3.23.2</protobuf.version>
     </properties>
 
     <dependencyManagement>

--- a/spring-cloud-generator/src/test/java/com/google/cloud/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
+++ b/spring-cloud-generator/src/test/java/com/google/cloud/generator/spring/composer/goldens/EchoSpringAutoConfigurationFull.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-generator/src/test/java/com/google/cloud/generator/spring/composer/goldens/EchoSpringPropertiesFull.golden
+++ b/spring-cloud-generator/src/test/java/com/google/cloud/generator/spring/composer/goldens/EchoSpringPropertiesFull.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-generator/src/test/java/com/google/cloud/generator/spring/composer/goldens/SpringPackageInfoFull.golden
+++ b/spring-cloud-generator/src/test/java/com/google/cloud/generator/spring/composer/goldens/SpringPackageInfoFull.golden
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Opening a manual PR to make this gapic-generator-java version bump, as it also requires:
* Spring generator golden test updates, to reflect new copyright year in license header template (https://github.com/googleapis/sdk-platform-java/pull/1720)
* Update protobuf.version used in testing to 3.23.2 (aligning with https://github.com/googleapis/sdk-platform-java/releases/tag/v2.21.0 update)

This PR should supersede https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1929 and https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1928 (currently blocked on presubmits)