### PR TITLE
chore: migrate from `dev.miku:r2dbc-mysql` to `io.asyncer:r2dbc-mysql` 

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -124,7 +124,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>dev.miku</groupId>
+            <groupId>io.asyncer</groupId>
             <artifactId>r2dbc-mysql</artifactId>
             <optional>true</optional>
         </dependency>

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/R2dbcCloudSqlEnvironmentPostProcessor.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/R2dbcCloudSqlEnvironmentPostProcessor.java
@@ -108,7 +108,7 @@ public class R2dbcCloudSqlEnvironmentPostProcessor implements EnvironmentPostPro
         && isOnClasspath("com.google.cloud.sql.CredentialFactory")
         && isOnClasspath("io.r2dbc.spi.ConnectionFactory")) {
       if (isOnClasspath("com.google.cloud.sql.core.GcpConnectionFactoryProviderMysql")
-          && isOnClasspath("dev.miku.r2dbc.mysql.MySqlConnectionFactoryProvider")) {
+          && isOnClasspath("io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider")) {
         return DatabaseType.MYSQL;
       } else if (isOnClasspath("com.google.cloud.sql.core.GcpConnectionFactoryProviderPostgres")
           && isOnClasspath("io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider")) {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/sql/R2dbcCloudSqlEnvironmentPostProcessorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/sql/R2dbcCloudSqlEnvironmentPostProcessorTests.java
@@ -108,7 +108,7 @@ class R2dbcCloudSqlEnvironmentPostProcessorTests {
         .withPropertyValues(
             "spring.cloud.gcp.sql.databaseName=my-database",
             "spring.cloud.gcp.sql.instanceConnectionName=my-project:region:my-instance")
-        .withClassLoader(excludeDriverPackages(new String[] {"dev.miku.r2dbc.mysql"}))
+        .withClassLoader(excludeDriverPackages(new String[] {"io.asyncer.r2dbc.mysql"}))
         .run(
             context -> {
               assertThat(context.getEnvironment().getProperty("spring.r2dbc.url"))
@@ -192,7 +192,7 @@ class R2dbcCloudSqlEnvironmentPostProcessorTests {
     // Because `FilteredClassLoader` accepts a list of packages to remove from classpath,
     // `driverPackagesToInclude` is used to calculate the inverse list of packages to _exclude_.
     Set<String> driverPackagesToExclude = new HashSet<>(
-        Arrays.asList("io.r2dbc.postgresql", "dev.miku.r2dbc.mysql"));
+        Arrays.asList("io.r2dbc.postgresql", "io.asyncer.r2dbc.mysql"));
     Arrays.stream(driverPackagesToInclude)
         .forEach(driverPackagesToExclude::remove);
 

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -32,7 +32,7 @@
 		<gcp-libraries-bom.version>26.17.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.12.0</cloud-sql-socket-factory.version>
 		<guava.version>31.1-jre</guava.version>
-		<r2dbc-mysql-driver.version>0.8.2.RELEASE</r2dbc-mysql-driver.version>
+		<r2dbc-mysql-driver.version>0.9.3</r2dbc-mysql-driver.version>
 		<r2dbc-postgres-driver.version>0.8.13.RELEASE</r2dbc-postgres-driver.version>
 	</properties>
 
@@ -277,16 +277,6 @@
 			</dependency>
 			<dependency>
 				<groupId>io.asyncer</groupId>
-				<artifactId>r2dbc-mysql</artifactId>
-				<version>0.9.3</version>
-			</dependency>
-
-			<!-- Spring Boot 2.7 no longer manages this dependency.
-			     Replace with MariaDB driver once it's supported.
-			     https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/990
-			 -->
-			<dependency>
-				<groupId>dev.miku</groupId>
 				<artifactId>r2dbc-mysql</artifactId>
 				<version>${r2dbc-mysql-driver.version}</version>
 			</dependency>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -275,6 +275,11 @@
 				<artifactId>cloud-sql-connector-r2dbc-mysql</artifactId>
 				<version>${cloud-sql-socket-factory.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>io.asyncer</groupId>
+				<artifactId>r2dbc-mysql</artifactId>
+				<version>0.9.3</version>
+			</dependency>
 
 			<!-- Spring Boot 2.7 no longer manages this dependency.
 			     Replace with MariaDB driver once it's supported.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-r2dbc-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-r2dbc-sample/pom.xml
@@ -35,10 +35,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.asyncer</groupId>
-            <artifactId>r2dbc-mysql</artifactId>
-        </dependency>
 
         <!-- Test-related dependencies. -->
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-r2dbc-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-r2dbc-sample/pom.xml
@@ -35,6 +35,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.asyncer</groupId>
+            <artifactId>r2dbc-mysql</artifactId>
+        </dependency>
 
         <!-- Test-related dependencies. -->
         <dependency>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql-mysql-r2dbc/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql-mysql-r2dbc/pom.xml
@@ -29,7 +29,7 @@
             <artifactId>cloud-sql-connector-r2dbc-mysql</artifactId>
         </dependency>
         <dependency>
-            <groupId>dev.miku</groupId>
+            <groupId>io.asyncer</groupId>
             <artifactId>r2dbc-mysql</artifactId>
         </dependency>
 


### PR DESCRIPTION
Fixes regression brought by https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1950

After merging it, the Cloud SQL Mysql R2DBC IT started failing. Details in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1951#issuecomment-1591912710

It was suggested in https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/blame/24e35149b74e661276607e6b8341ca518ed91427/docs/r2dbc-mysql.md#L23 (seems like a recent addition)

EDIT: as per https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1955#discussion_r1230352167 I transformed this PR in a migration to `io.asyncer:r2dbc-mysql`