### PR TITLE
chore: Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,5 @@
 {
-  "packageRules": [{
-    "packageNames": [
-      "com.coveo:fmt-maven-plugin",
-      "com.google.googlejavaformat:google-java-format"
-    ],
-    "enabled": false
-  },
-    {
-      "major": {
-        "enabled": false
-      }
-    },
+  "packageRules": [
     {
       "matchPackageNames": ["org.springframework.boot:spring-boot-dependencies"],
       "allowedVersions": "<3.0.0"
@@ -44,4 +33,3 @@
     "3.x-dependencies"
   ]
 }
-

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     },
     {
       "matchPackageNames": ["org.springframework.cloud:spring-cloud-dependencies"],
-      "allowedVersions": "<2022.0"
+      "allowedVersions": "<2022.0.0"
     },
     {
       "matchPackageNames": ["org.springframework.cloud:spring-cloud-config"],

--- a/renovate.json
+++ b/renovate.json
@@ -2,31 +2,31 @@
   "packageRules": [
     {
       "matchPackageNames": ["org.springframework.boot:spring-boot-dependencies"],
-      "allowedVersions": "<3.0.0"
+      "allowedVersions": "<4.0.0"
     },
     {
       "matchPackageNames": ["org.springframework.boot:spring-boot-starter-parent"],
-      "allowedVersions": "<3.0.0"
+      "allowedVersions": "<4.0.0"
     },
     {
       "matchPackageNames": ["org.springframework.cloud:spring-cloud-dependencies"],
-      "allowedVersions": "<2022.0.0"
+      "allowedVersions": "<2023.0"
     },
     {
       "matchPackageNames": ["org.springframework.cloud:spring-cloud-config"],
-      "allowedVersions": "<4.0.0"
+      "allowedVersions": "<5.0.0"
     },
     {
       "matchPackageNames": ["org.springframework.cloud:spring-cloud-function"],
-      "allowedVersions": "<4.0.0"
+      "allowedVersions": "<5.0.0"
     },
     {
       "matchPackageNames": ["org.springframework.cloud:spring-cloud-dependencies-parent"],
-      "allowedVersions": "<4.0.0"
+      "allowedVersions": "<5.0.0"
     },
     {
       "matchPackageNames": ["org.springframework.shell:spring-shell-starter"],
-      "allowedVersions": "<3.0.0"
+      "allowedVersions": "<4.0.0"
     }
   ],
   "labels": [

--- a/renovate.json
+++ b/renovate.json
@@ -2,31 +2,31 @@
   "packageRules": [
     {
       "matchPackageNames": ["org.springframework.boot:spring-boot-dependencies"],
-      "allowedVersions": "<4.0.0"
+      "allowedVersions": "<3.0.0"
     },
     {
       "matchPackageNames": ["org.springframework.boot:spring-boot-starter-parent"],
-      "allowedVersions": "<4.0.0"
+      "allowedVersions": "<3.0.0"
     },
     {
       "matchPackageNames": ["org.springframework.cloud:spring-cloud-dependencies"],
-      "allowedVersions": "<2023.0"
+      "allowedVersions": "<2022.0"
     },
     {
       "matchPackageNames": ["org.springframework.cloud:spring-cloud-config"],
-      "allowedVersions": "<5.0.0"
+      "allowedVersions": "<4.0.0"
     },
     {
       "matchPackageNames": ["org.springframework.cloud:spring-cloud-function"],
-      "allowedVersions": "<5.0.0"
+      "allowedVersions": "<4.0.0"
     },
     {
       "matchPackageNames": ["org.springframework.cloud:spring-cloud-dependencies-parent"],
-      "allowedVersions": "<5.0.0"
+      "allowedVersions": "<4.0.0"
     },
     {
       "matchPackageNames": ["org.springframework.shell:spring-shell-starter"],
-      "allowedVersions": "<4.0.0"
+      "allowedVersions": "<3.0.0"
     }
   ],
   "labels": [


### PR DESCRIPTION
It is currently configured((in the `main` branch) with these options:

1. `”baseBranches": ["main", “3.x”]` which tells it to read the config for each branch separately. (https://docs.renovatebot.com/configuration-options/#basebranches)

2. `"useBaseBranchConfig": "merge"` which tells it to merge the branch-specific config on top of the default branch config (https://docs.renovatebot.com/configuration-options/#usebasebranchconfig).

This config change along with base branch config on top of it matches the overall dependabot [configuration in 3.x](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/3.x/.github/dependabot.yml) branch. 

This should ideally work. If it doesn't, I can try to setup triggers on renovate-bot to work on the two branches separately maybe?  


