### PR TITLE
chore(deps): Use an explicit dependency on mysql-socket-factory-connector-j8 

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -81,7 +81,7 @@
         <!-- Adds SocketFactory and MySQL driver to classpath -->
         <dependency>
             <groupId>com.google.cloud.sql</groupId>
-            <artifactId>mysql-socket-factory</artifactId>
+            <artifactId>mysql-socket-factory-connector-j-8</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -253,7 +253,7 @@
 
 			<dependency>
 				<groupId>com.google.cloud.sql</groupId>
-				<artifactId>mysql-socket-factory</artifactId>
+				<artifactId>mysql-socket-factory-connector-j-8</artifactId>
 				<version>${cloud-sql-socket-factory.version}</version>
 			</dependency>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql-mysql/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-sql-mysql/pom.xml
@@ -24,7 +24,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.google.cloud.sql</groupId>
-			<artifactId>mysql-socket-factory</artifactId>
+			<artifactId>mysql-socket-factory-connector-j-8</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.mysql</groupId>


### PR DESCRIPTION
Update spring-cloud-gcp projects to depend explicitly on mysql-socket-factory-connector-j-8, instead of 
relying on the central maven repo to replace dependencies on `mysql-socket-factory` with
`mysql-socket-factory-connector-j-8`. 

This change should not have any effect on the classpath of existing customer applications. Customers
are already using `mysql-socket-factory-connector-j-8`  due to the relocation directive for the `mysql-socket-factory`
dependency. 

MySQL Connector/J 5.0.x is no longer under development and has significant security vulnerabilities. 
We strongly recommend all users update to 8.0.x instead. See the following GitHub issue for more details: https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/1243

Fixes #1982
Related to [cloud-sql-jdbc-socket-factory #1333](https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/1333)