### PR TITLE
fix: timestampNanos nanos precision.

### DIFF
--- a/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/StackdriverJsonLayout.java
+++ b/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/StackdriverJsonLayout.java
@@ -271,9 +271,10 @@ public class StackdriverJsonLayout extends JsonLayout {
       map.put(
           StackdriverTraceConstants.TIMESTAMP_SECONDS_ATTRIBUTE,
           TimeUnit.MILLISECONDS.toSeconds(event.getTimeStamp()));
+      int nanoseconds = event.getNanoseconds();
       map.put(
           StackdriverTraceConstants.TIMESTAMP_NANOS_ATTRIBUTE,
-          TimeUnit.MILLISECONDS.toNanos(event.getTimeStamp() % 1_000));
+          nanoseconds == -1 ? TimeUnit.MILLISECONDS.toNanos(event.getTimeStamp() % 1_000) : nanoseconds);
     }
 
     add(

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/StackdriverJsonLayoutLoggerTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/StackdriverJsonLayoutLoggerTests.java
@@ -247,6 +247,22 @@ class StackdriverJsonLayoutLoggerTests {
   }
 
   @Test
+  void testTimestampNanos() {
+    LOGGER.warn("test1");
+    LOGGER.warn("test2");
+
+    List<String> jsonLogRecords = Arrays.asList(new String(logOutput.toByteArray()).split("\n"));
+
+    List<Double> logTimestampNanos =
+            jsonLogRecords.stream()
+                    .map(record -> GSON.fromJson(record, Map.class))
+                    .map(data -> (Double) data.get(StackdriverTraceConstants.TIMESTAMP_NANOS_ATTRIBUTE))
+                    .collect(Collectors.toList());
+
+    assertThat(logTimestampNanos).anySatisfy(nanos -> assertThat(nanos % 1000000).isGreaterThan(0));
+  }
+
+  @Test
   void testJsonLayoutEnhancer_missing() {
     LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
     assertThat(


### PR DESCRIPTION
Fix https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/1996
I hope that testTimestampNanos() is enough. I am testing 2 logs to lower false negative possibility (when all micros and nanos are 0) to 1:1e+12 
