### PR TITLE
chore: fix generate-showcase script to checkout sdk-platform-java at tag

### DIFF
--- a/spring-cloud-generator/scripts/generate-showcase.sh
+++ b/spring-cloud-generator/scripts/generate-showcase.sh
@@ -67,7 +67,6 @@ function generate_showcase_spring_starter(){
   cd sdk-platform-java && git checkout "v${GAPIC_GENERATOR_JAVA_VERSION}"
 
   # Install showcase client libraries locally
-  # mvn clean install -B -ntp -DskipTests -Dclirr.skip -Dcheckstyle.skip
   cd showcase && mvn clean install
   GAPIC_SHOWCASE_CLIENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 


### PR DESCRIPTION
This is a follow-up fix to showcase CI added in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1957, which did not perform `git checkout` for `sdk-platform-java` in the correct directory:

```
Cloning into 'sdk-platform-java'...
error: pathspec 'v2.23.0' did not match any file(s) known to git
```

* Add check and correction to checkout sdk-platform-java at version tag corresponding to:
https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/2a4c14ab43b99c80879d94779bde943bd3e3ba78/spring-cloud-generator/pom.xml#L18

* Add flag to exit script on error
* Remove command to locally install sdk-platform-java modules (other than showcase) from root, since these will correspond to versions available in Maven Central
