### PR TITLE
feat: Add overloaded `executePartitionedDmlStatement` to support set priority Options for partitioned DML

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/ReadOnlyTransactionSpannerTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/ReadOnlyTransactionSpannerTemplate.java
@@ -18,6 +18,7 @@ package com.google.cloud.spring.data.spanner.core;
 
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.Statement;
@@ -70,6 +71,12 @@ class ReadOnlyTransactionSpannerTemplate extends SpannerTemplate {
   public long executePartitionedDmlStatement(Statement statement) {
     throw new SpannerDataException(
         "A read-only transaction template cannot execute partitioned DML.");
+  }
+
+  @Override
+  public long executePartitionedDmlStatement(Statement statement, UpdateOption... options) {
+    throw new SpannerDataException(
+        "A read-write transaction template cannot execute partitioned DML.");
   }
 
   @Override

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/ReadWriteTransactionSpannerTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/ReadWriteTransactionSpannerTemplate.java
@@ -18,6 +18,7 @@ package com.google.cloud.spring.data.spanner.core;
 
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
@@ -73,6 +74,12 @@ class ReadWriteTransactionSpannerTemplate extends SpannerTemplate {
 
   @Override
   public long executePartitionedDmlStatement(Statement statement) {
+    throw new SpannerDataException(
+        "A read-write transaction template cannot execute partitioned DML.");
+  }
+
+  @Override
+  public long executePartitionedDmlStatement(Statement statement, UpdateOption... options) {
     throw new SpannerDataException(
         "A read-write transaction template cannot execute partitioned DML.");
   }

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerOperations.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerOperations.java
@@ -18,6 +18,8 @@ package com.google.cloud.spring.data.spanner.core;
 
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.KeySet;
+import com.google.cloud.spanner.Options;
+import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
@@ -49,6 +51,14 @@ public interface SpannerOperations {
    * @return the lower-bound of number of rows affected.
    */
   long executePartitionedDmlStatement(Statement statement);
+  /**
+   * Execute a DML statement in partitioned mode. This is not available inside of transactions.
+   *
+   * @param statement the DML statement to execute.
+   * @param options marks options applicable to update operation.
+   * @return the lower-bound of number of rows affected.
+   */
+  long executePartitionedDmlStatement(Statement statement, UpdateOption... options);
 
   /**
    * Finds a single stored object using a key.

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerTemplate.java
@@ -22,6 +22,7 @@ import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options.QueryOption;
 import com.google.cloud.spanner.Options.ReadOption;
+import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.ResultSet;
@@ -154,6 +155,21 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
               throw new SpannerDataException("Cannot execute partitioned DML in a transaction.");
             },
             () -> this.databaseClientProvider.get().executePartitionedUpdate(statement));
+    maybeEmitEvent(new AfterExecuteDmlEvent(statement, rowsAffected));
+    return rowsAffected;
+  }
+
+  @Override
+  public long executePartitionedDmlStatement(Statement statement, UpdateOption... options) {
+    Assert.notNull(statement, "A non-null statement is required.");
+    Assert.notNull(options, "A non-null UpdateOption is required.");
+    maybeEmitEvent(new BeforeExecuteDmlEvent(statement));
+    long rowsAffected =
+        doWithOrWithoutTransactionContext(
+            x -> {
+              throw new SpannerDataException("Cannot execute partitioned DML in a transaction.");
+            },
+            () -> this.databaseClientProvider.get().executePartitionedUpdate(statement, options));
     maybeEmitEvent(new AfterExecuteDmlEvent(statement, rowsAffected));
     return rowsAffected;
   }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
@@ -38,6 +38,8 @@ import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.Options.ReadOption;
+import com.google.cloud.spanner.Options.ReadQueryUpdateTransactionOption;
+import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.ResultSet;
@@ -88,6 +90,8 @@ import org.springframework.data.domain.Sort;
 class SpannerTemplateTests {
 
   private static final Statement DML = Statement.of("update statement");
+
+  private static final ReadQueryUpdateTransactionOption OPTION = Options.priority(RpcPriority.HIGH);
 
   private DatabaseClient databaseClient;
 
@@ -194,6 +198,16 @@ class SpannerTemplateTests {
         new AfterExecuteDmlEvent(DML, 333L),
         () -> this.spannerTemplate.executePartitionedDmlStatement(DML),
         x -> x.verify(this.databaseClient, times(1)).executePartitionedUpdate(DML));
+  }
+
+  @Test
+  void executePartitionedDmlWithOptionsTest() {
+    when(this.databaseClient.executePartitionedUpdate(DML,OPTION)).thenReturn(333L);
+    verifyBeforeAndAfterEvents(
+        new BeforeExecuteDmlEvent(DML),
+        new AfterExecuteDmlEvent(DML, 333L),
+        () -> this.spannerTemplate.executePartitionedDmlStatement(DML, OPTION),
+        x -> x.verify(this.databaseClient, times(1)).executePartitionedUpdate(DML, OPTION));
   }
 
   @Test


### PR DESCRIPTION
This PR adds overloaded `executePartitionedDmlStatement` to support set priority Options for partitioned DML

Ref: Support required in Spring Lib to set priority for partitioned DML b/287076754