### PR TITLE
deps(3.x): stop forcing Guava version

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -31,7 +31,6 @@
 	<properties>
 		<gcp-libraries-bom.version>26.19.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.13.1</cloud-sql-socket-factory.version>
-		<guava.version>31.1-jre</guava.version>
 		<r2dbc-mysql-driver.version>0.9.3</r2dbc-mysql-driver.version>
 		<r2dbc-postgres-driver.version>0.8.13.RELEASE</r2dbc-postgres-driver.version>
 		<cloud-spanner-r2dbc.version>1.2.2</cloud-spanner-r2dbc.version>
@@ -45,15 +44,6 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-function-dependencies</artifactId>
 				<version>3.2.7</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			
-			<!-- Overriding Guava from libraries-bom; Spring Framework on Google Cloud does not require Java 7 support -->
-			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava-bom</artifactId>
-				<version>${guava.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
The Guava version is already managed in shared-dependencies that are imported into the BOM.

Fixes #2067.