### PR TITLE
Make CloudFoundryEnvironmentPostProcessor R2DBC ready

### DIFF
--- a/spring-cloud-gcp-cloudfoundry/src/main/java/com/google/cloud/spring/cloudfoundry/GcpCloudFoundryEnvironmentPostProcessor.java
+++ b/spring-cloud-gcp-cloudfoundry/src/main/java/com/google/cloud/spring/cloudfoundry/GcpCloudFoundryEnvironmentPostProcessor.java
@@ -103,14 +103,14 @@ public class GcpCloudFoundryEnvironmentPostProcessor implements EnvironmentPostP
       }
       // The username and password should be in the generic DataSourceProperties.
       if (gcpCfServiceProperties.containsKey("spring.cloud.gcp.sql.username")) {
-        gcpCfServiceProperties.put(
-            "spring.datasource.username",
-            gcpCfServiceProperties.getProperty("spring.cloud.gcp.sql.username"));
+        String username = gcpCfServiceProperties.getProperty("spring.cloud.gcp.sql.username");
+        gcpCfServiceProperties.put("spring.datasource.username", username);
+        gcpCfServiceProperties.put("spring.r2dbc.username", username);
       }
       if (gcpCfServiceProperties.containsKey("spring.cloud.gcp.sql.password")) {
-        gcpCfServiceProperties.put(
-            "spring.datasource.password",
-            gcpCfServiceProperties.getProperty("spring.cloud.gcp.sql.password"));
+        String password = gcpCfServiceProperties.getProperty("spring.cloud.gcp.sql.password");
+        gcpCfServiceProperties.put("spring.datasource.password", password);
+        gcpCfServiceProperties.put("spring.r2dbc.password", password);
       }
 
       environment


### PR DESCRIPTION
At the moment, when including the dependency `spring-cloud-gcp-starter-cloudfoundry`, only jdbc connections work out of the box as only the variables of `spring.datasource` are set.
When including this code, the `spring.r2dbc` variables are also set correctly.