### PR TITLE
feat: add support for Datastore database name configuration #2145

### DIFF
--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -68,6 +68,7 @@ The following configuration options are available:
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.datastore.enabled` | Enables the Cloud Datastore client | No | `true`
 | `spring.cloud.gcp.datastore.project-id` | Google Cloud project ID where the Google Cloud Datastore API is hosted, if different from the one in the <<spring-cloud-gcp-core,Spring Framework on Google Cloud Core Module>> | No |
+| `spring.cloud.gcp.datastore.database-id` | Google Cloud project can host multiple databases. You can specify which database will be used. | No |
 | `spring.cloud.gcp.datastore.credentials.location` | OAuth2 credentials for authenticating with the Google Cloud Datastore API, if different from the ones in the <<spring-cloud-gcp-core,Spring Framework on Google Cloud Core Module>> | No |
 | `spring.cloud.gcp.datastore.credentials.encoded-key` | Base64-encoded OAuth2 credentials for authenticating with the Google Cloud Datastore API, if different from the ones in the <<spring-cloud-gcp-core,Spring Framework on Google Cloud Core Module>> | No |
 | `spring.cloud.gcp.datastore.credentials.scopes` | https://developers.google.com/identity/protocols/googlescopes[OAuth2 scope] for Spring Framework on Google CloudDatastore credentials | No | https://www.googleapis.com/auth/datastore

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -70,6 +70,8 @@ public class GcpDatastoreAutoConfiguration {
 
   private final String namespace;
 
+  private final String databaseId;
+
   private final Credentials credentials;
 
   private final String host;
@@ -85,6 +87,7 @@ public class GcpDatastoreAutoConfiguration {
             ? gcpDatastoreProperties.getProjectId()
             : projectIdProvider.getProjectId();
     this.namespace = gcpDatastoreProperties.getNamespace();
+    this.databaseId = gcpDatastoreProperties.getDatabaseId();
 
     String hostToConnect = gcpDatastoreProperties.getHost();
     if (gcpDatastoreProperties.getEmulator().isEnabled()) {
@@ -191,6 +194,10 @@ public class GcpDatastoreAutoConfiguration {
             .setCredentials(this.credentials);
     if (namespace != null) {
       builder.setNamespace(namespace);
+    }
+
+    if (databaseId != null) {
+      builder.setDatabaseId(databaseId);
     }
 
     if (this.host != null) {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreProperties.java
@@ -42,6 +42,8 @@ public class GcpDatastoreProperties implements CredentialsSupplier {
 
   private String projectId;
 
+  private String databaseId;
+
   private String namespace;
 
   @Override
@@ -59,6 +61,14 @@ public class GcpDatastoreProperties implements CredentialsSupplier {
 
   public void setProjectId(String projectId) {
     this.projectId = projectId;
+  }
+
+  public String getDatabaseId() {
+    return databaseId;
+  }
+
+  public void setDatabaseId(String databaseId) {
+    this.databaseId = databaseId;
   }
 
   public String getNamespace() {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
@@ -62,6 +62,7 @@ class GcpDatastoreAutoConfigurationTests {
           .withUserConfiguration(TestConfiguration.class)
           .withPropertyValues(
               "spring.cloud.gcp.datastore.project-id=test-project",
+              "spring.cloud.gcp.datastore.database-id=test-database",
               "spring.cloud.gcp.datastore.namespace=testNamespace",
               "spring.cloud.gcp.datastore.host=localhost:8081",
               "management.health.datastore.enabled=false");
@@ -74,6 +75,7 @@ class GcpDatastoreAutoConfigurationTests {
             .withUserConfiguration(TestConfigurationWithDatastoreBean.class)
             .withPropertyValues(
                 "spring.cloud.gcp.datastore.project-id=test-project",
+                "spring.cloud.gcp.datastore.database-id=test-database",
                 "spring.cloud.gcp.datastore.namespace=testNamespace",
                 "spring.cloud.gcp.datastore.host=localhost:8081",
                 "management.health.datastore.enabled=false");
@@ -94,6 +96,7 @@ class GcpDatastoreAutoConfigurationTests {
             .withUserConfiguration(TestConfigurationWithDatastoreBeanNamespaceProvider.class)
             .withPropertyValues(
                 "spring.cloud.gcp.datastore.project-id=test-project",
+                "spring.cloud.gcp.datastore.database-id=test-database",
                 "spring.cloud.gcp.datastore.namespace=testNamespace",
                 "spring.cloud.gcp.datastore.host=localhost:8081",
                 "management.health.datastore.enabled=false");
@@ -114,6 +117,7 @@ class GcpDatastoreAutoConfigurationTests {
         context -> {
           DatastoreOptions datastoreOptions = getDatastoreBean(context).getOptions();
           assertThat(datastoreOptions.getProjectId()).isEqualTo("test-project");
+          assertThat(datastoreOptions.getDatabaseId()).isEqualTo("test-database");
           assertThat(datastoreOptions.getNamespace()).isEqualTo("testNamespace");
           assertThat(datastoreOptions.getHost()).isEqualTo("localhost:8081");
         });


### PR DESCRIPTION
GCP added support for multiple databases inside single GCP project. It's possible to specify database id on `com.google.cloud.datastore` level, but it was missing on autoconfiguration side.