### PR TITLE
fix: Firestore updateTime extraction after commit

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
@@ -331,10 +331,11 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
                   .flatMapMany(
                       response -> {
                         if (setUpdateTime) {
-                          for (T entity : batch) {
+                          for (int i = 0; i< batch.size(); i++) {
                             getClassMapper()
                                 .setUpdateTime(
-                                    entity, Timestamp.fromProto(response.getCommitTime()));
+                                    batch.get(i), Timestamp.fromProto(
+                                        response.getWriteResults(i).getUpdateTime()));
                           }
                         }
                         return Flux.fromIterable(batch);

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
@@ -331,7 +331,7 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
                   .flatMapMany(
                       response -> {
                         if (setUpdateTime) {
-                          for (int i = 0; i< batch.size(); i++) {
+                          for (int i = 0; i < batch.size(); i++) {
                             getClassMapper()
                                 .setUpdateTime(
                                     batch.get(i), Timestamp.fromProto(

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
@@ -42,6 +42,7 @@ import com.google.firestore.v1.RunQueryResponse;
 import com.google.firestore.v1.StructuredQuery;
 import com.google.firestore.v1.Value;
 import com.google.firestore.v1.Write;
+import com.google.firestore.v1.WriteResult;
 import io.grpc.stub.StreamObserver;
 import java.util.HashMap;
 import java.util.Map;
@@ -280,9 +281,11 @@ public class FirestoreTemplateTests {
     doAnswer(
             invocation -> {
               StreamObserver<CommitResponse> streamObserver = invocation.getArgument(1);
+              com.google.protobuf.Timestamp ts = Timestamp.ofTimeMicroseconds(123456789).toProto();
               CommitResponse response =
                   CommitResponse.newBuilder()
-                      .setCommitTime(Timestamp.ofTimeMicroseconds(123456789).toProto())
+                      .addWriteResults(WriteResult.newBuilder().setUpdateTime(ts).build())
+                      .addWriteResults(WriteResult.newBuilder().setUpdateTime(ts).build())
                       .build();
               streamObserver.onNext(response);
               streamObserver.onCompleted();

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -420,7 +420,7 @@ class FirestoreRepositoryIntegrationTests {
   }
 
   @Test
-  public void testUpdateTimeNoDocumentChangeDoesNotResultInOptimisticLockingFailure() {
+  void testUpdateTimeNoDocumentChangeDoesNotResultInOptimisticLockingFailure() {
     User user = new User();
     user.setName("Axle");
     user.setAge(25);

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.google.cloud.Timestamp;
 import com.google.cloud.spring.data.firestore.SimpleFirestoreReactiveRepository;
 import com.google.cloud.spring.data.firestore.entities.User;
 import com.google.cloud.spring.data.firestore.entities.User.Address;
@@ -416,5 +417,20 @@ class FirestoreRepositoryIntegrationTests {
                 user -> testUser.flatMap(user1 -> Mono.just(user.getName() + " " + user1.getName())));
     List<String> list = stringFlux.collectList().block();
     assertThat(list).contains("Alice Alice", "Bob Alice");
+  }
+
+  @Test
+  public void testUpdateTimeNoDocumentChangeDoesNotResultInOptimisticLockingFailure() {
+    User user = new User();
+    user.setName("Axle");
+    user.setAge(25);
+    userRepository.save(user).block();
+    Timestamp updateTime = user.getUpdateTime();
+    userRepository.save(user).block();
+    Timestamp updateTime2 = user.getUpdateTime();
+    assertThat(updateTime2).isEqualTo(updateTime);
+    user.setAge(26);
+    userRepository.save(user).block();
+    // no optimistic locking exception expected
   }
 }


### PR DESCRIPTION
This change ensures that the correct updateTime is extracted for each entity after commit. Previously, commit timestamp was used, but it's wrong when there is no change to the entity.

Fixes: #2163.