### PR TITLE
fix(3.x): Firestore updateTime extraction after commit

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/FirestoreTemplate.java
@@ -331,10 +331,11 @@ public class FirestoreTemplate implements FirestoreReactiveOperations {
                   .flatMapMany(
                       response -> {
                         if (setUpdateTime) {
-                          for (T entity : batch) {
+                          for (int i = 0; i < batch.size(); i++) {
                             getClassMapper()
                                 .setUpdateTime(
-                                    entity, Timestamp.fromProto(response.getCommitTime()));
+                                    batch.get(i), Timestamp.fromProto(
+                                        response.getWriteResults(i).getUpdateTime()));
                           }
                         }
                         return Flux.fromIterable(batch);

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/FirestoreTemplateTests.java
@@ -42,6 +42,7 @@ import com.google.firestore.v1.RunQueryResponse;
 import com.google.firestore.v1.StructuredQuery;
 import com.google.firestore.v1.Value;
 import com.google.firestore.v1.Write;
+import com.google.firestore.v1.WriteResult;
 import io.grpc.stub.StreamObserver;
 import java.util.HashMap;
 import java.util.Map;
@@ -280,9 +281,11 @@ public class FirestoreTemplateTests {
     doAnswer(
             invocation -> {
               StreamObserver<CommitResponse> streamObserver = invocation.getArgument(1);
+              com.google.protobuf.Timestamp ts = Timestamp.ofTimeMicroseconds(123456789).toProto();
               CommitResponse response =
                   CommitResponse.newBuilder()
-                      .setCommitTime(Timestamp.ofTimeMicroseconds(123456789).toProto())
+                      .addWriteResults(WriteResult.newBuilder().setUpdateTime(ts).build())
+                      .addWriteResults(WriteResult.newBuilder().setUpdateTime(ts).build())
                       .build();
               streamObserver.onNext(response);
               streamObserver.onCompleted();


### PR DESCRIPTION
This change ensures that the correct updateTime is extracted for each entity after commit. Previously, commit timestamp was used, but it's wrong when there is no change to the entity.

Backport of #2165.
Fixes: #2163 for 3.x branch.