### PR TITLE
feat(3.x): add support for Firestore database id configuration

### DIFF
--- a/docs/src/main/asciidoc/datastore.adoc
+++ b/docs/src/main/asciidoc/datastore.adoc
@@ -68,6 +68,7 @@ The following configuration options are available:
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.datastore.enabled` | Enables the Cloud Datastore client | No | `true`
 | `spring.cloud.gcp.datastore.project-id` | Google Cloud project ID where the Google Cloud Datastore API is hosted, if different from the one in the <<spring-cloud-gcp-core,Spring Framework on Google Cloud Core Module>> | No |
+| `spring.cloud.gcp.datastore.database-id` | Google Cloud project can host multiple databases. You can specify which database will be used. If not specified, the database id will be "(default)". | No |
 | `spring.cloud.gcp.datastore.credentials.location` | OAuth2 credentials for authenticating with the Google Cloud Datastore API, if different from the ones in the <<spring-cloud-gcp-core,Spring Framework on Google Cloud Core Module>> | No |
 | `spring.cloud.gcp.datastore.credentials.encoded-key` | Base64-encoded OAuth2 credentials for authenticating with the Google Cloud Datastore API, if different from the ones in the <<spring-cloud-gcp-core,Spring Framework on Google Cloud Core Module>> | No |
 | `spring.cloud.gcp.datastore.credentials.scopes` | https://developers.google.com/identity/protocols/googlescopes[OAuth2 scope] for Spring Framework on Google CloudDatastore credentials | No | https://www.googleapis.com/auth/datastore
@@ -853,6 +854,13 @@ This feature requires a bean of `DatastoreTransactionManager`, which is provided
 `DatastoreTemplate` and `DatastoreRepository` support running methods with the `@Transactional` https://docs.spring.io/spring/docs/current/spring-framework-reference/data-access.html#transaction-declarative[annotation] as transactions.
 If a method annotated with `@Transactional` calls another method also annotated, then both methods will work within the same transaction.
 `performTransaction` cannot be used in `@Transactional` annotated methods because Cloud Datastore does not support transactions within transactions.
+
+Other Google Cloud database-related integrations like Spanner and Firestore can introduce `PlatformTransactionManager` beans, and can interfere with Datastore Transaction Manager. To disambiguate, explicitly specify the name of the transaction manager bean for such `@Transactional` methods. Example:
+
+[source,java]
+----
+@Transactional(transactionManager = "datastoreTransactionManager")
+----
 
 ==== Read-Write Support for Maps
 

--- a/docs/src/main/asciidoc/firestore.adoc
+++ b/docs/src/main/asciidoc/firestore.adoc
@@ -54,6 +54,7 @@ The Spring Boot starter for Google Cloud Firestore provides the following config
 | Name | Description | Required | Default value
 | `spring.cloud.gcp.firestore.enabled` | Enables or disables Firestore auto-configuration | No | `true`
 | `spring.cloud.gcp.firestore.project-id` | Google Cloud project ID where the Google Cloud Firestore API is hosted, if different from the one in the <<spring-cloud-gcp-core,Spring Framework on Google Cloud Core Module>> | No |
+| `spring.cloud.gcp.firestore.database-id` | Google Cloud project can host multiple databases. You can specify which database will be used. If not specified, the database id will be "(default)". | No |
 | `spring.cloud.gcp.firestore.emulator.enabled` | Enables the usage of an emulator. If this is set to true, then you should set the `spring.cloud.gcp.firestore.host-port` to the host:port of your locally running emulator instance | No | `false`
 | `spring.cloud.gcp.firestore.host-port` | The host and port of the Firestore service; can be overridden to specify connecting to an already-running https://firebase.google.com/docs/emulator-suite/install_and_configure[Firestore emulator] instance. | No | `firestore.googleapis.com:443` (the host/port of official Firestore service)
 | `spring.cloud.gcp.firestore.credentials.location` | OAuth2 credentials for authenticating with the Google Cloud Firestore API, if different from the ones in the <<spring-cloud-gcp-core,Spring Framework on Google Cloud Core Module>> | No |

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreAutoConfiguration.java
@@ -16,9 +16,11 @@
 
 package com.google.cloud.spring.autoconfigure.firestore;
 
+import com.google.api.client.util.escape.PercentEscaper;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.rpc.internal.Headers;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
@@ -30,9 +32,12 @@ import com.google.cloud.spring.data.firestore.mapping.FirestoreClassMapper;
 import com.google.cloud.spring.data.firestore.mapping.FirestoreDefaultClassMapper;
 import com.google.cloud.spring.data.firestore.mapping.FirestoreMappingContext;
 import com.google.firestore.v1.FirestoreGrpc;
+import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
 import io.grpc.auth.MoreCallCredentials;
+import io.grpc.stub.MetadataUtils;
 import java.io.IOException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -59,7 +64,11 @@ public class GcpFirestoreAutoConfiguration {
   private static final UserAgentHeaderProvider USER_AGENT_HEADER_PROVIDER =
       new UserAgentHeaderProvider(GcpFirestoreAutoConfiguration.class);
 
+  private static final PercentEscaper PERCENT_ESCAPER = new PercentEscaper("._-~");
+
   private final String projectId;
+
+  private final String databaseId;
 
   private final CredentialsProvider credentialsProvider;
 
@@ -74,6 +83,7 @@ public class GcpFirestoreAutoConfiguration {
       throws IOException {
 
     this.projectId = gcpFirestoreProperties.getResolvedProjectId(projectIdProvider);
+    this.databaseId = gcpFirestoreProperties.getResolvedDatabaseId();
 
     if (gcpFirestoreProperties.getEmulator().isEnabled()) {
       // if the emulator is enabled, create CredentialsProvider for this particular case.
@@ -95,6 +105,7 @@ public class GcpFirestoreAutoConfiguration {
     return FirestoreOptions.getDefaultInstance().toBuilder()
         .setCredentialsProvider(this.credentialsProvider)
         .setProjectId(this.projectId)
+        .setDatabaseId(databaseId)
         .setHeaderProvider(USER_AGENT_HEADER_PROVIDER)
         .setChannelProvider(
             InstantiatingGrpcChannelProvider.newBuilder().setEndpoint(this.hostPort).build())
@@ -151,11 +162,26 @@ public class GcpFirestoreAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(name = "firestoreRoutingHeadersInterceptor")
+    public ClientInterceptor firestoreRoutingHeadersInterceptor() {
+      // add routing header for custom database id
+      Metadata routingHeader = new Metadata();
+      Metadata.Key<String> key =
+          Metadata.Key.of(Headers.DYNAMIC_ROUTING_HEADER_KEY, Metadata.ASCII_STRING_MARSHALLER);
+      routingHeader.put(key,
+          "project_id=" + PERCENT_ESCAPER.escape(projectId)
+              + "&database_id=" + PERCENT_ESCAPER.escape(databaseId));
+      return MetadataUtils.newAttachHeadersInterceptor(routingHeader);
+    }
+
+    @Bean
     @ConditionalOnMissingBean(name = "firestoreManagedChannel")
-    public ManagedChannel firestoreManagedChannel() {
+    public ManagedChannel firestoreManagedChannel(
+        ClientInterceptor firestoreRoutingHeadersInterceptor) {
       return ManagedChannelBuilder.forTarget(
               "dns:///" + GcpFirestoreAutoConfiguration.this.hostPort)
           .userAgent(USER_AGENT_HEADER_PROVIDER.getUserAgent())
+          .intercept(firestoreRoutingHeadersInterceptor)
           .build();
     }
   }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfiguration.java
@@ -59,7 +59,7 @@ public class GcpFirestoreEmulatorAutoConfiguration {
   GcpFirestoreEmulatorAutoConfiguration(GcpFirestoreProperties properties) {
     this.hostPort = properties.getHostPort();
     this.projectId = StringUtils.defaultIfEmpty(properties.getProjectId(), "unused");
-    this.rootPath = String.format("projects/%s/databases/(default)", this.projectId);
+    this.rootPath = properties.getFirestoreRootPath(() -> projectId);
   }
 
   @Bean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreProperties.java
@@ -30,7 +30,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  */
 @ConfigurationProperties("spring.cloud.gcp.firestore")
 public class GcpFirestoreProperties implements CredentialsSupplier {
-  private static final String ROOT_PATH_FORMAT = "projects/%s/databases/(default)/documents";
+  private static final String ROOT_PATH_FORMAT = "projects/%s/databases/%s/documents";
 
   /**
    * Overrides the GCP OAuth2 credentials specified in the Core module. Uses same URL as Datastore
@@ -39,6 +39,8 @@ public class GcpFirestoreProperties implements CredentialsSupplier {
   private final Credentials credentials = new Credentials(GcpScope.DATASTORE.getUrl());
 
   private String projectId;
+
+  private String databaseId;
 
   /**
    * The host and port of the Firestore emulator service; can be overridden to specify an emulator.
@@ -65,6 +67,18 @@ public class GcpFirestoreProperties implements CredentialsSupplier {
     this.projectId = projectId;
   }
 
+  public String getDatabaseId() {
+    return databaseId;
+  }
+
+  public String getResolvedDatabaseId() {
+    return this.getDatabaseId() == null ? "(default)" : this.getDatabaseId();
+  }
+
+  public void setDatabaseId(String databaseId) {
+    this.databaseId = databaseId;
+  }
+
   public String getHostPort() {
     return hostPort;
   }
@@ -82,7 +96,8 @@ public class GcpFirestoreProperties implements CredentialsSupplier {
   }
 
   public String getFirestoreRootPath(GcpProjectIdProvider projectIdProvider) {
-    return String.format(ROOT_PATH_FORMAT, this.getResolvedProjectId(projectIdProvider));
+    return String.format(ROOT_PATH_FORMAT, this.getResolvedProjectId(projectIdProvider),
+        this.getResolvedDatabaseId());
   }
 
   public static class FirestoreEmulatorProperties {

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/repository/query/FirestoreRepositoryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/repository/query/FirestoreRepositoryTests.java
@@ -113,8 +113,6 @@ class FirestoreRepositoryTests {
   @Configuration
   @EnableReactiveFirestoreRepositories(basePackageClasses = UserRepository.class)
   static class FirestoreRepositoryTestsConfiguration {
-    private static final String DEFAULT_PARENT =
-        "projects/my-project/databases/(default)/documents";
 
     @Bean
     public FirestoreMappingContext firestoreMappingContext() {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/resources/application-test.properties
@@ -1,1 +1,2 @@
-spring.cloud.gcp.firestore.project-id=spring-cloud-gcp-ci-firestore
+spring.cloud.gcp.firestore.project-id=spring-cloud-gcp-ci
+spring.cloud.gcp.firestore.database-id=firestoredb


### PR DESCRIPTION
Also adds routing headers for all Firestore requests.

Backport of #2164.

Fixes #2145.