### PR TITLE
chore: add secret manager module and sample it tests to native image CI

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -26,10 +26,12 @@ jobs:
           - vision
           - spanner
           - storage
+          - secretmanager
           - logging-sample
           - storage-sample
           - trace-sample
           - vision-sample
+          - secretmanager-sample
     steps:
       - name: Get current date
         id: date

--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,7 @@
 			<module>spring-cloud-gcp-storage</module>
 			<module>spring-cloud-gcp-vision</module>
 			<module>spring-cloud-gcp-data-spanner</module>
+			<module>spring-cloud-gcp-secretmanager</module>
 		</modules>
 
 		<dependencies>
@@ -381,9 +382,10 @@
 						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
 						<systemPropertyVariables>
 							<!--integration tests are not invoked unless the relevant system property is set to true here. -->
-              				<it.storage>true</it.storage>
+							<it.storage>true</it.storage>
 							<it.vision>true</it.vision>
 							<it.spanner>true</it.spanner>
+							<it.secretmanager>true</it.secretmanager>
 						</systemPropertyVariables>
 					</configuration>
 				</plugin>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -95,6 +95,7 @@
 				<module>spring-cloud-gcp-integration-storage-sample</module>
 				<module>spring-cloud-gcp-trace-sample</module>
 				<module>spring-cloud-gcp-vision-api-sample</module>
+				<module>spring-cloud-gcp-secretmanager-sample</module>
 			</modules>
 			<build>
 				<plugins>
@@ -138,9 +139,9 @@
 							<systemPropertyVariables>
 								<it.logging>true</it.logging>
 								<it.storage>true</it.storage>
-                <it.vision>true</it.vision>
-								<it.trace>true</it.trace>
 								<it.vision>true</it.vision>
+								<it.trace>true</it.trace>
+								<it.secretmanager>true</it.secretmanager>
                 <gcs-resource-test-bucket>gcp-storage-resource-bucket-sample</gcs-resource-test-bucket>
 								<gcs-read-bucket>gcp-storage-bucket-sample-input</gcs-read-bucket>
 								<gcs-write-bucket>gcp-storage-bucket-sample-output</gcs-write-bucket>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleIntegrationTests.java
@@ -32,9 +32,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-/**
- * Application secret named "application-secret" must exist and have a value of "Hello world.".
- */
+/** Application secret named "application-secret" must exist. */
 @EnabledIfSystemProperty(named = "it.secretmanager", matches = "true")
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
@@ -52,12 +50,19 @@ class SecretManagerSampleIntegrationTests {
 
   @Test
   void testApplicationStartup() {
+    // retrieve secret string with secretManagerTemplate directly, to compare with loaded
+    // application
+    String secretString =
+        this.secretManagerTemplate.getSecretString(
+            "sm://" + "application-secret" + "/" + SecretManagerTemplate.LATEST_VERSION);
+
     ResponseEntity<String> response = this.testRestTemplate.getForEntity("/", String.class);
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
-    assertThat(response.getBody()).contains(
-        "<b>Application secret from @Value:</b> <i>Hello world.</i>");
-    assertThat(response.getBody()).contains(
-        "<b>Application secret from @ConfigurationProperties:</b> <i>Hello world.</i>");
+    assertThat(response.getBody())
+        .contains("<b>Application secret from @Value:</b> <i>" + secretString + "</i>");
+    assertThat(response.getBody())
+        .contains(
+            "<b>Application secret from @ConfigurationProperties:</b> <i>" + secretString + "</i>");
   }
 
   @Test

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleLoadSecretsIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleLoadSecretsIntegrationTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Tests sample application endpoint that loads secrets as properties into the application context.
+ * Application secret named "application-secret" must exist.
+ */
+@EnabledIfSystemProperty(named = "it.secretmanager", matches = "true")
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = SecretManagerApplication.class)
+class SecretManagerSampleLoadSecretsIntegrationTests {
+
+  @Autowired private SecretManagerTemplate secretManagerTemplate;
+
+  @Autowired private TestRestTemplate testRestTemplate;
+
+  private static final String SECRET_CONTENT = "Hello world.";
+
+  @Test
+  void testApplicationStartupSecretLoadsCorrectly() {
+    ResponseEntity<String> response = this.testRestTemplate.getForEntity("/", String.class);
+    assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+    assertThat(response.getBody())
+        .contains("<b>Application secret from @Value:</b> <i>" + SECRET_CONTENT + "</i>");
+    assertThat(response.getBody())
+        .contains(
+            "<b>Application secret from @ConfigurationProperties:</b> <i>"
+                + SECRET_CONTENT
+                + "</i>");
+  }
+}

--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerTemplateIntegrationTests.java
@@ -60,6 +60,7 @@ class SecretManagerTemplateIntegrationTests {
   void deleteSecret() {
     secretManagerTemplate.deleteSecret(this.secretName);
   }
+
   @Test
   void testReadWriteSecrets() {
     await()

--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerTemplateIntegrationTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/it/SecretManagerTemplateIntegrationTests.java
@@ -18,11 +18,13 @@ package com.google.cloud.spring.secretmanager.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.awaitility.Awaitility.await;
 
 import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
 import java.time.Duration;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,18 +40,36 @@ class SecretManagerTemplateIntegrationTests {
 
   @Autowired SecretManagerTemplate secretManagerTemplate;
 
-  @Test
-  void testReadWriteSecrets() {
-    secretManagerTemplate.createSecret("test-secret-1234", "1234");
+  private String secretName;
 
+  @BeforeEach
+  void createSecret() {
+    this.secretName = String.format("test-secret-%s", UUID.randomUUID());
+
+    secretManagerTemplate.createSecret(secretName, "1234");
     await()
         .atMost(Duration.ofSeconds(5))
         .untilAsserted(
             () -> {
-              String secretString = secretManagerTemplate.getSecretString("test-secret-1234");
+              String secretString = secretManagerTemplate.getSecretString(secretName);
+              assertThat(secretString).isEqualTo("1234");
+            });
+  }
+
+  @AfterEach
+  void deleteSecret() {
+    secretManagerTemplate.deleteSecret(this.secretName);
+  }
+  @Test
+  void testReadWriteSecrets() {
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              String secretString = secretManagerTemplate.getSecretString(this.secretName);
               assertThat(secretString).isEqualTo("1234");
 
-              byte[] secretBytes = secretManagerTemplate.getSecretBytes("test-secret-1234");
+              byte[] secretBytes = secretManagerTemplate.getSecretBytes(this.secretName);
               assertThat(secretBytes).isEqualTo("1234".getBytes());
             });
   }
@@ -63,16 +83,8 @@ class SecretManagerTemplateIntegrationTests {
 
   @Test
   void testUpdateSecrets() {
-    secretManagerTemplate.createSecret("test-update-secret", "5555");
-    await()
-        .atMost(Duration.ofSeconds(5))
-        .untilAsserted(
-            () -> {
-              String secretString = secretManagerTemplate.getSecretString("test-update-secret");
-              assertThat(secretString).isEqualTo("5555");
-            });
 
-    secretManagerTemplate.createSecret("test-update-secret", "6666");
+    secretManagerTemplate.createSecret(this.secretName, "6666");
     await()
         .atMost(Duration.ofSeconds(10))
         .untilAsserted(


### PR DESCRIPTION
Changes in this pr:

- Add secret manager sample app test to native test ci. Tests run for sample application:
```
com.example.SecretManagerSampleIntegrationTests > testDeleteSecret() SUCCESSFUL

com.example.SecretManagerSampleIntegrationTests > testCreateReadSecret() SUCCESSFUL

com.example.SecretManagerSampleIntegrationTests > testApplicationStartup() SUCCESSFUL
```

- Add secret manager module it test to native test ci.
tests run for module:
```
com.google.cloud.spring.secretmanager.it.SecretManagerTemplateIntegrationTests > testReadWriteSecrets() SUCCESSFUL

com.google.cloud.spring.secretmanager.it.SecretManagerTemplateIntegrationTests > testUpdateSecrets() SUCCESSFUL

com.google.cloud.spring.secretmanager.it.SecretManagerTemplateIntegrationTests > testReadMissingSecret() SUCCESSFUL
```
- Test resource uniqueness for parallel runs  : 
  - Module test: add uuid to secret used. 
  - Sample test: refactor into 2 separate tests.
    - `SecretManagerSampleLoadSecretsIntegrationTests` tests for sample application load, which load secrets as properties into the application context; This test uses one pre-created secret in ci, read-only.
    - `SecretManagerSampleTemplateIntegrationTests` tests for `SecretManagerTemplate` operations in sample application. This test now creates and deletes unique secrets for each run.