### PR TITLE
fix: removed topic existence & creation from provisionConsumerDestination

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -71,7 +71,6 @@ public class PubSubChannelProvisioner
     String subscriptionName = null;
     String customName = properties.getExtension().getSubscriptionName();
 
-
     boolean autoCreate = properties.getExtension().isAutoCreateResources();
     PubSubConsumerProperties.DeadLetterPolicy deadLetterPolicy =
         properties.getExtension().getDeadLetterPolicy();

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -102,6 +102,7 @@ public class PubSubChannelProvisioner
       ensureSubscriptionExists(subscriptionName, topicName, deadLetterPolicy, autoCreate);
     }
 
+    Assert.hasText(subscriptionName, "Subscription Name cannot be null or empty");
     return new PubSubConsumerDestination(subscriptionName);
   }
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -236,4 +236,16 @@ class PubSubChannelProvisionerTests {
     assertThatExceptionOfType(ProvisioningException.class)
         .isThrownBy(() -> this.pubSubChannelProvisioner.ensureTopicExists("new_topic", true));
   }
+
+  @Test
+  void testProvisionConsumerDestination_subscriptionNameCannotBeNull() {
+    when(this.pubSubConsumerProperties.isAutoCreateResources()).thenReturn(false);
+    when(this.pubSubConsumerProperties.getSubscriptionName()).thenReturn(null);
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                this.pubSubChannelProvisioner.provisionConsumerDestination(
+                    "topic_A", null, this.properties))
+        .withMessage("Subscription Name cannot be null or empty");
+  }
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -142,48 +142,9 @@ class PubSubChannelProvisionerTests {
   }
 
   @Test
-  void testProvisionConsumerDestination_noTopicException() {
-    when(this.pubSubConsumerProperties.isAutoCreateResources()).thenReturn(false);
-    when(this.pubSubAdminMock.getTopic("topic_A")).thenReturn(null);
-
-    assertThatExceptionOfType(ProvisioningException.class)
-        .isThrownBy(
-            () ->
-                this.pubSubChannelProvisioner.provisionConsumerDestination(
-                    "topic_A", "group_A", this.properties))
-        .withMessage("Non-existing 'topic_A' topic.");
-  }
-
-  @Test
-  void testProvisionConsumerDestination_noSubscriptionException() {
-    when(this.pubSubConsumerProperties.isAutoCreateResources()).thenReturn(false);
-
-    assertThatExceptionOfType(ProvisioningException.class)
-        .isThrownBy(
-            () ->
-                this.pubSubChannelProvisioner.provisionConsumerDestination(
-                    "topic_A", "group_A", this.properties))
-        .withMessage("Non-existing 'topic_A.group_A' subscription.");
-  }
-
-  @Test
-  void testProvisionConsumerDestination_wrongTopicException() {
-    when(this.pubSubConsumerProperties.isAutoCreateResources()).thenReturn(false);
-    when(this.pubSubAdminMock.getSubscription("topic_A.group_A"))
-        .thenReturn(Subscription.newBuilder().setTopic("topic_B").build());
-
-    assertThatExceptionOfType(ProvisioningException.class)
-        .isThrownBy(
-            () ->
-                this.pubSubChannelProvisioner.provisionConsumerDestination(
-                    "topic_A", "group_A", this.properties))
-        .withMessage("Existing 'topic_A.group_A' subscription is for a different topic 'topic_B'.");
-  }
-
-  @Test
   void testProvisionConsumerDestination_anonymousGroup() {
     // should work with auto-create = false
-    when(this.pubSubConsumerProperties.isAutoCreateResources()).thenReturn(false);
+    when(this.pubSubConsumerProperties.isAutoCreateResources()).thenReturn(true);
 
     String subscriptionNameRegex = "anonymous\\.topic_A\\.[a-f0-9\\-]{36}";
 
@@ -264,20 +225,6 @@ class PubSubChannelProvisionerTests {
     this.pubSubChannelProvisioner.afterUnbindConsumer(result);
 
     verify(this.pubSubAdminMock, never()).deleteSubscription(result.getName());
-  }
-
-  @Test
-  void testProvisionConsumerDestination_concurrentTopicCreation() {
-    when(this.pubSubAdminMock.createTopic(any())).thenThrow(AlreadyExistsException.class);
-    when(this.pubSubAdminMock.getTopic("already_existing_topic"))
-        .thenReturn(null)
-        .thenReturn(Topic.newBuilder().setName("already_existing_topic").build());
-
-    // Ensure no exceptions occur if topic already exists on create call
-    assertThat(
-            this.pubSubChannelProvisioner.provisionConsumerDestination(
-                "already_existing_topic", "group1", this.properties))
-        .isNotNull();
   }
 
   @Test


### PR DESCRIPTION
fix: removed topic existence and creation from provisionConsumerDestination

As Pub/Sub subscriber role does have permission to access or create topic so in case `autoCreateResources` is set to false `provisionConsumerDestination` should not perform any admin task e.g fetch or create  subscription or topic. 
So in case subscription name is provided in the configuration with `autoCreateResources` to false provisionConsumerDestination should return `PubSubConsumerDestination` with provided subscription name.

also removed test against creation validation of topic for provision consumer Fixes #2231