### PR TITLE
chore: add back original comment.

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleLoadSecretsIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleLoadSecretsIntegrationTests.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Tests sample application endpoint that loads secrets as properties into the application context.
- * Application secret named "application-secret" must exist.
+ * Application secret named "application-secret" must exist and have a value of "Hello world.".
  */
 @EnabledIfSystemProperty(named = "it.secretmanager", matches = "true")
 @ExtendWith(SpringExtension.class)


### PR DESCRIPTION
Part of [this comment](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/1e8602dd41e63902b8e4193653d2ce5e68e795d3/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleIntegrationTests.java#L36) was accidentally removed with changes in #2206.