### PR TITLE
ci: add parallel integration and native tests (#2265)

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -11,9 +11,11 @@ on:
     - 'spring-cloud-previews/**'
   workflow_dispatch:
 
+env:
+  EXCLUDED_MODULES: spring-cloud-spanner-spring-data-r2dbc
 
 jobs:
-  NativeTests:
+  parallel-NativeTests:
     if: |
       github.actor != 'dependabot[bot]' && ((
         github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
@@ -24,7 +26,6 @@ jobs:
       matrix:
         it:
           - vision
-          - spanner
           - storage
           - secretmanager
           - logging-sample
@@ -52,9 +53,9 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw compile dependency:go-offline
+        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
       - name: Mvn install # Need this when the directory/pom structure changes
-        id: install1
+        id: install
         continue-on-error: true
         run: |
           ./mvnw \
@@ -63,9 +64,71 @@ jobs:
             --define maven.test.skip=true \
             --define maven.javadoc.skip=true \
             install
-      - name: Retry install on failure
-        id: install2
-        if: steps.install1.outcome == 'failure'
+      # Unlike for the other NativeTests job, we don't block here as these run in parallel.
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          version: '22.3.2'
+          java-version: '17'
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+      - name: Native Tests in Modules
+        id: intTest
+        continue-on-error: true
+        run: |
+          MODULE_UNDER_TEST="${{ matrix.it }}" ./.github/workflows/scripts/native-image-tests.sh
+      - name: Aggregate Report
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --define aggregate=true \
+            --activate-profiles spring-native,\!default \
+          surefire-report:report-only
+      - name: Archive logs
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: Native Test Logs
+          path: |
+            **/target/failsafe-reports/*
+            **/target/site
+
+  NativeTests:
+    if: |
+      github.actor != 'dependabot[bot]' && ((
+        github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
+      ) || (github.event_name != 'pull_request'))
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        it:
+          - spanner
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+      - name: Set Up Authentication
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.SPRING_CLOUD_GCP_CI_NATIVE_SA_KEY }}
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: spring-cloud-gcp-ci-native
+      - name: Maven go offline
+        id: mvn-offline
+        if: steps.mvn-cache.outputs.cache-hit != 'true'
+        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
+      - name: Mvn install # Need this when the directory/pom structure changes
+        id: install
+        continue-on-error: true
         run: |
           ./mvnw \
             --batch-mode \
@@ -88,10 +151,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
       - name: Native Tests in Modules
-        id: intTest3
+        id: intTest
         continue-on-error: true
         run: |
-          EXCLUDED_MODULES=spring-cloud-spanner-spring-data-r2dbc MODULE_UNDER_TEST="${{ matrix.it }}" ./.github/workflows/scripts/native-image-tests.sh
+          MODULE_UNDER_TEST="${{ matrix.it }}" ./.github/workflows/scripts/native-image-tests.sh
       - name: Aggregate Report
         run: |
           ./mvnw \

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Maven go offline
       id: mvn-offline
       if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: ./mvnw compile dependency:go-offline
+      run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/compatibilityCheck.yaml
+++ b/.github/workflows/compatibilityCheck.yaml
@@ -106,7 +106,7 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw compile dependency:go-offline --define compatibilityCheckRepository=$REPO
+        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
         env:
           REPO: ${{ inputs.mavenRepository }}
       - name: Retry install on failure

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -16,7 +16,7 @@ on:
 
 
 jobs:
-  integrationTests:
+  parallel-integrationTests:
     if: |
       github.actor != 'dependabot[bot]' && ((
         github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
@@ -26,25 +26,13 @@ jobs:
       fail-fast: false
       matrix:
         it:
-          - bigquery
-          - cloudsql
           - config
-          - datastore
-          - firestore
-          - kms
-          - logging
-          - metrics
-          - multisample
-          - kotlin
           - pubsub
           - pubsub-bus
           - pubsub-docs
           - pubsub-emulator
           - pubsub-integration
           - secretmanager
-          - spanner
-          - storage
-          - trace
           - vision
     steps:
       - name: Get current date
@@ -52,8 +40,9 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v2
       - name: Setup Java 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 17
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v0
@@ -70,9 +59,9 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw compile dependency:go-offline
+        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
       - name: Mvn install # Need this when the directory/pom structure changes
-        id: install1
+        id: install
         continue-on-error: true
         run: |
           ./mvnw \
@@ -81,9 +70,83 @@ jobs:
             --define maven.test.skip=true \
             --define maven.javadoc.skip=true \
             install
-      - name: Retry install on failure
-        id: install2
-        if: steps.install1.outcome == 'failure'
+      # Unlike for the other integrationTest job, we don't block here as these run in parallel.
+      - name: Integration Tests
+        id: intTest
+        continue-on-error: true
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --activate-profiles spring-cloud-gcp-ci-it \
+            --define maven.javadoc.skip=true \
+            --define skip.surefire.tests=true \
+            --define "spring.datasource.password=${DB_PASSWORD}" \
+            --define "spring.r2dbc.password=${DB_PASSWORD}" \
+            --define it.${{ matrix.it }}=true \
+            verify
+        env:
+          DB_PASSWORD: ${{ secrets.SPRING_CLOUD_GCP_CI_DB_ROOT_PASSWORD }}
+      - name: Aggregate Report
+        run: |
+          ./mvnw \
+            --batch-mode \
+            --define aggregate=true \
+            surefire-report:failsafe-report-only
+      - name: Archive logs
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: Integration Test Logs - ${{ matrix.it}}
+          path: |
+            **/target/failsafe-reports/*
+            **/target/site
+  integrationTests:
+    if: |
+      github.actor != 'dependabot[bot]' && ((
+        github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
+      ) || (github.event_name != 'pull_request'))
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        it:
+          - bigquery
+          - cloudsql
+          - datastore
+          - firestore
+          - kms
+          - logging
+          - metrics
+          - multisample
+          - kotlin
+          - spanner
+          - storage
+          - trace
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v2
+      - name: Setup Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          version: latest
+          project_id: spring-cloud-gcp-ci
+          service_account_key: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY }}
+          export_default_credentials: true
+      - name: Maven go offline
+        id: mvn-offline
+        if: steps.mvn-cache.outputs.cache-hit != 'true'
+        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
+      - name: Mvn install # Need this when the directory/pom structure changes
+        id: install
+        continue-on-error: true
         run: |
           ./mvnw \
             --batch-mode \
@@ -99,23 +162,8 @@ jobs:
           continue-after-seconds: 1200 # 30 min
           same-branch-only: false
       - name: Integration Tests
-        id: intTest1
+        id: intTest
         continue-on-error: true
-        run: |
-          ./mvnw \
-            --batch-mode \
-            --activate-profiles spring-cloud-gcp-ci-it \
-            --define maven.javadoc.skip=true \
-            --define skip.surefire.tests=true \
-            --define "spring.datasource.password=${DB_PASSWORD}" \
-            --define "spring.r2dbc.password=${DB_PASSWORD}" \
-            --define it.${{ matrix.it }}=true \
-            verify
-        env:
-          DB_PASSWORD: ${{ secrets.SPRING_CLOUD_GCP_CI_DB_ROOT_PASSWORD }}
-      - name: Retry on Failure
-        id: intTest2
-        if: steps.intTest1.outcome == 'failure'
         run: |
           ./mvnw \
             --batch-mode \

--- a/.github/workflows/linkageCheck.yaml
+++ b/.github/workflows/linkageCheck.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw compile dependency:go-offline
+        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
       - name: install
         # install before running Linkage Checker
         run: |

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw compile dependency:go-offline
+        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
       - name: Mvn install w/ coverage # Need this when the directory/pom structure changes
         id: install1
         continue-on-error: true

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Maven go offline
       id: mvn-offline
       if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: ./mvnw compile dependency:go-offline
+      run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
 
     - name: Mvn install # Need this when the directory/pom structure changes
       id: install1
@@ -116,7 +116,7 @@ jobs:
       - name: Maven go offline
         id: mvn-offline
         if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw compile dependency:go-offline
+        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
 
       - name: releaseCheck
         run: |

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Maven go offline
       id: mvn-offline
       if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: ./mvnw compile dependency:go-offline
+      run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
 
     - name: Mvn install # Need this when the version/directory/pom structure changes
       run: |


### PR DESCRIPTION
* Adds a parallel-integrationTests and parallel-NativeTests job that copies the non-parallel workflow except for the blocking step prior to integration testing.

* Removes 'compile' from the mvn dependency:go-offline command and adds `-T 1.5C -ntp -B` to speed this step up (~10mins per test before change). Now ~1m

* Uses Temurin for integration testing