### PR TITLE
chore: removes unnecessary bean from sample app config.

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/SampleApplicationConfiguration.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/SampleApplicationConfiguration.java
@@ -16,8 +16,6 @@
 
 package com.example;
 
-import com.google.cloud.spring.autoconfigure.datastore.DatastoreProvider;
-import com.google.cloud.spring.data.datastore.core.DatastoreTransactionManager;
 import com.google.cloud.spring.data.datastore.core.convert.DatastoreCustomConversions;
 import com.google.cloud.spring.data.datastore.repository.config.EnableDatastoreAuditing;
 import java.util.Arrays;
@@ -33,11 +31,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 @EnableDatastoreAuditing
 public class SampleApplicationConfiguration {
-
-  @Bean
-  DatastoreTransactionManager datastoreTransactionManager(DatastoreProvider datastore) {
-    return new DatastoreTransactionManager(datastore);
-  }
 
   @Bean
   public TransactionalRepositoryService transactionalRepositoryService() {


### PR DESCRIPTION
According to our [doc](https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#declarative-transactions-with-transactional-annotation-2),  a bean of `DatastoreTransactionManager` is already provided when using `spring-cloud-gcp-starter-data-datastore`. This bean setup in sample should be redundant.

update: 
`DatastoreTransactionManager` bean is pre-configured in [autoconfig code](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/f937b36efb442e5294a357c1a5a14e529aac3fa4/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/DatastoreTransactionManagerAutoConfiguration.java#L60C1-L69).