### PR TITLE
chore: split pubsub tests into sub-jobs

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -33,6 +33,10 @@ jobs:
           - trace-sample
           - vision-sample
           - secretmanager-sample
+          - pubsub-sample
+          - pubsub-integration-sample
+          - pubsub-bus-sample
+          - pubsub-stream-sample
     steps:
       - name: Get current date
         id: date

--- a/.github/workflows/scripts/native-image-tests.sh
+++ b/.github/workflows/scripts/native-image-tests.sh
@@ -1,25 +1,63 @@
 #!/bin/bash
-
 # This script executes native image tests based on the MODULE_UNDER_TEST provided.
 # If MODULE_UNDER_TEST is 'vision', for example, then it runs tests under spring-cloud-gcp-vision.
 # If it is 'vision-sample' then it runs tests under spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample
 # and spring-cloud-gcp-samples/spring-cloud-gcp-vision-ocr-demo.
-
+set -eo pipefail
 # Get git repo root
 scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 cd "${scriptDir}/../../.."
+IFS='-' read -ra MATRIX_SUBSTRINGS <<< "$MODULE_UNDER_TEST"
 
-run_sample_tests () {
-  module_name=$(echo "$MODULE_UNDER_TEST" | cut -d '-' -f 1)
-  directory_names=$(ls 'spring-cloud-gcp-samples')
-  module_samples=()
-  for dir in $directory_names; do
-    if [[ $dir =~ $module_name ]]; then
-      module_samples+=("spring-cloud-gcp-samples/$dir")
+is_desired_directory() {
+  local directory="$1"
+
+  # Exclude Spring Integration, Config Bus, Cloud Stream samples when testing with pubsub-sample
+  if [ "$MODULE_UNDER_TEST" == "pubsub-sample" ]  && [[ "$directory" =~ "integration" || "$directory" =~ "stream" ||  "$directory" =~ "bus" ]] ; then
+     return 1
+  fi
+
+  for substring in "${MATRIX_SUBSTRINGS[@]}"; do
+    if [[ ! "$directory" =~ $substring ]]; then
+      return 1
     fi
   done
-  project_names="$(echo "${module_samples[@]}" | sed 's/ /,/g')"
-  mvn clean --activate-profiles native-sample-config,nativeTest --define notAllModules=true --define maven.javadoc.skip=true -pl="${project_names}" test
+  return 0
+}
+
+run_sample_tests () {
+  pushd spring-cloud-gcp-samples
+  directory_names=$(find -maxdepth 2 -type d -name 'spring-cloud-gcp-*' | sed 's/.\///')
+  module_samples=()
+  for dir in $directory_names; do
+    if is_desired_directory "$dir"; then
+      module_samples+=("$dir")
+    fi
+  done
+
+  # The spring-cloud-gcp-pubsub-stream-functional-sample-test needs the process-aot step to explicitly be triggered
+  # before native image tests. The module's application class is not tested through the SpringBootTest annotation
+  # so it doesn't get automatically detected by the Spring AOT processor (See https://github.com/spring-projects/spring-boot/issues/35626)
+  if [[ ${module_samples[*]} =~ "spring-cloud-gcp-pubsub-stream-functional-sample" ]]; then
+    functional_test_directory_names=$(find -maxdepth 2 -type d -name 'spring-cloud-gcp-pubsub-stream-functional-*' | sed 's/\.\///')
+    filtered_modules=()
+    for sample in "${module_samples[@]}"; do
+      if [[ ! $functional_test_directory_names =~ $sample ]]; then
+        filtered_modules+=("$sample")
+      fi
+    done
+    pushd spring-cloud-gcp-pubsub-stream-functional-sample/spring-cloud-gcp-pubsub-stream-functional-sample-test
+    mvn package -Pnative -Pnative-sample-config -DskipTests
+    mvn -Pnative-sample-config -PnativeTest --define notAllModules=true --define maven.javadoc.skip=true test
+    popd
+    filtered_project_names="$(echo "${filtered_modules[@]}" | sed 's/ /,/g')"
+    mvn clean --activate-profiles native-sample-config,nativeTest --define notAllModules=true --define maven.javadoc.skip=true -pl="${filtered_project_names}" test
+
+  else
+    project_names="$(echo "${module_samples[@]}" | sed 's/ /,/g')"
+    mvn clean --activate-profiles native-sample-config,nativeTest --define notAllModules=true --define maven.javadoc.skip=true -pl="${project_names}" test
+  fi
+  popd
 }
 
 run_module_tests() {
@@ -34,6 +72,7 @@ run_module_tests() {
   mvn clean verify -Pspring-native,!default -pl="${project_names}"
 }
 
+
 if [ -z "$MODULE_UNDER_TEST" ]; then
   echo "Please specify the MODULE_UNDER_TEST."
   exit 1
@@ -44,4 +83,3 @@ if [[ "$MODULE_UNDER_TEST" == *"sample" ]]; then
 else
   run_module_tests
 fi
-

--- a/.github/workflows/scripts/native-image-tests.sh
+++ b/.github/workflows/scripts/native-image-tests.sh
@@ -9,7 +9,10 @@ set -eo pipefail
 # Get git repo root
 scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 cd "${scriptDir}/../../.."
+
+OLD_IFS="$IFS"
 IFS='-' read -ra MATRIX_SUBSTRINGS <<< "$MODULE_UNDER_TEST"
+IFS="$OLD_IFS"
 
 is_desired_directory() {
   local directory="$1"

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/SampleApplicationConfiguration.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/main/java/com/example/SampleApplicationConfiguration.java
@@ -16,8 +16,6 @@
 
 package com.example;
 
-import com.google.cloud.spring.autoconfigure.datastore.DatastoreProvider;
-import com.google.cloud.spring.data.datastore.core.DatastoreTransactionManager;
 import com.google.cloud.spring.data.datastore.core.convert.DatastoreCustomConversions;
 import com.google.cloud.spring.data.datastore.repository.config.EnableDatastoreAuditing;
 import java.util.Arrays;
@@ -33,11 +31,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 @EnableDatastoreAuditing
 public class SampleApplicationConfiguration {
-
-  @Bean
-  DatastoreTransactionManager datastoreTransactionManager(DatastoreProvider datastore) {
-    return new DatastoreTransactionManager(datastore);
-  }
 
   @Bean
   public TransactionalRepositoryService transactionalRepositoryService() {


### PR DESCRIPTION
As discovered in #2007, the Pub/Sub native image job is taking a really long time to run (approx. 145 mins). Instead of all Pub/Sub tests running in a single job, this PR splits them into multiple sub-jobs:
- pubsub-sample which runs template sample tests
- pubsub-integration-sample which runs Spring Integration tests
- pubsub-stream-sample which runs Cloud Stream tests
- pubsub-bus-sample which runs tests under `spring-cloud-gcp-pubsub-bus-config-sample`