### PR TITLE
ci: remove mvn go-offline

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -54,10 +54,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: spring-cloud-gcp-ci-native
-      - name: Maven go offline
-        id: mvn-offline
-        if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
       - name: Mvn install # Need this when the directory/pom structure changes
         id: install
         run: |
@@ -126,10 +122,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: spring-cloud-gcp-ci-native
-      - name: Maven go offline
-        id: mvn-offline
-        if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
       - name: Mvn install # Need this when the directory/pom structure changes
         id: install
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,11 +54,6 @@ jobs:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
 
-    - name: Maven go offline
-      id: mvn-offline
-      if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/compatibilityCheck.yaml
+++ b/.github/workflows/compatibilityCheck.yaml
@@ -103,12 +103,6 @@ jobs:
         run: |
           gcloud components install pubsub-emulator beta && \
             gcloud components update
-      - name: Maven go offline
-        id: mvn-offline
-        if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
-        env:
-          REPO: ${{ inputs.mavenRepository }}
       - name: Retry install on failure
         id: install2
         if: steps.install1.outcome == 'failure'

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -56,10 +56,6 @@ jobs:
         run: |
           gcloud components install pubsub-emulator beta && \
             gcloud components update
-      - name: Maven go offline
-        id: mvn-offline
-        if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
       - name: Mvn install # Need this when the directory/pom structure changes
         id: install
         run: |
@@ -140,10 +136,6 @@ jobs:
           project_id: spring-cloud-gcp-ci
           service_account_key: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY }}
           export_default_credentials: true
-      - name: Maven go offline
-        id: mvn-offline
-        if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
       - name: Mvn install # Need this when the directory/pom structure changes
         id: install
         run: |

--- a/.github/workflows/linkageCheck.yaml
+++ b/.github/workflows/linkageCheck.yaml
@@ -30,10 +30,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
-      - name: Maven go offline
-        id: mvn-offline
-        if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
       - name: install
         # install before running Linkage Checker
         run: |

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -38,10 +38,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
-      - name: Maven go offline
-        id: mvn-offline
-        if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
       - name: Mvn install w/ coverage # Need this when the directory/pom structure changes
         id: install
         run: |

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -37,11 +37,6 @@ jobs:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
 
-    - name: Maven go offline
-      id: mvn-offline
-      if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
-
     - name: Mvn install # Need this when the directory/pom structure changes
       id: install1
       continue-on-error: true
@@ -112,11 +107,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
-
-      - name: Maven go offline
-        id: mvn-offline
-        if: steps.mvn-cache.outputs.cache-hit != 'true'
-        run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
 
       - name: releaseCheck
         run: |

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -37,11 +37,6 @@ jobs:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
 
-    - name: Maven go offline
-      id: mvn-offline
-      if: steps.mvn-cache.outputs.cache-hit != 'true'
-      run: ./mvnw dependency:go-offline -ntp -B -T 1.5C
-
     - name: Mvn install # Need this when the version/directory/pom structure changes
       run: |
         ./mvnw \


### PR DESCRIPTION
Go-offline isn't required, takes 10mins if compile is performed at the same time, and appears to be break without compile. This PR provides an option to just remove the stage.