### PR TITLE
chore: add spring-cloud-gcp-core tests to native ci.

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         it:
+          - core
           - vision
           - storage
           - secretmanager

--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,7 @@
 			<module>spring-cloud-gcp-data-spanner</module>
 			<module>spring-cloud-gcp-secretmanager</module>
 			<module>spring-cloud-gcp-data-datastore</module>
+			<module>spring-cloud-gcp-core</module>
 		</modules>
 
 		<dependencies>
@@ -379,6 +380,7 @@
 						<includes>
 							<!--including all integration tests for testing purposes. -->
 							<include>${integration-test.pattern}</include>
+							<include>com.google.cloud.spring.core.**Tests</include>
 						</includes>
 						<classesDirectory>${project.build.outputDirectory}</classesDirectory>
 						<systemPropertyVariables>


### PR DESCRIPTION
Adding 2 tests from core module to native ci. 
`spring-cloud-gcp-core` is also tested via module sample tests.