### PR TITLE
chore: cleanup firestore ci test resource

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -369,7 +369,6 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
-                                <spring.cloud.gcp.firestore.project-id>spring-cloud-gcp-ci</spring.cloud.gcp.firestore.project-id>
                                 <spring.cloud.gcp.firestore.database-id>firestoredb</spring.cloud.gcp.firestore.database-id>
                             </systemPropertyVariables>
                         </configuration>

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -369,7 +369,8 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
-                                <spring.cloud.gcp.firestore.project-id>spring-cloud-gcp-ci-firestore</spring.cloud.gcp.firestore.project-id>
+                                <spring.cloud.gcp.firestore.project-id>spring-cloud-gcp-ci</spring.cloud.gcp.firestore.project-id>
+                                <spring.cloud.gcp.firestore.database-id>firestoredb</spring.cloud.gcp.firestore.database-id>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTestsConfiguration.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTestsConfiguration.java
@@ -19,6 +19,7 @@ package com.google.cloud.spring.data.firestore.it;
 import com.google.api.client.util.escape.PercentEscaper;
 import com.google.api.gax.rpc.internal.Headers;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.spring.core.DefaultGcpProjectIdProvider;
 import com.google.cloud.spring.data.firestore.FirestoreTemplate;
 import com.google.cloud.spring.data.firestore.entities.UserRepository;
 import com.google.cloud.spring.data.firestore.mapping.FirestoreClassMapper;
@@ -36,6 +37,7 @@ import io.grpc.auth.MoreCallCredentials;
 import io.grpc.stub.MetadataUtils;
 import java.io.IOException;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -49,15 +51,24 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableReactiveFirestoreRepositories(basePackageClasses = UserRepository.class)
 @EnableTransactionManagement
 public class FirestoreIntegrationTestsConfiguration {
-  @Value(
-      "projects/${test.integration.firestore.project-id}/databases/${test.integration.firestore.database-id:(default)}/documents")
   String defaultParent;
 
-  @Value("${test.integration.firestore.project-id}")
   String projectId;
 
-  @Value("${test.integration.firestore.database-id:(default)}")
   String databaseId;
+
+  @Autowired
+  public FirestoreIntegrationTestsConfiguration(
+      @Value("${test.integration.firestore.project-id:default}") String projectId,
+      @Value("${test.integration.firestore.database-id:(default)}") String databaseId) {
+    this.projectId =
+        (projectId.equals("default"))
+            ? new DefaultGcpProjectIdProvider().getProjectId()
+            : projectId;
+    this.databaseId = databaseId;
+    this.defaultParent =
+        String.format("projects/%s/databases/%s/documents", this.projectId, databaseId);
+  }
 
   private static final PercentEscaper PERCENT_ESCAPER = new PercentEscaper("._-~");
 

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTestsConfiguration.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreIntegrationTestsConfiguration.java
@@ -59,12 +59,8 @@ public class FirestoreIntegrationTestsConfiguration {
 
   @Autowired
   public FirestoreIntegrationTestsConfiguration(
-      @Value("${test.integration.firestore.project-id:default}") String projectId,
       @Value("${test.integration.firestore.database-id:(default)}") String databaseId) {
-    this.projectId =
-        (projectId.equals("default"))
-            ? new DefaultGcpProjectIdProvider().getProjectId()
-            : projectId;
+    this.projectId = new DefaultGcpProjectIdProvider().getProjectId();
     this.databaseId = databaseId;
     this.defaultParent =
         String.format("projects/%s/databases/%s/documents", this.projectId, databaseId);

--- a/spring-cloud-gcp-data-firestore/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-data-firestore/src/test/resources/application-test.properties
@@ -1,1 +1,2 @@
-test.integration.firestore.project-id=spring-cloud-gcp-ci-firestore
+test.integration.firestore.project-id=spring-cloud-gcp-ci
+test.integration.firestore.database-id=firestoredb

--- a/spring-cloud-gcp-data-firestore/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-data-firestore/src/test/resources/application-test.properties
@@ -1,2 +1,1 @@
-test.integration.firestore.project-id=spring-cloud-gcp-ci
 test.integration.firestore.database-id=firestoredb

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/resources/application-test.properties
@@ -1,2 +1,1 @@
-spring.cloud.gcp.firestore.project-id=spring-cloud-gcp-ci
 spring.cloud.gcp.firestore.database-id=firestoredb

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-starter-firestore-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-starter-firestore-sample/src/test/resources/application-test.properties
@@ -1,2 +1,1 @@
-spring.cloud.gcp.firestore.project-id=spring-cloud-gcp-ci
 spring.cloud.gcp.firestore.database-id=firestoredb

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-starter-firestore-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-starter-firestore-sample/src/test/resources/application-test.properties
@@ -1,1 +1,2 @@
-spring.cloud.gcp.firestore.project-id=spring-cloud-gcp-ci-firestore
+spring.cloud.gcp.firestore.project-id=spring-cloud-gcp-ci
+spring.cloud.gcp.firestore.database-id=firestoredb


### PR DESCRIPTION
With feature in [#2164](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/2164), now  Firestore can run in same project as datastore. This PR cleans up settings for integration tests ci so that tests for Firestore module and samples run in the same ci project as the rest.
Modules affected in this change:
- autoconfigure/firestore
- data-firestore
- data-firestore-sample
- starter-firestore-sample

Before this change, these modules are setup to run with `spring-cloud-gcp-ci-firestore` project.

After this change:
- database-id=firestoredb is specified for above module's tests.
- does not specify `firestore.project-id` and get project id info from `DefaultGcpProjectIdProvider`. For integration test ci, it is `spring-cloud-gcp-ci` set via gcloud [here](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/ef30225e60e270f8cc1a9213728f0cfdd7e4de50/.github/workflows/integrationTests.yaml#L51).