### PR TITLE
sample: Transactional annotation sample to demonstrate Read-write transaction

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/main/java/com/example/Book.java
+++ b/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/main/java/com/example/Book.java
@@ -20,13 +20,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 /** Book entity. */
 @Table
-public class Book implements Persistable {
+public class Book implements Persistable<String> {
 
   @Id
   @Column("ID")
@@ -44,11 +45,19 @@ public class Book implements Persistable {
   @Column("CATEGORIES")
   private List<String> categories;
 
+  @Column("COUNT")
+  private int count;
+
+  @Transient
+  private boolean isNew;
+
   public Book(String title, Map<String, String> extraDetails, Review review) {
     this.id = UUID.randomUUID().toString();
     this.title = title;
     this.extraDetails = extraDetails;
     this.review = review;
+    this.count = 0;
+    this.isNew = true;
   }
 
   public String getId() {
@@ -57,7 +66,7 @@ public class Book implements Persistable {
 
   @Override
   public boolean isNew() {
-    return true;
+    return this.isNew;
   }
 
   public String getTitle() {
@@ -78,6 +87,15 @@ public class Book implements Persistable {
 
   public void setCategories(List<String> categories) {
     this.categories = categories;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  public void incrementCount() {
+    this.count++;
+    this.isNew = false;
   }
 
   @Override

--- a/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/main/java/com/example/SpringDataR2dbcApp.java
+++ b/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/main/java/com/example/SpringDataR2dbcApp.java
@@ -73,7 +73,8 @@ public class SpringDataR2dbcApp {
                   + "  TITLE STRING(MAX) NOT NULL,"
                   + "  EXTRADETAILS JSON,"
                   + "  REVIEWS JSON,"
-                  + "  CATEGORIES ARRAY<STRING(64)>"
+                  + "  CATEGORIES ARRAY<STRING(64)>,"
+                  + "  COUNT INT64 NOT NULL"
                   + ") PRIMARY KEY (ID)")
           .fetch()
           .rowsUpdated()

--- a/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/main/java/com/example/WebController.java
@@ -18,6 +18,7 @@ package com.example;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -61,5 +62,15 @@ public class WebController {
   @GetMapping("/search/{id}")
   public Mono<Book> searchBooks(@PathVariable String id) {
     return r2dbcRepository.findById(id);
+  }
+
+  @Transactional
+  @PostMapping("/increment-count/{id}")
+  public Mono<Void> incrementCount(@PathVariable String id) {
+    return r2dbcRepository.findById(id)
+        .doOnNext(Book::incrementCount)
+        .flatMap(book -> r2dbcRepository.save(book))
+        .log()
+        .then();
   }
 }

--- a/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/main/java/com/example/WebController.java
@@ -69,7 +69,7 @@ public class WebController {
   public Mono<Void> incrementCount(@PathVariable String id) {
     return r2dbcRepository.findById(id)
         .doOnNext(Book::incrementCount)
-        .flatMap(book -> r2dbcRepository.save(book))
+        .flatMap(r2dbcRepository::save)
         .log()
         .then();
   }

--- a/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/main/resources/static/index.html
+++ b/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/main/resources/static/index.html
@@ -86,6 +86,27 @@
       return false;
     }
 
+    function incrementCount() {
+      const id = document.getElementById('bookIdCountIncrement').value;
+      if (!id) {
+        appendOutput("Please provide non-empty id");
+        return false;
+      }
+
+      fetch('/increment-count/' + id, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json'}
+      }).then(response => {
+         if (response.ok) {
+           appendOutput("Count updated.");
+         } else {
+           appendOutput("Failed to update count.");
+         }
+       });
+
+      return false;
+    }
+
   </script>
 
   <style>
@@ -141,6 +162,10 @@
   <div class="buttonLink">
     Search for: <input id="bookId" name="bookId"/> <a class="buttonLink" href="/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static" onClick="return findBookById();">Find
     Books</a>
+  </div>
+
+  <div class="buttonLink">
+    Read count: <input id="bookIdCountIncrement" name="bookId" placeholder="Book ID"/> <a class="buttonLink" href="/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static" onClick="return incrementCount();">Increment</a>
   </div>
 </div>
 

--- a/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/test/java/com/example/SpringDataR2dbcAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/test/java/com/example/SpringDataR2dbcAppIntegrationTest.java
@@ -91,6 +91,7 @@ class SpringDataR2dbcAppIntegrationTest {
             books -> {
               assertThat(books).hasSize(1);
               assertThat(books[0].getTitle()).isEqualTo("Call of the wild");
+              assertThat(books[0].getCount()).isEqualTo(0);
               id.set(books[0].getId());
             });
 

--- a/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/test/java/com/example/SpringDataR2dbcAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/test/java/com/example/SpringDataR2dbcAppIntegrationTest.java
@@ -105,6 +105,24 @@ class SpringDataR2dbcAppIntegrationTest {
             book -> {
               assertThat(book.getTitle()).isEqualTo("Call of the wild");
             });
+
+    this.webTestClient
+        .post()
+        .uri("/increment-count/" + id.get())
+        .exchange()
+        .expectStatus()
+        .is2xxSuccessful();
+
+    this.webTestClient
+        .get()
+        .uri("/search/" + id.get())
+        .exchange()
+        .expectBody(Book.class)
+        .value(
+            book -> {
+              assertThat(book.getCount()).isEqualTo(1);
+            });
+
   }
 
   @Test


### PR DESCRIPTION
Adding a capability to increment the *read count* of a book, It starts a transaction, and then fetches a book by ID and update the count followed by persisting the changes back to the database before committing the transaction.

![image](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/assets/5915092/88c507f0-5cb2-4af1-b1cd-853e4a52219b)
