### PR TITLE
[Draft] Adding documentation for experimental native image support

### DIFF
--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -71,6 +71,8 @@ include::cloudfoundry.adoc[]
 
 include::kotlin.adoc[]
 
+include::native.adoc[]
+
 == Configuration properties
 
 To see the list of all Google Cloud related configuration properties please check link:appendix.html[the Appendix page].

--- a/docs/src/main/asciidoc/native.adoc
+++ b/docs/src/main/asciidoc/native.adoc
@@ -3,8 +3,40 @@
 https://www.graalvm.org/docs/[GraalVM Native Image] allows you to ahead-of-time compile Java code to a standalone executable.
 GraalVM native images are supported in Spring Boot since 3.0 and Spring Framework 6.0.
 
-WARNING: Native Image Support for Spring Framework on Google Cloud is Experimental.
+WARNING: Native Image Support for Spring Framework on Google Cloud is **Experimental**.
 Compatibility with native image compilation are available "as is" and might have limited support.
+
+=== Currently Included Modules
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#spring-cloud-gcp-core[Google Cloud Core]
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#cloud-storage[Cloud Storage]
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#cloud-pubsub[Cloud PubSub]
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#spring-integration[Spring Integration for Cloud PubSub and Cloud Storage]
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#spring-cloud-stream[Spring Cloud Stream binder to Google Cloud Pub/Sub]
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#spring-cloud-bus[Cloud Pub/Sub as the Spring Cloud Bus]
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#cloud-trace[Cloud Trace]
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#cloud-logging[Cloud Logging]
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#cloud-monitoring[Cloud Monitoring]
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#spring-data-cloud-spanner[Spring Data Cloud Spanner] (See details in <<detail_guides>> )
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#spring-data-cloud-datastore[Spring Data Cloud Datastore] (See details in <<detail_guides>> )
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#spring-data-cloud-firestore[Spring Data Cloud Firestore] (See details in <<detail_guides>> )
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#cloud-vision[Cloud Vision]
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#secret-manager[Cloud Secret Manager]
+
+https://googlecloudplatform.github.io/spring-cloud-gcp//reference/html/index.html#google-cloud-key-management-service[Cloud KMS]
 
 === Usage
 
@@ -61,7 +93,7 @@ This dependency provides the `native` profile.
 The spring boot maven plugin uses this to activate native image compilation.
 4. Call `mvn -Pnative native:compile`
 
-=== Guides Specific to a Module
+=== Guides Specific to a Module [[detail_guides]]
 
 ==== Datastore
 

--- a/docs/src/main/asciidoc/native.adoc
+++ b/docs/src/main/asciidoc/native.adoc
@@ -1,0 +1,74 @@
+== Native Image Support (Experimental)
+
+https://www.graalvm.org/docs/[GraalVM Native Image] allows you to ahead-of-time compile Java code to a standalone executable.
+GraalVM native images are supported in Spring Boot since 3.0 and Spring Framework 6.0.
+
+WARNING: Native Image Support for Spring Framework on Google Cloud is Experimental.
+Compatibility with native image compilation are available "as is" and might have limited support.
+
+=== Usage
+
+==== Paketo Buildpacks
+
+Doesn't require GraalVM to be installed on the local environment.
+Needs docker to be installed and the following
+
+1. spring-boot-starter-parent
+
+[source]
+----
+<parent>
+<groupId>org.springframework.boot</groupId>
+<artifactId>spring-boot-starter-parent</artifactId>
+<version>3.0.5</version>
+</parent>
+----
+
+2. native-maven-plugin
+
+[source]
+----
+<plugin>
+<groupId>org.graalvm.buildtools</groupId>
+<artifactId>native-maven-plugin</artifactId>
+</plugin>
+----
+
+3. Call `mvn -Pnative spring-boot:build-image`
+
+==== Native Build Plugins
+
+Needs GraalVM to be installed on the local environment and the following:
+
+1. `org.springframework.boot:spring-boot-starter-parent`.
+No special dependencies for native image support.
+It is all baked into the spring boot dependency.
+This dependency provides the `native` profile.
+2. The `spring-boot-maven-plugin` - provides Spring Boot support in Maven and inherits a lot of default configurations from the spring-boot-starter-parent.
+
+[source]
+----
+<plugin>
+<groupId>org.springframework.boot</groupId>
+<artifactId>spring-boot-maven-plugin</artifactId>
+</plugin>
+----
+
+3. Org.graalvm.buildtools: native-maven-plugin.
+The spring boot maven plugin uses this to activate native image compilation.
+4. Call `mvn -Pnative native:compile`
+
+For more details, please refer to Spring boot guide to https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#native-image.developing-your-first-application[Developing Your First GraalVM Native Application]
+
+=== Guides Specific to a Module
+
+==== Datastore
+
+To use `DatastoreTemplate` without the `DatastoreRepository`, user needs to register runtime hints for domain POJOs in the application. See details in sample application.
+
+===== Relationships
+@LazyReference is not yet supported for Native Image.
+
+==== Firestore
+
+To use `FirestoreTemplate` methods without `FirestoreReactiveRepository`, user needs to register runtime hints for domain POJOs in the application. For more details, refer to sample application.

--- a/docs/src/main/asciidoc/native.adoc
+++ b/docs/src/main/asciidoc/native.adoc
@@ -71,4 +71,4 @@ To use `DatastoreTemplate` without the `DatastoreRepository`, user needs to regi
 
 ==== Firestore
 
-To use `FirestoreTemplate` methods without `FirestoreReactiveRepository`, user needs to register runtime hints for domain POJOs in the application. For more details, refer to sample application.
+To use `FirestoreTemplate` methods without `FirestoreReactiveRepository`, user needs to register runtime hints for domain POJOs in the application. For more details, refer to https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/DataClassRuntimeHints.java[`DataClassRuntimeHints`] in Reactive Firestore Repository sample application.

--- a/docs/src/main/asciidoc/native.adoc
+++ b/docs/src/main/asciidoc/native.adoc
@@ -8,6 +8,9 @@ Compatibility with native image compilation are available "as is" and might have
 
 === Usage
 
+This section provides a quick guide to build native image for Spring Boot Application with Google Cloud integrations.
+For more details, please refer to Spring boot guide to https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#native-image.developing-your-first-application[Developing Your First GraalVM Native Application]
+
 ==== Paketo Buildpacks
 
 Doesn't require GraalVM to be installed on the local environment.
@@ -54,21 +57,20 @@ This dependency provides the `native` profile.
 </plugin>
 ----
 
-3. Org.graalvm.buildtools: native-maven-plugin.
+3. `org.graalvm.buildtools: native-maven-plugin`.
 The spring boot maven plugin uses this to activate native image compilation.
 4. Call `mvn -Pnative native:compile`
-
-For more details, please refer to Spring boot guide to https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#native-image.developing-your-first-application[Developing Your First GraalVM Native Application]
 
 === Guides Specific to a Module
 
 ==== Datastore
 
-To use `DatastoreTemplate` without the `DatastoreRepository`, user needs to register runtime hints for domain POJOs in the application. See details in sample application.
+To use `DatastoreTemplate` methods on Domain types not managed by `DatastoreRepository`, you need to register runtime hints for these domain POJOs in your application. For more details, refer to example
+https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/src/main/java/com/example/DomainTypeRuntimeHints.java[`DomainTypeRuntimeHints`] in Datastore basic sample.
 
 ===== Relationships
 @LazyReference is not yet supported for Native Image.
 
 ==== Firestore
 
-To use `FirestoreTemplate` methods without `FirestoreReactiveRepository`, user needs to register runtime hints for domain POJOs in the application. For more details, refer to https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/DataClassRuntimeHints.java[`DataClassRuntimeHints`] in Reactive Firestore Repository sample application.
+To use `FirestoreTemplate`  methods on Domain types not managed by `FirestoreReactiveRepository`, you need to register runtime hints for these domain POJOs in your application. For more details, refer to example https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/DomainTypeRuntimeHints.java[`DomainTypeRuntimeHints`] in Reactive Firestore Repository sample application.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/src/main/java/com/example/Computer.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/src/main/java/com/example/Computer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.google.cloud.spring.data.datastore.core.mapping.Entity;
+import com.google.common.base.Objects;
+import org.springframework.data.annotation.Id;
+
+/**
+ * This class represents a single computer stored in Datastore. To demonstrate template usage
+ * without repository.
+ */
+@Entity(name = "computer")
+public class Computer {
+  @Id Long id;
+
+  private final String brand;
+
+  private final String model;
+
+  private final int year;
+
+  public Computer(String brand, String model, int year) {
+    this.brand = brand;
+    this.model = model;
+    this.year = year;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Computer computer)) {
+      return false;
+    }
+    return year == computer.year
+        && Objects.equal(id, computer.id)
+        && Objects.equal(brand, computer.brand)
+        && Objects.equal(model, computer.model);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id, brand, model, year);
+  }
+
+  @Override
+  public String toString() {
+    return "Computer{"
+        + "id="
+        + this.id
+        + ", brand='"
+        + this.brand
+        + '\''
+        + ", model='"
+        + this.model
+        + '\''
+        + ", year="
+        + this.year
+        + '}';
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/src/main/java/com/example/DomainTypeRuntimeHints.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/src/main/java/com/example/DomainTypeRuntimeHints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package com.example;
 
-import com.google.cloud.spring.data.firestore.FirestoreTemplate;
-import com.google.cloud.spring.data.firestore.FirestoreReactiveRepository;
+import com.google.cloud.spring.data.datastore.core.DatastoreTemplate;
+import com.google.cloud.spring.data.datastore.repository.DatastoreRepository;
 import java.util.Arrays;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
@@ -26,10 +26,10 @@ import org.springframework.aot.hint.TypeReference;
 
 /**
  * Demonstrates adding runtime hints for native compilation. Runtime hints needs to be registered
- * for Data POJO classes when desire to use {@link FirestoreTemplate} methods directly without a
- * repository class for that domain type extending {@link FirestoreReactiveRepository} class.
+ * for Data POJO classes when desire to use {@link DatastoreTemplate} methods directly without a
+ * repository class for that domain type extending {@link DatastoreRepository} class.
  */
-public class DataClassRuntimeHints implements RuntimeHintsRegistrar {
+public class DomainTypeRuntimeHints implements RuntimeHintsRegistrar {
 
   @Override
   public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
@@ -37,7 +37,7 @@ public class DataClassRuntimeHints implements RuntimeHintsRegistrar {
     hints
         .reflection()
         .registerTypes(
-            Arrays.asList(TypeReference.of(Person.class)),
+            Arrays.asList(TypeReference.of(Computer.class)),
             hint ->
                 hint.withMembers(
                     MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/DataClassRuntimeHints.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/DataClassRuntimeHints.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.google.cloud.spring.data.firestore.FirestoreTemplate;
+import com.google.cloud.spring.data.firestore.FirestoreReactiveRepository;
+import java.util.Arrays;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+
+/**
+ * Demonstrates adding runtime hints for native compilation. Runtime hints needs to be registered
+ * for Data POJO classes when desire to use {@link FirestoreTemplate} methods directly without a
+ * repository class for that domain type extending {@link FirestoreReactiveRepository} class.
+ */
+public class DataClassRuntimeHints implements RuntimeHintsRegistrar {
+
+  @Override
+  public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+
+    hints
+        .reflection()
+        .registerTypes(
+            Arrays.asList(TypeReference.of(Person.class)),
+            hint ->
+                hint.withMembers(
+                    MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                    MemberCategory.INVOKE_DECLARED_METHODS,
+                    MemberCategory.DECLARED_FIELDS));
+
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/DomainTypeRuntimeHints.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/DomainTypeRuntimeHints.java
@@ -16,8 +16,8 @@
 
 package com.example;
 
-import com.google.cloud.spring.data.firestore.FirestoreTemplate;
 import com.google.cloud.spring.data.firestore.FirestoreReactiveRepository;
+import com.google.cloud.spring.data.firestore.FirestoreTemplate;
 import java.util.Arrays;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
@@ -29,7 +29,7 @@ import org.springframework.aot.hint.TypeReference;
  * for Data POJO classes when desire to use {@link FirestoreTemplate} methods directly without a
  * repository class for that domain type extending {@link FirestoreReactiveRepository} class.
  */
-public class DataClassRuntimeHints implements RuntimeHintsRegistrar {
+public class DomainTypeRuntimeHints implements RuntimeHintsRegistrar {
 
   @Override
   public void registerHints(RuntimeHints hints, ClassLoader classLoader) {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/Person.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/Person.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.google.cloud.firestore.annotation.DocumentId;
+import com.google.cloud.spring.data.firestore.Document;
+
+/** Example POJO to demonstrate Spring Cloud GCP Spring Data Firestore operations. */
+@Document(collectionName = "people")
+public class Person {
+
+  @DocumentId String name;
+
+  int age;
+
+  public Person(String name, int age) {
+    this.name = name;
+    this.age = age;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{" + "name='" + name + '\'' + ", age=" + age + '}';
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/Person.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/Person.java
@@ -19,7 +19,10 @@ package com.example;
 import com.google.cloud.firestore.annotation.DocumentId;
 import com.google.cloud.spring.data.firestore.Document;
 
-/** Example POJO to demonstrate Spring Cloud GCP Spring Data Firestore operations. */
+/**
+ * Example POJO to demonstrate Spring Cloud GCP Spring Data Firestore operations.To demonstrate
+ * template usage without repository.
+ */
 @Document(collectionName = "people")
 public class Person {
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/FirestoreSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/FirestoreSampleApplicationIntegrationTests.java
@@ -41,7 +41,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
     webEnvironment = WebEnvironment.RANDOM_PORT,
     classes = FirestoreSampleApplication.class)
 @TestPropertySource("classpath:application-test.properties")
-@ImportRuntimeHints(DataClassRuntimeHints.class)
+@ImportRuntimeHints(DomainTypeRuntimeHints.class)
 class FirestoreSampleApplicationIntegrationTests {
   private static final User ALPHA_USER =
       new User("Alpha", 49, singletonList(new Pet("rat", "Snowflake")));

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/FirestoreSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/test/java/com/example/FirestoreSampleApplicationIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -40,6 +41,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
     webEnvironment = WebEnvironment.RANDOM_PORT,
     classes = FirestoreSampleApplication.class)
 @TestPropertySource("classpath:application-test.properties")
+@ImportRuntimeHints(DataClassRuntimeHints.class)
 class FirestoreSampleApplicationIntegrationTests {
   private static final User ALPHA_USER =
       new User("Alpha", 49, singletonList(new Pet("rat", "Snowflake")));
@@ -96,5 +98,13 @@ class FirestoreSampleApplicationIntegrationTests {
     testUserClient.removePhonesForUser("Alpha");
     phoneNumbers = testUserClient.listPhoneNumbers("Alpha");
     assertThat(phoneNumbers).isEmpty();
+  }
+
+  @Test
+  void templateTest() {
+    this.firestoreTemplate.save(new Person("Alice", 12)).block();
+    assertThat(this.firestoreTemplate.count(Person.class).block()).isEqualTo(1);
+    this.firestoreTemplate.deleteAll(Person.class).block();
+    assertThat(this.firestoreTemplate.count(Person.class).block()).isEqualTo(0);
   }
 }


### PR DESCRIPTION
This pr: 
- Adds a section about native image support on documentation. Another option is to add in documentation to each relevant modules existing documentation page. But adding a centralized page is more convenient for adding general guides regarding native builds, and is less prone to error when it come to adding/removing experimental items in the future.
- Add to Firestore and Datastore sample to demonstrate runtime hints needs to be added for data domains if not managed with repositories (Native build). 

Todo: 
Add explanation on partial support of spanner.