### PR TITLE
chore: update github action for update docs.

### DIFF
--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -22,16 +22,17 @@ jobs:
     - name: Get current date
       id: date
       run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
 
-    - uses: actions/setup-java@v1
+    - uses: actions/checkout@v2
       with:
         java-version: 17
+        distribution: 'temurin'
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: mvn-cache
       with:
         path: ~/.m2/repository


### PR DESCRIPTION
To fix warning:
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-java@v1, actions/cache@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```
And specify temurin as jdk distribution.