### PR TITLE
chore: upgrade github action setup-gcloud to v1

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -44,12 +44,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
+      - name: Set Up Authentication
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: latest
           project_id: spring-cloud-gcp-ci
-          service_account_key: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY }}
           export_default_credentials: true
       - name: Install pubsub-emulator
         if: ${{ matrix.it == 'pubsub-emulator' }}
@@ -132,7 +135,7 @@ jobs:
       - name: Set Up Authentication
         uses: google-github-actions/auth@v1
         with:
-          credentials_json: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY  }}
+          credentials_json: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY }}
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v1
         with:

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -129,12 +129,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
+      - name: Set Up Authentication
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY  }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: latest
           project_id: spring-cloud-gcp-ci
-          service_account_key: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY }}
           export_default_credentials: true
       - name: Mvn install # Need this when the directory/pom structure changes
         id: install


### PR DESCRIPTION
Followup to comment [here](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/2384#discussion_r1409865100), upgrades `google-github-actions/setup-gcloud` to be consistent with  [nativeTests.yaml](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/main/.github/workflows/NativeTests.yaml) following example [here](https://github.com/google-github-actions/setup-gcloud#service-account-key-json).

This also fixes deprecation warnings on integration test workflows.
```
"service_account_key" has been deprecated. Please switch to using google-github-actions/auth which supports both Workload Identity Federation and Service Account Key JSON authentication. For more details, see https://github.com/google-github-actions/setup-gcloud#authorization
```