### PR TITLE
fix: backport Spring Boot 3.2 compatibility updates to Spring Cloud GCP 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,26 +22,37 @@
 		<url>https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues</url>
 	</issueManagement>
 
-	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://google.oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://google.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
+  <repositories>
+    <repository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+    <repository>
+      <id>spring-milestones</id>
+      <url>https://repo.spring.io/milestone</url>
+    </repository>
+  </repositories>
 
-	<properties>
-		<project.parent.version>${project.version}</project.parent.version>
-		<!-- Dependency versions -->
-		<spring-cloud-dependencies.version>2022.0.4</spring-cloud-dependencies.version>
-		<spring-boot-dependencies.version>3.1.5</spring-boot-dependencies.version>
-		<spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
-		<zipkin-gcp.version>1.0.4</zipkin-gcp.version>
-		<java-cfenv.version>2.5.0</java-cfenv.version>
-		<micrometer-tracing.verison>1.1.6</micrometer-tracing.verison>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://google.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://google.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+  <properties>
+    <project.parent.version>${project.version}</project.parent.version>
+    <!-- Dependency versions -->
+    <spring-cloud-dependencies.version>2023.0.0-M2</spring-cloud-dependencies.version>
+    <spring-boot-dependencies.version>3.2.0-RC1</spring-boot-dependencies.version>
+    <spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
+    <zipkin-gcp.version>1.0.4</zipkin-gcp.version>
+    <java-cfenv.version>2.5.0</java-cfenv.version>
+    <micrometer-tracing.verison>1.1.6</micrometer-tracing.verison>
 
 		<!-- Plugin versions -->
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
@@ -848,7 +859,7 @@
 			<name>Apache License, Version 2.0</name>
 			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
 			<comments>
-				Copyright 2015-2022 the original author or authors.
+				Copyright 2015-2023 the original author or authors.
 
 				Licensed under the Apache License, Version 2.0 (the "License");
 				you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -22,33 +22,22 @@
 		<url>https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues</url>
 	</issueManagement>
 
-  <repositories>
-    <repository>
-      <id>central</id>
-      <url>https://repo1.maven.org/maven2/</url>
-    </repository>
-    <repository>
-      <id>spring-milestones</id>
-      <url>https://repo.spring.io/milestone</url>
-    </repository>
-  </repositories>
+	<distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://google.oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://google.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
+	</distributionManagement>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://google.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://google.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
-  <properties>
-    <project.parent.version>${project.version}</project.parent.version>
-    <!-- Dependency versions -->
-    <spring-cloud-dependencies.version>2023.0.0-M2</spring-cloud-dependencies.version>
-    <spring-boot-dependencies.version>3.2.0-RC1</spring-boot-dependencies.version>
+	<properties>
+		<project.parent.version>${project.version}</project.parent.version>
+		<!-- Dependency versions -->
+		<spring-cloud-dependencies.version>2022.0.4</spring-cloud-dependencies.version>
+		<spring-boot-dependencies.version>3.1.5</spring-boot-dependencies.version>
     <spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
     <zipkin-gcp.version>1.0.4</zipkin-gcp.version>
     <java-cfenv.version>2.5.0</java-cfenv.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,10 @@
 		<!-- Dependency versions -->
 		<spring-cloud-dependencies.version>2022.0.4</spring-cloud-dependencies.version>
 		<spring-boot-dependencies.version>3.1.5</spring-boot-dependencies.version>
-    <spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
-    <zipkin-gcp.version>1.0.4</zipkin-gcp.version>
-    <java-cfenv.version>2.5.0</java-cfenv.version>
-    <micrometer-tracing.verison>1.1.6</micrometer-tracing.verison>
+		<spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
+		<zipkin-gcp.version>1.0.4</zipkin-gcp.version>
+		<java-cfenv.version>2.5.0</java-cfenv.version>
+		<micrometer-tracing.verison>1.1.6</micrometer-tracing.verison>
 
 		<!-- Plugin versions -->
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfiguration.java
@@ -49,11 +49,14 @@ import org.springframework.util.Assert;
 public class PubSubHealthIndicatorAutoConfiguration
     extends CompositeHealthContributorConfiguration<PubSubHealthIndicator, PubSubTemplate> {
 
-  private PubSubHealthIndicatorProperties pubSubHealthProperties;
-
   public PubSubHealthIndicatorAutoConfiguration(
       PubSubHealthIndicatorProperties pubSubHealthProperties) {
-    this.pubSubHealthProperties = pubSubHealthProperties;
+    super(pubSubTemplate ->
+        new PubSubHealthIndicator(
+            pubSubTemplate,
+            pubSubHealthProperties.getSubscription(),
+            pubSubHealthProperties.getTimeoutMillis(),
+            pubSubHealthProperties.isAcknowledgeMessages()));
   }
 
   @Bean
@@ -61,14 +64,5 @@ public class PubSubHealthIndicatorAutoConfiguration
   public HealthContributor pubSubHealthContributor(Map<String, PubSubTemplate> pubSubTemplates) {
     Assert.notNull(pubSubTemplates, "pubSubTemplates must be provided");
     return createContributor(pubSubTemplates);
-  }
-
-  @Override
-  protected PubSubHealthIndicator createIndicator(PubSubTemplate pubSubTemplate) {
-    return new PubSubHealthIndicator(
-            pubSubTemplate,
-            this.pubSubHealthProperties.getSubscription(),
-            this.pubSubHealthProperties.getTimeoutMillis(),
-            this.pubSubHealthProperties.isAcknowledgeMessages());
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubSubscriptionHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubSubscriptionHealthIndicatorAutoConfiguration.java
@@ -22,7 +22,6 @@ import com.google.cloud.monitoring.v3.MetricServiceClient;
 import com.google.cloud.spring.autoconfigure.pubsub.GcpPubSubAutoConfiguration;
 import com.google.cloud.spring.autoconfigure.pubsub.GcpPubSubProperties;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
-import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 import com.google.cloud.spring.pubsub.core.health.HealthTrackerRegistry;
 import com.google.cloud.spring.pubsub.core.health.HealthTrackerRegistryImpl;
 import java.io.IOException;
@@ -46,13 +45,14 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 @ConditionalOnClass({HealthIndicator.class, MetricServiceClient.class})
 @ConditionalOnEnabledHealthIndicator("pubsub-subscriber")
 @ConditionalOnProperty({
-  "spring.cloud.gcp.pubsub.health.lagThreshold",
-  "spring.cloud.gcp.pubsub.health.backlogThreshold"
+    "spring.cloud.gcp.pubsub.health.lagThreshold",
+    "spring.cloud.gcp.pubsub.health.backlogThreshold"
 })
 @AutoConfigureBefore(GcpPubSubAutoConfiguration.class)
 @EnableConfigurationProperties(GcpPubSubProperties.class)
 public class PubSubSubscriptionHealthIndicatorAutoConfiguration
-    extends CompositeHealthContributorConfiguration<PubSubHealthIndicator, PubSubTemplate> {
+    extends
+    CompositeHealthContributorConfiguration<PubSubSubscriptionHealthIndicator, HealthTrackerRegistry> {
 
   private final GcpPubSubProperties gcpPubSubProperties;
 
@@ -60,6 +60,7 @@ public class PubSubSubscriptionHealthIndicatorAutoConfiguration
 
   public PubSubSubscriptionHealthIndicatorAutoConfiguration(
       GcpPubSubProperties gcpPubSubProperties, GcpProjectIdProvider projectIdProvider) {
+    super(PubSubSubscriptionHealthIndicator::new);
     this.projectId =
         (gcpPubSubProperties.getProjectId() != null)
             ? gcpPubSubProperties.getProjectId()

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/health/SpannerHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/spanner/health/SpannerHealthIndicatorAutoConfiguration.java
@@ -35,7 +35,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.util.Assert;
 
 /**
- * {@link HealthContributorAutoConfiguration Auto-configuration} for {@link SpannerHealthIndicator}.
+ * {@link HealthContributorAutoConfiguration Auto-configuration} for
+ * {@link SpannerHealthIndicator}.
  *
  * @since 2.0.6
  */
@@ -49,11 +50,12 @@ import org.springframework.util.Assert;
 public class SpannerHealthIndicatorAutoConfiguration
     extends CompositeHealthContributorConfiguration<SpannerHealthIndicator, SpannerTemplate> {
 
-  private SpannerHealthIndicatorProperties spannerHealthProperties;
-
   public SpannerHealthIndicatorAutoConfiguration(
       SpannerHealthIndicatorProperties spannerHealthProperties) {
-    this.spannerHealthProperties = spannerHealthProperties;
+    super(spannerTemplate ->
+        new SpannerHealthIndicator(
+            spannerTemplate,
+            spannerHealthProperties.getQuery()));
   }
 
   @Bean
@@ -61,10 +63,5 @@ public class SpannerHealthIndicatorAutoConfiguration
   public HealthContributor spannerHealthContributor(Map<String, SpannerTemplate> spannerTemplates) {
     Assert.notNull(spannerTemplates, "SpannerTemplates must be provided");
     return createContributor(spannerTemplates);
-  }
-
-  @Override
-  protected SpannerHealthIndicator createIndicator(SpannerTemplate spannerTemplate) {
-    return new SpannerHealthIndicator(spannerTemplate, this.spannerHealthProperties.getQuery());
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubSubscriptionHealthIndicatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubSubscriptionHealthIndicatorAutoConfigurationTests.java
@@ -21,9 +21,9 @@ import static org.mockito.Mockito.mock;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
 import com.google.cloud.spring.autoconfigure.pubsub.GcpPubSubAutoConfiguration;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
-import com.google.cloud.spring.pubsub.core.health.HealthTrackerRegistry;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -40,7 +40,8 @@ class PubSubSubscriptionHealthIndicatorAutoConfigurationTests {
                   PubSubSubscriptionHealthIndicatorAutoConfiguration.class,
                   GcpPubSubAutoConfiguration.class))
           .withBean(GcpProjectIdProvider.class, () -> () -> "fake project")
-          .withBean(CredentialsProvider.class, () -> () -> mock(Credentials.class));
+          .withBean(CredentialsProvider.class, () -> () -> mock(Credentials.class))
+          .withBean(MetricServiceClient.class, () -> mock(MetricServiceClient.class));
 
   @Test
   void healthIndicatorPresent_defaults() {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubSubscriptionHealthIndicatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubSubscriptionHealthIndicatorAutoConfigurationTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.pubsub.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.cloud.spring.autoconfigure.pubsub.GcpPubSubAutoConfiguration;
+import com.google.cloud.spring.core.GcpProjectIdProvider;
+import com.google.cloud.spring.pubsub.core.health.HealthTrackerRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Tests for Pub/Sub Health Indicator autoconfiguration.
+ */
+class PubSubSubscriptionHealthIndicatorAutoConfigurationTests {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withConfiguration(
+              AutoConfigurations.of(
+                  PubSubSubscriptionHealthIndicatorAutoConfiguration.class,
+                  GcpPubSubAutoConfiguration.class))
+          .withBean(GcpProjectIdProvider.class, () -> () -> "fake project")
+          .withBean(CredentialsProvider.class, () -> () -> mock(Credentials.class));
+
+  @Test
+  void healthIndicatorPresent_defaults() {
+    this.contextRunner
+        .withPropertyValues(
+            "spring.cloud.gcp.pubsub.health.lagThreshold=1",
+            "spring.cloud.gcp.pubsub.health.backlogThreshold=1")
+        .run(ctx -> assertThat(ctx).hasSingleBean(PubSubSubscriptionHealthIndicator.class));
+  }
+
+  @Test
+  void healthIndicatorNotPresent_whenDisabled() {
+    this.contextRunner
+        .withPropertyValues(
+            "management.health.pubsub-subscriber.enabled:false",
+            "spring.cloud.gcp.pubsub.health.lagThreshold=1",
+            "spring.cloud.gcp.pubsub.health.backlogThreshold=1")
+        .run(ctx -> assertThat(ctx).doesNotHaveBean(PubSubSubscriptionHealthIndicator.class));
+  }
+
+  @Test
+  void healthIndicatorNotPresent_whenMissingLagThreshold() {
+    this.contextRunner
+        .withPropertyValues(
+            "spring.cloud.gcp.pubsub.health.backlogThreshold=1")
+        .run(ctx -> assertThat(ctx).doesNotHaveBean(PubSubSubscriptionHealthIndicator.class));
+  }
+
+  @Test
+  void healthIndicatorNotPresent_whenMissingBacklogThreshold() {
+    this.contextRunner
+        .withPropertyValues(
+            "spring.cloud.gcp.pubsub.health.lagThreshold=1")
+        .run(ctx -> assertThat(ctx).doesNotHaveBean(PubSubSubscriptionHealthIndicator.class));
+  }
+}

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/GqlDatastoreQuery.java
@@ -381,7 +381,7 @@ public class GqlDatastoreQuery<T> extends AbstractDatastoreQuery<T> {
 
       this.noLimitQuery = this.finalGql;
       Pageable pageable = paramAccessor.getPageable();
-      if (!pageable.equals(Pageable.unpaged())) {
+      if (pageable.isPaged()) {
         this.finalGql += LIMIT_CLAUSE;
         this.tagsOrdered.add(LIMIT_TAG_NAME);
         this.limitPosition = this.params.size();

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerCompositeKeyProperty.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerCompositeKeyProperty.java
@@ -243,6 +243,10 @@ public class SpannerCompositeKeyProperty implements SpannerPersistentProperty {
     return false;
   }
 
+  public boolean isReadable() {
+    return true;
+  }
+
   @Override
   public boolean isWritable() {
     return false;


### PR DESCRIPTION
These updates introduce source changes that will be required for Spring Boot 3.2.x compatibility, but do not update Spring Cloud GCP to use Spring Boot 3.2.x as Spring Cloud 2022 is not compatible and Spring Cloud 2023 has not yet been GA released.

Attempting to update to Spring Boot 3.2.x will cause a compatibility verification error if using any module requiring Spring Cloud 2022.

Related issue: #2379