### PR TITLE
chore(test): add cleanup to script to initialize database.

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-r2dbc-sample/src/main/resources/schema.sql
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-r2dbc-sample/src/main/resources/schema.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS users;
+
 CREATE TABLE users (
   email VARCHAR(255),
   first_name VARCHAR(255),


### PR DESCRIPTION
Try to cleanup database before starting test.

According to doc for [`ResourceDatabasePopulator`](https://github.com/spring-projects/spring-framework/blob/cb60f745566767554b620df5663a9e1055f8d26d/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/init/ResourceDatabasePopulator.java#L87-L92), looks like it can also used to clean up database before initialize. 
