### PR TITLE
ci: remove parallel integration tests

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -27,13 +27,25 @@ jobs:
       fail-fast: false
       matrix:
         it:
+          - bigquery
+          - cloudsql
           - config
+          - datastore
+          - firestore
+          - kms
+          - kotlin
+          - logging
+          - metrics
+          - multisample
           - pubsub
           - pubsub-bus
           - pubsub-docs
           - pubsub-emulator
           - pubsub-integration
           - secretmanager
+          - spanner
+          - storage
+          - trace
           - vision
     steps:
       - name: Get current date
@@ -75,6 +87,8 @@ jobs:
       # Unlike for the other integrationTest job, we don't block here as these run in parallel.
       - name: Integration Tests
         id: intTest
+        env:
+          DB_PASSWORD: ${{ secrets.SPRING_CLOUD_GCP_CI_DB_ROOT_PASSWORD }}
         run: |
           ./mvnw \
             --batch-mode \
@@ -88,106 +102,10 @@ jobs:
             --define "spring.r2dbc.password=${DB_PASSWORD}" \
             --define it.${{ matrix.it }}=true \
             verify
-        env:
-          DB_PASSWORD: ${{ secrets.SPRING_CLOUD_GCP_CI_DB_ROOT_PASSWORD }}
       - name: Aggregate Report
         run: |
           ./mvnw \
             --batch-mode \
-            --define aggregate=true \
-            surefire-report:failsafe-report-only
-      - name: Archive logs
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v2
-        with:
-          name: Integration Test Logs - ${{ matrix.it}}
-          path: |
-            **/target/failsafe-reports/*
-            **/target/site
-  integrationTests:
-    if: |
-      github.actor != 'dependabot[bot]' && ((
-        github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
-      ) || (github.event_name != 'pull_request'))
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        it:
-          - bigquery
-          - cloudsql
-          - datastore
-          - firestore
-          - kms
-          - logging
-          - metrics
-          - multisample
-          - kotlin
-          - spanner
-          - storage
-          - trace
-    steps:
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v2
-      - name: Setup Java 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 17
-      - name: Set Up Authentication
-        uses: google-github-actions/auth@v1
-        with:
-          credentials_json: ${{ secrets.SPRING_CLOUD_GCP_CI_SA_KEY }}
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
-        with:
-          version: latest
-          project_id: spring-cloud-gcp-ci
-          export_default_credentials: true
-      - name: Mvn install # Need this when the directory/pom structure changes
-        id: install
-        run: |
-          ./mvnw \
-            --batch-mode \
-            --no-transfer-progress \
-            --threads 1.5C \
-            --define maven.test.skip=true \
-            --define maven.javadoc.skip=true \
-            --define org.slf4j.simpleLogger.showDateTime=true \
-            --define org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS \
-            install
-      - name: Wait our turn for running integration tests
-        uses: softprops/turnstyle@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          continue-after-seconds: 1200 # 30 min
-          same-branch-only: false
-      - name: Integration Tests
-        id: intTest
-        run: |
-          ./mvnw \
-            --batch-mode \
-            --no-transfer-progress \
-            --activate-profiles spring-cloud-gcp-ci-it \
-            --define maven.javadoc.skip=true \
-            --define skip.surefire.tests=true \
-            --define org.slf4j.simpleLogger.showDateTime=true \
-            --define org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS \
-            --define "spring.datasource.password=${DB_PASSWORD}" \
-            --define "spring.r2dbc.password=${DB_PASSWORD}" \
-            --define it.${{ matrix.it }}=true \
-            verify
-        env:
-          DB_PASSWORD: ${{ secrets.SPRING_CLOUD_GCP_CI_DB_ROOT_PASSWORD }}
-      - name: Aggregate Report
-        run: |
-          ./mvnw \
-            --batch-mode \
-            --no-transfer-progress \
             --define aggregate=true \
             surefire-report:failsafe-report-only
       - name: Archive logs


### PR DESCRIPTION
The parallelizing github action being used (softprops/turnstyle@v1) is no longer supported, resulting in unnecessary maximum delays and then all the tests being run in parallel anyhow.

This PR removes the unnecessary delay and unsupported github action.