### PR TITLE
deps: revert to spring-cloud-build 4.0.5 to fix docs generation

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.1.0</version>
+		<version>4.0.5</version>
 		<relativePath/>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
This dependency is not used in the Spring Cloud GCP artifacts. It is used for doc generation only.