### PR TITLE
ci: enable updateDocs PR check

### DIFF
--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -1,6 +1,7 @@
 name: Update Docs
 
 on:
+  pull_request:
   push:
     branches:
     - main

--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -63,5 +63,5 @@ jobs:
         elif [[ -n "${{ github.event.inputs.committish }}" ]] && [[ "${{ github.event.inputs.committish }}" != "main" ]] ; then
             ./docs/src/main/asciidoc/ghpages.sh --version ${{ github.event.inputs.committish }} --destination . --build
         else
-          ./docs/src/main/asciidoc/ghpages.sh --build
+          ./mvnw install -P docs -P '!CI' -pl docs -DskipTests # Simplified PR check
         fi

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.1.0</version>
+		<version>4.0.5</version>
 		<relativePath/>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
+ cherry-pick spring-cloud-build dependency fix.

This PR triggers this branch of the updateDocs CI check: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/main/.github/workflows/updateDocs.yaml#L65

Which when run locally shows no updates occur to the production docs.