### PR TITLE
fix: config release-please to stop at original 5.0.0 merge commit

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,6 +1,7 @@
 primaryBranch: main
 releaseType: java-yoshi
 handleGHRelease: true
+last-release-sha: 103846dbe135790a59788a5ae3bafe56ededba3e
 extraFiles: [
   "README.adoc",
   "spring-cloud-generator/scripts/resources/googleapis_modification_string.txt"


### PR DESCRIPTION
See also https://github.com/googleapis/release-please/blob/611db3d5628d1ff4cd7c40259894daf0c13f8e17/docs/manifest-releaser.md?plain=1#L134-L147

This PR is intended to resolve the incorrect release-please 6.0.0 PR: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/2467