### PR TITLE
fix(3.x): delegate to all parent logging options

### DIFF
--- a/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/LoggingAppender.java
+++ b/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/LoggingAppender.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spring.logging;
 
-import com.google.auth.Credentials;
 import com.google.cloud.logging.LoggingOptions;
 import com.google.cloud.spring.core.UserAgentHeaderProvider;
 
@@ -38,13 +37,7 @@ public class LoggingAppender extends com.google.cloud.logging.logback.LoggingApp
   protected LoggingOptions getLoggingOptions() {
 
     if (loggingOptions == null) {
-      LoggingOptions.Builder loggingOptionsBuilder = LoggingOptions.newBuilder();
-
-      // only credentials are set in the options of the parent class
-      Credentials credentials = super.getLoggingOptions().getCredentials();
-      if (credentials != null) {
-        loggingOptionsBuilder.setCredentials(credentials);
-      }
+      LoggingOptions.Builder loggingOptionsBuilder = super.getLoggingOptions().toBuilder();
 
       // set User-Agent
       loggingOptionsBuilder.setHeaderProvider(new UserAgentHeaderProvider(this.getClass()));

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/LoggingAppenderTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/LoggingAppenderTests.java
@@ -38,4 +38,17 @@ class LoggingAppenderTests {
         .contains("spring-cloud-gcp-logging")
         .contains("Spring");
   }
+
+  @Test
+  void testSetLogDestinationProjectId() {
+    LoggingAppender loggingAppender = new LoggingAppender();
+    loggingAppender.setCredentialsFile("src/test/resources/fake-project-key.json");
+    loggingAppender.setLogDestinationProjectId("my-log-destination-project");
+    assertThat(loggingAppender.getLoggingOptions().getCredentials()).isNotNull();
+    assertThat(loggingAppender.getLoggingOptions().getProjectId()).isEqualTo("my-log-destination-project");
+    assertThat(loggingAppender.getLoggingOptions().getUserAgent())
+        .isNotNull()
+        .contains("spring-cloud-gcp-logging")
+        .contains("Spring");
+  }
 }


### PR DESCRIPTION
Support setting logDestinationProjectId.

Backport of #2500.
Fixes: #2496.