### PR TITLE
fix: include schema name in table name

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/admin/SpannerDatabaseAdminTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/admin/SpannerDatabaseAdminTemplate.java
@@ -25,7 +25,6 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerDataException;
-import com.google.common.base.Strings;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/admin/SpannerDatabaseAdminTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/admin/SpannerDatabaseAdminTemplate.java
@@ -20,13 +20,16 @@ import com.google.cloud.spanner.Database;
 import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerDataException;
+import com.google.common.base.Strings;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
@@ -40,6 +43,8 @@ import org.springframework.util.Assert;
  */
 public class SpannerDatabaseAdminTemplate {
 
+  private static final String TABLE_SCHEMA_COL_NAME = "table_schema";
+  
   private static final String TABLE_NAME_COL_NAME = "table_name";
 
   private static final String PARENT_TABLE_NAME_COL_NAME = "parent_table_name";
@@ -47,6 +52,8 @@ public class SpannerDatabaseAdminTemplate {
   private static final Statement TABLE_AND_PARENT_QUERY =
       Statement.of(
           "SELECT t."
+              + TABLE_SCHEMA_COL_NAME
+              + ", t."
               + TABLE_NAME_COL_NAME
               + ", t."
               + PARENT_TABLE_NAME_COL_NAME
@@ -151,13 +158,35 @@ public class SpannerDatabaseAdminTemplate {
       while (results.next()) {
         Struct row = results.getCurrentRowAsStruct();
         relationships.put(
-            row.getString(TABLE_NAME_COL_NAME),
+            getQualifiedTableName(
+                row.getString(TABLE_SCHEMA_COL_NAME),
+                row.getString(TABLE_NAME_COL_NAME)),
             row.isNull(PARENT_TABLE_NAME_COL_NAME)
                 ? null
-                : row.getString(PARENT_TABLE_NAME_COL_NAME));
+                : getQualifiedTableName(
+                    // Parent/child tables must be in the same schema, and so there is no separate
+                    // schema name column for the parent table.
+                    row.getString(TABLE_SCHEMA_COL_NAME),
+                    row.getString(PARENT_TABLE_NAME_COL_NAME)));
       }
       return relationships;
     }
+  }
+  
+  private String getQualifiedTableName(String schema, String table) {
+    if (schema == null || Objects.equals(schema, getDefaultSchemaName())) {
+      return table;
+    }
+    return schema + "." + table;
+  }
+  
+  private String getDefaultSchemaName() {
+    // TODO: Get the default schema directly from the dialect when this is supported in the Spanner
+    //       Java client.
+    if (databaseClientProvider.get().getDialect() == Dialect.POSTGRESQL) {
+      return "public";
+    }
+    return "";
   }
 
   /**


### PR DESCRIPTION
Spanner databases contain both system schemas and a user schema. The current Spring Data Spanner implementation assumes that all table names in a database are unique, but this is not true if a user creates a table that is equal to the name of a system table in one of the system schemas.

Additionally, Spanner could introduce support for user-defined named schemas in the future. This would increase the probability that a single database contains multiple tables with the same name, but in different schemas.

This change fixes any problems that might occur if a database contains multiple tables with the same name in different schemas. The change does not attempt to implement full support for using multiple different schemas with Spring Cloud Data Spanner.