### PR TITLE
chore: Removing spring-cloud-previews module for current release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -688,7 +688,6 @@
 				<module>spring-cloud-gcp-security-firebase</module>
 				<module>spring-cloud-gcp-vision</module>
 				<module>spring-cloud-gcp-kms</module>
-				<module>spring-cloud-previews</module>
 				<module>spring-cloud-spanner-spring-data-r2dbc</module>
 			</modules>
 			<build>


### PR DESCRIPTION
The [generateAutoConfigs](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/main/.github/workflows/generateAutoConfigs.yaml) workflow is currently failing and needs more time to get resolved, hence excluding this module from current release.