### PR TITLE
chore: reenable tests with spring boot upgraded to 3.2.2.

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -28,9 +28,9 @@ jobs:
           - bigquery-sample
           - bigquery
           - core
-          #- data-firestore ## https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/2455
+          - data-firestore
           - data-firestore-sample
-          #- datastore ## https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/2455
+          - datastore
           - datastore-basic-sample
           - kms
           - kms-sample


### PR DESCRIPTION
Try reenable native tests.
fixes #2455

The failed datastore-basic-sample is related a known issue from spring-data-commons

Fix is scheduled to be released in v3.2.3