### PR TITLE
fix(deps): update cloud-sql-socket-factory.version to v1.16.0

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/CloudSqlEnvironmentPostProcessor.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/CloudSqlEnvironmentPostProcessor.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spring.autoconfigure.sql;
 
+import com.google.cloud.sql.ConnectorRegistry;
 import com.google.cloud.sql.core.CoreSocketFactory;
 import java.util.HashMap;
 import java.util.Map;
@@ -83,7 +84,7 @@ public class CloudSqlEnvironmentPostProcessor implements EnvironmentPostProcesso
       CredentialsPropertiesSetter.setCredentials(sqlProperties, propertiesRetriever.getGcpProperties());
 
       // support usage metrics
-      CoreSocketFactory.setApplicationName(
+      ConnectorRegistry.addArtifactId(
           "spring-cloud-gcp-sql/" + this.getClass().getPackage().getImplementationVersion());
     }
   }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/CloudSqlEnvironmentPostProcessor.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/CloudSqlEnvironmentPostProcessor.java
@@ -17,7 +17,6 @@
 package com.google.cloud.spring.autoconfigure.sql;
 
 import com.google.cloud.sql.ConnectorRegistry;
-import com.google.cloud.sql.core.CoreSocketFactory;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.logging.Log;

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -35,7 +35,7 @@
 
 	<properties>
 		<gcp-libraries-bom.version>26.33.0</gcp-libraries-bom.version>
-		<cloud-sql-socket-factory.version>1.14.1</cloud-sql-socket-factory.version>
+		<cloud-sql-socket-factory.version>1.16.0</cloud-sql-socket-factory.version>
 		<r2dbc-postgres-driver.version>1.0.4.RELEASE</r2dbc-postgres-driver.version>
 		<cloud-spanner-r2dbc.version>1.3.0</cloud-spanner-r2dbc.version>
 	</properties>


### PR DESCRIPTION
In order to use the new version `1.16.0` it's required to use the new method to set artifact ID.

Related to #2503
