### PR TITLE
chore: Update memorystore doc

### DIFF
--- a/docs/src/main/asciidoc/memorystore.adoc
+++ b/docs/src/main/asciidoc/memorystore.adoc
@@ -3,7 +3,7 @@
 === Spring Caching
 
 https://cloud.google.com/memorystore/[Cloud Memorystore for Redis] provides a fully managed in-memory data store service.
-Cloud Memorystore is compatible with the Redis protocol, allowing easy integration with https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-caching.html[Spring Caching].
+Cloud Memorystore is compatible with the Redis protocol, allowing easy integration with https://docs.spring.io/spring-boot/docs/3.2.x/reference/html/io.html#io.caching[Spring Caching].
 
 All you have to do is create a Cloud Memorystore instance and use its IP address in `application.properties` file as `spring.redis.host` property value.
 Everything else is exactly the same as setting up redis-backed Spring caching.

--- a/docs/src/main/asciidoc/memorystore.adoc
+++ b/docs/src/main/asciidoc/memorystore.adoc
@@ -26,6 +26,7 @@ In short, the following dependencies are needed:
     <artifactId>spring-boot-starter-data-redis</artifactId>
 </dependency>
 ----
+For reactive applications, you can also use `spring-boot-starter-data-redis-reactive` instead.
 
 And then you can use `org.springframework.cache.annotation.Cacheable` annotation for methods you'd like to be cached.
 [source,java]

--- a/docs/src/main/asciidoc/memorystore.adoc
+++ b/docs/src/main/asciidoc/memorystore.adoc
@@ -5,7 +5,7 @@
 https://cloud.google.com/memorystore/[Cloud Memorystore for Redis] provides a fully managed in-memory data store service.
 Cloud Memorystore is compatible with the Redis protocol, allowing easy integration with https://docs.spring.io/spring-boot/docs/3.2.x/reference/html/io.html#io.caching[Spring Caching].
 
-All you have to do is create a Cloud Memorystore instance and use its IP address in `application.properties` file as `spring.redis.host` property value.
+All you have to do is create a Cloud Memorystore instance and use its IP address in `application.properties` file as `spring.data.redis.host` property value. (Read more about this property in https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#appendix.application-properties.data[Spring Boot documentation]. )
 Everything else is exactly the same as setting up redis-backed Spring caching.
 
 [NOTE]


### PR DESCRIPTION
Closes #2661 

Needs to backport to 4.x and 3.x with adjustments.

The newly referenced reactive starter: `spring-boot-starter-data-redis-reactive` ([source](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-starters/spring-boot-starter-data-redis-reactive/build.gradle)) includes `reactor-core` in addition to `spring-boot-starter-data-redis`.