### PR TITLE
chore(codegen): adopt hermetic build configs and simplify logic

### DIFF
--- a/spring-cloud-generator/scripts/generate-library-list.sh
+++ b/spring-cloud-generator/scripts/generate-library-list.sh
@@ -18,21 +18,10 @@ if [[ -z "$commitish" ]]; then
   exit 1
 fi
 
-# download the monorepo, need to loop through metadata there
-git clone https://github.com/googleapis/google-cloud-java.git
-
-# switch to the specified release commitish
-cd ./google-cloud-java
-git checkout $commitish
-
-# read googleapis committish used in hermetic build
-googleapis_committish=$(yq -r ".googleapis_commitish" generation_config.yaml)
-echo "googleapis_committish: ${googleapis_committish}"
-
 cd ${SPRING_GENERATOR_DIR}
 # start file, always override is present
 filename=${SPRING_GENERATOR_DIR}/scripts/resources/library_list.txt
-echo "# api_shortname, googleapis-folder, distribution_name:version, googleapis_committish, monorepo_folder" > "$filename"
+echo "# api_shortname, googleapis-folder, distribution_name:version, monorepo_folder" > "$filename"
 
 # loop through folders
 count=0
@@ -72,10 +61,7 @@ for d in ./google-cloud-java/*java-*/; do
   proto_paths_stable=$(echo "$library" | yq -r '.GAPICs[] | select(.proto_path | test("/v[0-9]+$")) | .proto_path')
   proto_paths_latest=$(echo "$proto_paths_stable" | sort -d -r | head -n 1)
 
-  echo "$api_shortname, $proto_paths_latest, $distribution_name, $googleapis_committish, $monorepo_folder" >> $filename
+  echo "$api_shortname, $proto_paths_latest, $distribution_name, $monorepo_folder" >> $filename
   count=$((count+1))
 done
 echo "Total in-scope client libraries: $count"
-
-# clean up
-rm -rf google-cloud-java/

--- a/spring-cloud-generator/scripts/generate-steps.sh
+++ b/spring-cloud-generator/scripts/generate-steps.sh
@@ -27,8 +27,9 @@ function compute_monorepo_version() {
 }
 
 # Generate list of in-scope libraries to use (as static data source to generate modules from)
-# Uses heuristic approach to parse googleapis commitish and other metadata from google-cloud-java
-# See generate-library-list.sh and https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/1390 for details
+# Get googleapis committish used for specified release and assign to global GOOGLEAPIS_COMMITTISH.
+# For each library in google-cloud-java, parse information from ".repo-metadata.json"
+# and hermetic build config file: generation_config.yaml
 # Assumes current working directory is spring-cloud-generator
 #
 # $1 - Monorepo version tag (or committish)

--- a/spring-cloud-generator/scripts/generate-steps.sh
+++ b/spring-cloud-generator/scripts/generate-steps.sh
@@ -34,7 +34,14 @@ function compute_monorepo_version() {
 # $1 - Monorepo version tag (or committish)
 function generate_libraries_list(){
   monorepo_commitish=$1
+  git clone https://github.com/googleapis/google-cloud-java.git
+  pushd google-cloud-java || { echo "Failure: google-cloud-java folder does not exists."; exit 1; }
+  # read googleapis committish used in hermetic build
+  GOOGLEAPIS_COMMITTISH=$(yq -r ".googleapis_commitish" generation_config.yaml)
+  popd || { echo "Failure in popd."; exit 1; }
+
   bash scripts/generate-library-list.sh -c $monorepo_commitish
+  rm -rf google-cloud-java/
 }
 
 # When bazel prepare, build, or post-processing step fails, stores the captured stdout and stderr to a file
@@ -49,10 +56,15 @@ function save_error_info () {
   cp tmp-output ${parent_directory}/failed-library-generations/${step_identifier}
 }
 
-# Clone googleapis repository, and makes bazel workspace modifications required for generation
+# Clone googleapis repository, checkout commitish
+# and makes bazel workspace modifications required for generation
+#
+# $1 - googleapis commitish
 function setup_googleapis(){
+  googleapis_commitish=$1
   git clone https://github.com/googleapis/googleapis.git
   cd googleapis
+  git checkout ${googleapis_commitish}
   modify_workspace_file "WORKSPACE" "../../spring-cloud-generator" "../scripts/resources/googleapis_modification_string.txt"
   # In repository_rules.bzl, add switch for new spring rule
   JAVA_SPRING_SWITCH="    rules[\\\"java_gapic_spring_library\\\"] = _switch(\n        java and grpc and gapic,\n        \\\"\@spring_cloud_generator\/\/:java_gapic_spring.bzl\\\",\n    )"
@@ -79,13 +91,11 @@ function modify_workspace_file(){
   perl -pi -e "s{(^_gapic_generator_java_version[^\n]*)}{\$1\n$(cat ${path_to_modification_string})}" ${path_to_workspace}
 }
 
-# For individual library, checkout versioned protos folder and set up bazel rules
+# For individual library, set up bazel rules
 #
-# $1 - googleapis commitish
-# $2 - googleapis folder (e.g. google/cloud/accessapproval/v1)
+# $1 - googleapis folder (e.g. google/cloud/accessapproval/v1)
 function prepare_bazel_build(){
-  googleapis_commitish=$1
-  googleapis_folder=$2
+  googleapis_folder=$1
 
   # If googleapis folder does not exist, exit
   if [ ! -d "$(pwd)/${googleapis_folder}" ]
@@ -93,8 +103,6 @@ function prepare_bazel_build(){
     echo "Directory $(pwd)/${googleapis_folder} does not exist."
     exit
   fi
-
-  git checkout ${googleapis_commitish} -- ${googleapis_folder}
 
   # Modify BUILD.bazel file for library
   # Additional rule to load
@@ -184,16 +192,14 @@ function add_line_to_readme() {
 # $3 - parent (spring-cloud-gcp-starters) version  (e.g. 4.5.0)
 # $4 - googleapis folder (e.g. google/cloud/accessapproval/v1)
 # $5 - monorepo folder (e.g. java-accessapproval)
-# $6 - googleapis commitish
-# $7 - monorepo commitish (e.g. v1.13.0)
+# $6 - monorepo commitish (e.g. v1.13.0)
 function postprocess_library() {
   client_lib_artifactid=$1
   client_lib_groupid=$2
   parent_version=$3
   googleapis_folder=$4
   monorepo_folder=$5
-  googleapis_commitish=$6
-  monorepo_commitish=$7
+  monorepo_commitish=$6
   starter_artifactid="${client_lib_artifactid}-spring-starter"
 
   # sometimes the rule name doesnt have the same prefix as $client_lib_name

--- a/spring-cloud-generator/scripts/generate-steps.sh
+++ b/spring-cloud-generator/scripts/generate-steps.sh
@@ -35,7 +35,7 @@ function compute_monorepo_version() {
 # $1 - Monorepo version tag (or committish)
 function generate_libraries_list(){
   monorepo_commitish=$1
-  git clone https://github.com/googleapis/google-cloud-java.git
+  git clone --depth=1 https://github.com/googleapis/google-cloud-java.git
   pushd google-cloud-java || { echo "Failure: google-cloud-java folder does not exists."; exit 1; }
   # read googleapis committish used in hermetic build
   GOOGLEAPIS_COMMITTISH=$(yq -r ".googleapis_commitish" generation_config.yaml)
@@ -63,9 +63,10 @@ function save_error_info () {
 # $1 - googleapis commitish
 function setup_googleapis(){
   googleapis_commitish=$1
-  git clone https://github.com/googleapis/googleapis.git
+  git clone --depth=1 https://github.com/googleapis/googleapis.git
   cd googleapis
-  git checkout ${googleapis_commitish}
+  git fetch origin "${googleapis_commitish}"
+  git checkout "${googleapis_commitish}"
   modify_workspace_file "WORKSPACE" "../../spring-cloud-generator" "../scripts/resources/googleapis_modification_string.txt"
   # In repository_rules.bzl, add switch for new spring rule
   JAVA_SPRING_SWITCH="    rules[\\\"java_gapic_spring_library\\\"] = _switch(\n        java and grpc and gapic,\n        \\\"\@spring_cloud_generator\/\/:java_gapic_spring.bzl\\\",\n    )"

--- a/spring-cloud-generator/scripts/generate.sh
+++ b/spring-cloud-generator/scripts/generate.sh
@@ -41,6 +41,7 @@ fi
 
 # If not provided, generate and set library list path variable
 # find googleapis commitish from monrepo tag
+GOOGLEAPIS_COMMITTISH=""
 if [[ -z "$LIBRARY_LIST_PATH" ]]; then
   echo "No LIBRARY_LIST_PATH override provided, generating for MONOREPO_TAG: ${MONOREPO_TAG}"
   cd ${SPRING_GENERATOR_DIR}


### PR DESCRIPTION
follow up to #2726. This pr tries to simplify logic now that googleapis commitish is consistent for all mono repo, it is not a blocker for current release cycle. 

- replace old logic to parse proto path from "OwlBot.yaml" file, to utilize the new "generation_config.yaml" and parse GAPIC.proto_path. Keep current logic to only grab latest stable version for now.
  - This step is done inside the loop for each library directory, look for library config by `api_shortname`. This is sufficient for current selection (stable libs). But noted  `api_shortname` is not unique identifier for libraries in config. Need followup on this.
- remove logic to checkout versioned proto folders, and set googleapis_committish directly from config.
