### PR TITLE
feat: Spring Cloud AlloyDB integration

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         it:
+          - alloydb-sample
           - bigquery-sample
           - bigquery
           - core

--- a/.github/workflows/compatibilityCheck.yaml
+++ b/.github/workflows/compatibilityCheck.yaml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         it:
+          - alloydb
           - bigquery
           - cloudsql
           - config

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -27,6 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         it:
+          - alloydb
           - bigquery
           - cloudsql
           - config

--- a/docs/src/main/asciidoc/alloydb.adoc
+++ b/docs/src/main/asciidoc/alloydb.adoc
@@ -13,8 +13,8 @@ Maven and Gradle coordinates, using <<getting-started.adoc#bill-of-materials, Sp
 [source,xml]
 ----
 <dependency>
-<groupId>com.google.cloud</groupId>
-<artifactId>spring-cloud-gcp-starter-alloydb</artifactId>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>spring-cloud-gcp-starter-alloydb</artifactId>
 </dependency>
 ----
 
@@ -61,9 +61,9 @@ NOTE: If you provide your own `spring.datasource.url`, it will be ignored, unles
 
 ===== `DataSource` creation flow
 
-Spring Boot starter for Google AlloyDB registers a `AlloyDbEnvironmentPostProcessor` that provides a correctly formatted `spring.datasource.url` property to the environment based on the properties mentioned above.
+Spring Boot starter for Google AlloyDB registers an `AlloyDbEnvironmentPostProcessor` that provides a correctly formatted `spring.datasource.url` property to the environment based on the properties mentioned above.
 It also provides defaults for `spring.datasource.username` and `spring.datasource.driver-class-name`, which can be overridden.
-The starter also configures credentials for the JDBC connection based on the properties below.
+The starter also configures credentials for the JDBC connection based on the AlloyDB properties below.
 
 The user properties and the properties provided by the `AlloyDbEnvironmentPostProcessor` are then used by https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html[Spring Boot] to create the `DataSource`.
 You can select the type of connection pool (e.g., Tomcat, HikariCP, etc.) by https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-connect-to-production-database[adding their dependency to the classpath].
@@ -91,7 +91,7 @@ However, it doesn't compromise the security of the communication because the con
 | `spring.cloud.gcp.alloydb.database-name` | The name of the database to connect to. | Yes |
 | `spring.cloud.gcp.alloydb.instance-connection-uri` | The Google AlloyDB instance connection URI. | Yes |
 For example, `projects/PROJECT_ID/locations/REGION_ID/clusters/CLUSTER_ID/instances/INSTANCE_ID`.
-| `spring.cloud.gcp.alloydb.ip-type` | Specifies a preferred IP type for connecting to a AlloyDB instance. | No | `PRIVATE`
+| `spring.cloud.gcp.alloydb.ip-type` | Specifies a preferred IP type for connecting to a AlloyDB instance. (`PUBLIC`, `PRIVATE`, `PSC`) | No | `PRIVATE`
 | `spring.cloud.gcp.alloydb.enable-iam-auth` | Specifies whether to enable IAM database authentication. | No | `False`
 | `spring.cloud.gcp.alloydb.admin-service-endpoint` | An alternate AlloyDB API endpoint. | No |
 | `spring.cloud.gcp.alloydb.quota-project` | The project ID for quota and billing. | No |

--- a/docs/src/main/asciidoc/alloydb.adoc
+++ b/docs/src/main/asciidoc/alloydb.adoc
@@ -1,0 +1,147 @@
+[#alloydb]
+== AlloyDB
+
+Spring Framework on Google Cloud adds integrations with
+https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html[Spring JDBC], so you can run your PostgreSQL databases in https://cloud.google.com/alloydb[Google AlloyDB] using Spring JDBC.
+
+The AlloyDB support is provided by Spring Framework on Google Cloud in the form of a Spring Boot AlloyDB starter for PostgreSQL.
+The role of the starters is to read configuration from properties and assume default settings so that user experience connecting to PostgreSQL is as simple as possible.
+
+=== JDBC Support
+Maven and Gradle coordinates, using <<getting-started.adoc#bill-of-materials, Spring Framework on Google Cloud BOM>>:
+
+To use PostgreSQL:
+
+[source,xml]
+----
+<dependency>
+<groupId>com.google.cloud</groupId>
+<artifactId>spring-cloud-gcp-starter-alloydb</artifactId>
+</dependency>
+----
+
+[source,subs="normal"]
+----
+dependencies {
+    implementation("com.google.cloud:spring-cloud-gcp-starter-alloydb")
+}
+----
+
+==== Prerequisites
+
+In order to use the Spring Boot Starters for Google AlloyDB, the Google AlloyDB API must be enabled in your Google Cloud project.
+
+To do that, go to the https://console.cloud.google.com/apis/library[API library page] of the Google Cloud Console, search for "AlloyDB API" and enable the option that is called "AlloyDB API" .
+
+
+==== Spring Boot Starter for Google AlloyDB
+
+The Spring Boot Starters for Google AlloyDB provide an autoconfigured https://docs.oracle.com/javase/7/docs/api/javax/sql/DataSource.html[`DataSource`] object.
+Coupled with Spring JDBC, it provides a
+https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html#jdbc-JdbcTemplate[`JdbcTemplate`] object bean that allows for operations such as querying and modifying a database.
+
+[source,java]
+----
+public List<Map<String, Object>> listUsers() {
+    return jdbcTemplate.queryForList("SELECT * FROM user;");
+}
+----
+
+You can rely on
+https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-connect-to-production-database[Spring Boot data source autoconfiguration] to configure a `DataSource` bean.
+In other words, properties like the SQL username, `spring.datasource.username`, and password, `spring.datasource.password` can be used.
+There is also some configuration specific to Google AlloyDB (see "AlloyDB Configuration Properties" section below).
+
+|===
+| Property name | Description | Required | Default value
+| `spring.datasource.username` | Database username | No | MySQL: `root`; PostgreSQL: `postgres`
+| `spring.datasource.password` | Database password | No | `null`
+| `spring.datasource.driver-class-name` | JDBC driver to use. | No | PostgreSQL: `org.postgresql.Driver`
+|===
+
+NOTE: If you provide your own `spring.datasource.url`, it will be ignored, unless you disable AlloyDB autoconfiguration with `spring.cloud.gcp.alloydb.enabled=false`.
+
+===== `DataSource` creation flow
+
+Spring Boot starter for Google AlloyDB registers a `AlloyDbEnvironmentPostProcessor` that provides a correctly formatted `spring.datasource.url` property to the environment based on the properties mentioned above.
+It also provides defaults for `spring.datasource.username` and `spring.datasource.driver-class-name`, which can be overridden.
+The starter also configures credentials for the JDBC connection based on the properties below.
+
+The user properties and the properties provided by the `AlloyDbEnvironmentPostProcessor` are then used by https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html[Spring Boot] to create the `DataSource`.
+You can select the type of connection pool (e.g., Tomcat, HikariCP, etc.) by https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-connect-to-production-database[adding their dependency to the classpath].
+
+Using the created `DataSource` in conjunction with Spring JDBC provides you with a fully configured and operational `JdbcTemplate` object that you can use to interact with your AlloyDB database.
+You can connect to your database with as little as a database and instance names.
+
+=== AlloyDB IAM database authentication
+
+Currently, AlloyDB supports https://cloud.google.com/alloydb/docs/manage-iam-authn[IAM database authentication].
+It allows you to connect to the database using an IAM account, rather than a predefined database username and password.
+You will need to do the following to enable it:
+
+. In your AlloyDB instance settings, turn on the `alloydb.iam_authentication` flag.
+. Add the IAM user or service account to the list of cluster users.
+. In the application settings, set `spring.cloud.gcp.alloydb.enable-iam-auth` to `true`. Note that this will also set the database protocol `sslmode` to `disabled`, as it's required for IAM authentication to work.
+However, it doesn't compromise the security of the communication because the connection is always encrypted.
+. Set `spring.datasource.username` to the IAM user or service account created in step 2. Note that IAM user or service account still needs to be https://www.postgresql.org/docs/current/sql-grant.html[granted permissions] before modifying or querying the database.
+
+=== AlloyDB Configuration Properties
+
+|===
+| Property name | Description | Required | Default value
+| `spring.cloud.gcp.alloydb.enabled` | Enables or disables AlloyDB auto configuration | No | `true`
+| `spring.cloud.gcp.alloydb.database-name` | The name of the database to connect to. | Yes |
+| `spring.cloud.gcp.alloydb.instance-connection-uri` | The Google AlloyDB instance connection URI. | Yes |
+For example, `projects/PROJECT_ID/locations/REGION_ID/clusters/CLUSTER_ID/instances/INSTANCE_ID`.
+| `spring.cloud.gcp.alloydb.ip-type` | Specifies a preferred IP type for connecting to a AlloyDB instance. | No | `PRIVATE`
+| `spring.cloud.gcp.alloydb.enable-iam-auth` | Specifies whether to enable IAM database authentication. | No | `False`
+| `spring.cloud.gcp.alloydb.admin-service-endpoint` | An alternate AlloyDB API endpoint. | No |
+| `spring.cloud.gcp.alloydb.quota-project` | The project ID for quota and billing. | No |
+| `spring.cloud.gcp.alloydb.target-principal` | The service account to impersonate when connecting to the database and database admin API. | No |
+| `spring.cloud.gcp.alloydb.delegates` | A comma-separated list of service accounts delegates. | No |
+| `spring.cloud.gcp.alloydb.named-connector` | The name of the named connector. | No |
+| `spring.cloud.gcp.alloydb.credentials.location` | File system path to the Google OAuth2 credentials private key file.
+Used to authenticate and authorize new connections to a Google AlloyDB instance. | No
+|===
+
+=== Troubleshooting tips
+
+[#connection-issues]
+==== Connection issues
+If you're not able to connect to a database and see an endless loop of `Connecting to AlloyDB instance [...] on IP [...]`, it's likely that exceptions are being thrown and logged at a level lower than your logger's level.
+This may be the case with HikariCP, if your logger is set to INFO or higher level.
+
+To see what's going on in the background, you should add a `logback.xml` file to your application resources folder, that looks like this:
+
+[source, xml]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+  <logger name="com.zaxxer.hikari.pool" level="DEBUG"/>
+</configuration>
+----
+
+==== PostgreSQL: `java.net.SocketException: already connected` issue
+
+We found this exception to be common if your Maven project's parent is `spring-boot` version `1.5.x`, or in any other circumstance that would cause the version of the `org.postgresql:postgresql` dependency to be an older one (e.g., `9.4.1212.jre7`).
+
+To fix this, re-declare the dependency in its correct version.
+For example, in Maven:
+
+[source,xml]
+----
+<dependency>
+  <groupId>org.postgresql</groupId>
+  <artifactId>postgresql</artifactId>
+  <version>42.7.3</version>
+</dependency>
+----
+
+
+=== Samples
+
+Available sample applications and codelabs:
+
+- https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample[Spring Framework on Google Cloud AlloyDB]
+- Codelab: https://codelabs.developers.google.com/create-alloydb-database-with-cloud-run-job[Creating AlloyDB database with Cloud Run Job]

--- a/docs/src/main/asciidoc/alloydb.adoc
+++ b/docs/src/main/asciidoc/alloydb.adoc
@@ -10,8 +10,6 @@ The role of the starters is to read configuration from properties and assume def
 === JDBC Support
 Maven and Gradle coordinates, using <<getting-started.adoc#bill-of-materials, Spring Framework on Google Cloud BOM>>:
 
-To use PostgreSQL:
-
 [source,xml]
 ----
 <dependency>
@@ -49,14 +47,14 @@ public List<Map<String, Object>> listUsers() {
 
 You can rely on
 https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-connect-to-production-database[Spring Boot data source autoconfiguration] to configure a `DataSource` bean.
-In other words, properties like the SQL username, `spring.datasource.username`, and password, `spring.datasource.password` can be used.
+In other words, properties like the username, `spring.datasource.username`, and password, `spring.datasource.password` can be used.
 There is also some configuration specific to Google AlloyDB (see "AlloyDB Configuration Properties" section below).
 
 |===
 | Property name | Description | Required | Default value
-| `spring.datasource.username` | Database username | No | MySQL: `root`; PostgreSQL: `postgres`
+| `spring.datasource.username` | Database username | No | `postgres`
 | `spring.datasource.password` | Database password | No | `null`
-| `spring.datasource.driver-class-name` | JDBC driver to use. | No | PostgreSQL: `org.postgresql.Driver`
+| `spring.datasource.driver-class-name` | JDBC driver to use. | No | `org.postgresql.Driver`
 |===
 
 NOTE: If you provide your own `spring.datasource.url`, it will be ignored, unless you disable AlloyDB autoconfiguration with `spring.cloud.gcp.alloydb.enabled=false`.

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -128,6 +128,10 @@ Refer for the full list https://github.com/GoogleCloudPlatform/spring-cloud-gcp/
 | Provides a security layer over applications deployed to Firebase
 | <<security-firebase.adoc#security-firebase, com.google.cloud:spring-cloud-gcp-starter-security-firebase>>
 
+| AlloyDB
+| AlloyDB integrations with PostgreSQL
+| <<alloydb.adoc#alloydb, com.google.cloud:spring-cloud-gcp-starter-alloydb>>
+
 |===
 
 ==== Spring Initializr
@@ -186,6 +190,9 @@ https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-g
 
 | Cloud Security - Firebase
 | https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-security-firebase-sample[spring-cloud-gcp-security-firebase-sample]
+
+| AlloyDB
+| https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample[spring-cloud-gcp-alloydb-sample]
 |===
 
 Each sample application demonstrates how to use Spring Framework on Google Cloud libraries in context and how to setup the dependencies for the project.

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -71,6 +71,8 @@ include::cloudfoundry.adoc[]
 
 include::kotlin.adoc[]
 
+include::alloydb.adoc[]
+
 == Configuration properties
 
 To see the list of all Google Cloud related configuration properties please check link:appendix.html[the Appendix page].

--- a/docs/src/main/asciidoc/sagan-index.adoc
+++ b/docs/src/main/asciidoc/sagan-index.adoc
@@ -11,6 +11,7 @@ Project features include:
 * Spring Data Cloud Datastore
 * Spring Data Reactive Repositories for Cloud Firestore
 * Spring Data Cloud SQL
+* Spring Data AlloyDB
 * Google Cloud Logging & Tracing
 * Google Cloud Storage (Spring Resource and Spring Integration)
 * Google Cloud Vision API Template
@@ -99,6 +100,10 @@ A sample of these artifacts are provided below.
 | Security - Firebase
 | Extracts IAP identity information from applications deployed to Firebase
 | `com.google.cloud:spring-cloud-gcp-starter-security-firebase`
+
+| AlloyDB
+| AlloyDB integrations with PostgreSQL
+| `com.google.cloud:spring-cloud-gcp-starter-alloydb`
 
 |===
 

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -298,6 +298,13 @@
             </exclusions>
         </dependency>
 
+        <!-- AlloyDB -->
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>alloydb-jdbc-connector</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Config -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/alloydb/AlloyDbEnvironmentPostProcessor.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/alloydb/AlloyDbEnvironmentPostProcessor.java
@@ -34,6 +34,10 @@ import org.springframework.util.StringUtils;
  */
 public class AlloyDbEnvironmentPostProcessor implements EnvironmentPostProcessor {
 
+  private static final String JDBC_URL_TEMPLATE = "jdbc:postgresql:///%s?socketFactory=com.google.cloud.alloydb.SocketFactory";
+  private static final String JDBC_DRIVER_CLASS = "org.postgresql.Driver";
+  private static final String DEFAULT_USERNAME = "postgres";
+
   @Override
   public void postProcessEnvironment(
       ConfigurableEnvironment environment, SpringApplication application) {
@@ -57,9 +61,9 @@ public class AlloyDbEnvironmentPostProcessor implements EnvironmentPostProcessor
     // configure default JDBC driver and username as fallback values when not
     // specified
     Map<String, Object> fallbackMap = new HashMap<>();
-    fallbackMap.put("spring.datasource.username", getDefaultUsername());
+    fallbackMap.put("spring.datasource.username", DEFAULT_USERNAME);
     fallbackMap.put(
-        "spring.datasource.driver-class-name", getJdbcDriverClass());
+        "spring.datasource.driver-class-name", JDBC_DRIVER_CLASS);
     environment
         .getPropertySources()
         .addLast(new MapPropertySource("ALLOYDB_DATA_SOURCE_FALLBACK", fallbackMap));
@@ -71,14 +75,13 @@ public class AlloyDbEnvironmentPostProcessor implements EnvironmentPostProcessor
         .getPropertySources()
         .addFirst(new MapPropertySource("ALLOYDB_DATA_SOURCE_URL", primaryMap));
 
-    System.out.println("HERE");
     // support usage metrics
     ConnectorRegistry.addArtifactId(
         "spring-cloud-gcp-alloydb/" + this.getClass().getPackage().getImplementationVersion());
   }
 
   private String getJdbcUrl(AlloyDbProperties properties) {
-    String jdbcUrl = String.format(this.getJdbcUrlTemplate(), properties.getDatabaseName());
+    String jdbcUrl = String.format(JDBC_URL_TEMPLATE, properties.getDatabaseName());
 
     if (StringUtils.hasText(properties.getInstanceConnectionUri())) {
       jdbcUrl += "&alloydbInstanceName=" + properties.getInstanceConnectionUri();
@@ -113,17 +116,5 @@ public class AlloyDbEnvironmentPostProcessor implements EnvironmentPostProcessor
     }
 
     return jdbcUrl;
-  }
-
-  private String getJdbcUrlTemplate() {
-    return "jdbc:postgresql:///%s?socketFactory=com.google.cloud.alloydb.SocketFactory";
-  }
-
-  private String getJdbcDriverClass() {
-    return "org.postgresql.Driver";
-  }
-
-  private String getDefaultUsername() {
-    return "postgres";
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/alloydb/AlloyDbEnvironmentPostProcessor.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/alloydb/AlloyDbEnvironmentPostProcessor.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.alloydb;
+
+import com.google.cloud.alloydb.ConnectorRegistry;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.util.StringUtils;
+
+/**
+ * Provides Google AlloyDB instance connectivity through Spring JDBC by
+ * providing only a database and instance connection URI.
+ */
+public class AlloyDbEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+  @Override
+  public void postProcessEnvironment(
+      ConfigurableEnvironment environment, SpringApplication application) {
+
+    if (environment.getPropertySources().contains("bootstrap")) {
+      // Do not run in the bootstrap phase as the user configuration is not available
+      // yet
+      return;
+    }
+
+    String propertiesPrefix = AlloyDbProperties.class.getAnnotation(ConfigurationProperties.class).value();
+    AlloyDbProperties alloyDbProperties = new Binder(
+        ConfigurationPropertySources.get(environment),
+        null,
+        null,
+        null,
+        null)
+        .bind(propertiesPrefix, AlloyDbProperties.class)
+        .orElse(new AlloyDbProperties());
+
+    // configure default JDBC driver and username as fallback values when not
+    // specified
+    Map<String, Object> fallbackMap = new HashMap<>();
+    fallbackMap.put("spring.datasource.username", getDefaultUsername());
+    fallbackMap.put(
+        "spring.datasource.driver-class-name", getJdbcDriverClass());
+    environment
+        .getPropertySources()
+        .addLast(new MapPropertySource("ALLOYDB_DATA_SOURCE_FALLBACK", fallbackMap));
+
+    // always set the spring.datasource.url property in the environment
+    Map<String, Object> primaryMap = new HashMap<>();
+    primaryMap.put("spring.datasource.url", getJdbcUrl(alloyDbProperties));
+    environment
+        .getPropertySources()
+        .addFirst(new MapPropertySource("ALLOYDB_DATA_SOURCE_URL", primaryMap));
+
+    System.out.println("HERE");
+    // support usage metrics
+    ConnectorRegistry.addArtifactId(
+        "spring-cloud-gcp-alloydb/" + this.getClass().getPackage().getImplementationVersion());
+  }
+
+  private String getJdbcUrl(AlloyDbProperties properties) {
+    String jdbcUrl = String.format(this.getJdbcUrlTemplate(), properties.getDatabaseName());
+
+    if (StringUtils.hasText(properties.getInstanceConnectionUri())) {
+      jdbcUrl += "&alloydbInstanceName=" + properties.getInstanceConnectionUri();
+    }
+
+    if (StringUtils.hasText(properties.getIpType())) {
+      jdbcUrl += "&alloydbIpType=" + properties.getIpType();
+    }
+
+    if (properties.isEnableIamAuth()) {
+      jdbcUrl += "&alloydbEnableIAMAuth=true&sslmode=disable";
+    }
+
+    if (StringUtils.hasText(properties.getAdminServiceEndpoint())) {
+      jdbcUrl += "&alloydbAdminServiceEndpoint=" + properties.getAdminServiceEndpoint();
+    }
+
+    if (StringUtils.hasText(properties.getQuotaProject())) {
+      jdbcUrl += "&alloydbQuotaProject=" + properties.getQuotaProject();
+    }
+
+    if (StringUtils.hasText(properties.getTargetPrincipal())) {
+      jdbcUrl += "&alloydbTargetPrincipal=" + properties.getTargetPrincipal();
+    }
+
+    if (StringUtils.hasText(properties.getDelegates())) {
+      jdbcUrl += "&alloydbDelegates=" + properties.getDelegates();
+    }
+
+    if (StringUtils.hasText(properties.getNamedConnector())) {
+      jdbcUrl += "&alloydbNamedConnector=" + properties.getNamedConnector();
+    }
+
+    return jdbcUrl;
+  }
+
+  private String getJdbcUrlTemplate() {
+    return "jdbc:postgresql:///%s?socketFactory=com.google.cloud.alloydb.SocketFactory";
+  }
+
+  private String getJdbcDriverClass() {
+    return "org.postgresql.Driver";
+  }
+
+  private String getDefaultUsername() {
+    return "postgres";
+  }
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/alloydb/AlloyDbProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/alloydb/AlloyDbProperties.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.alloydb;
+
+import com.google.cloud.spring.core.Credentials;
+import com.google.cloud.spring.core.CredentialsSupplier;
+import com.google.cloud.spring.core.GcpScope;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+@ConfigurationProperties("spring.cloud.gcp.alloydb")
+public class AlloyDbProperties implements CredentialsSupplier {
+
+  /** Overrides the GCP OAuth2 credentials specified in the Core module. */
+  @NestedConfigurationProperty
+  private final Credentials credentials = new Credentials(GcpScope.CLOUD_PLATFORM.getUrl());
+
+  /** Overrides the GCP Project ID specified in the Core module. */
+  private String projectId;
+
+  /** Name of the database in the AlloyDB instance. */
+  private String databaseName;
+
+  /** AlloyDB instance connection URI. */
+  private String instanceConnectionUri;
+
+  /** Type of IP to be used: PRIVATE, PUBLIC, PSC. */
+  private String ipType;
+
+  /** Service account impersonation. */
+  private String targetPrincipal;
+
+  /**
+   * Comma-separated list of service accounts containing chained list of delegates
+   * required to grant the final access_token.
+   */
+  private String delegates;
+
+  /** Admin API Service Endpoint. */
+  private String adminServiceEndpoint;
+
+  /** GCP Project ID for quota and billing. */
+  private String quotaProject;
+
+  /** Named Connector */
+  private String namedConnector;
+
+  /** Specifies whether to enable IAM database authentication. */
+  private boolean enableIamAuth;
+
+  @Override
+  public Credentials getCredentials() {
+    return credentials;
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  public void setProjectId(String projectId) {
+    this.projectId = projectId;
+  }
+
+  public String getDatabaseName() {
+    return this.databaseName;
+  }
+
+  public void setDatabaseName(String databaseName) {
+    this.databaseName = databaseName;
+  }
+
+  public String getInstanceConnectionUri() {
+    return this.instanceConnectionUri;
+  }
+
+  public void setInstanceConnectionUri(String instanceConnectionUri) {
+    this.instanceConnectionUri = instanceConnectionUri;
+  }
+
+  public boolean isEnableIamAuth() {
+    return enableIamAuth;
+  }
+
+  public void setEnableIamAuth(boolean enableIamAuth) {
+    this.enableIamAuth = enableIamAuth;
+  }
+
+  public String getIpType() {
+    return this.ipType;
+  }
+
+  public void setIpType(String ipType) {
+    this.ipType = ipType;
+  }
+
+  public String getTargetPrincipal() {
+    return this.targetPrincipal;
+  }
+
+  public void setTargetPrincipal(String targetPrincipal) {
+    this.targetPrincipal = targetPrincipal;
+  }
+
+  public String getDelegates() {
+    return this.delegates;
+  }
+
+  public void setDelegates(String delegates) {
+    this.delegates = delegates;
+  }
+
+  public String getAdminServiceEndpoint() {
+    return this.adminServiceEndpoint;
+  }
+
+  public void setAdminServiceEndpoint(String adminServiceEndpoint) {
+    this.adminServiceEndpoint = adminServiceEndpoint;
+  }
+
+  public String getQuotaProject() {
+    return this.quotaProject;
+  }
+
+  public void setQuotaProject(String quotaProject) {
+    this.quotaProject = quotaProject;
+  }
+
+  public String getNamedConnector() {
+    return this.namedConnector;
+  }
+
+  public void setNamedConnector(String namedConnector) {
+    this.namedConnector = namedConnector;
+  }
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/alloydb/package-info.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/alloydb/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Auto-configuration for Spring Cloud GCP AlloyDB module. */
+package com.google.cloud.spring.autoconfigure.alloydb;

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -143,6 +143,12 @@
       "type": "java.lang.Boolean",
       "description": "Whether to enable the Pub/Sub health indicator when used with Spring Boot Actuator.",
       "defaultValue": true
+    },
+    {
+      "name": "spring.cloud.gcp.alloydb.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Google Alloydb support components.",
+      "defaultValue": true
     }
   ]
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -3,7 +3,8 @@ com.google.cloud.spring.autoconfigure.config.GcpConfigBootstrapConfiguration
 org.springframework.boot.env.EnvironmentPostProcessor=\
 com.google.cloud.spring.autoconfigure.sql.CloudSqlEnvironmentPostProcessor,\
 com.google.cloud.spring.autoconfigure.sql.R2dbcCloudSqlEnvironmentPostProcessor,\
-com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerEnvironmentPostProcessor
+com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerEnvironmentPostProcessor,\
+com.google.cloud.spring.autoconfigure.alloydb.AlloyDbEnvironmentPostProcessor
 # ConfigData Location Resolvers
 org.springframework.boot.context.config.ConfigDataLocationResolver=\
 com.google.cloud.spring.autoconfigure.secretmanager.SecretManagerConfigDataLocationResolver

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/alloydb/AlloyDbEnvironmentPostProcessorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/alloydb/AlloyDbEnvironmentPostProcessorTests.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.alloydb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+class AlloyDbEnvironmentPostProcessorTests {
+
+  private AlloyDbEnvironmentPostProcessor initializer = new AlloyDbEnvironmentPostProcessor();
+
+  private static final String INSTANCE_URI = "projects/test-proj/locations/us-central1/clusters/test-cluster/instances/test-instance";
+  private static final String CREDENTIAL_LOCATION = "src/test/resources/fake-credential-key.json";
+  private static final String SERVICE_ENDPOINT = "googleapis.example.com:443";
+
+  private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+      .withPropertyValues("spring.cloud.gcp.alloydb.database-name=test-database")
+      .withInitializer(configurableApplicationContext -> initializer.postProcessEnvironment(
+          configurableApplicationContext.getEnvironment(), new SpringApplication()))
+      .withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+      .withUserConfiguration(Config.class);
+
+  @Test
+  void testAlloyDbDataSource() {
+    this.contextRunner
+        .withPropertyValues(
+            String.format("spring.cloud.gcp.alloydb.instance-connection-uri=%s", INSTANCE_URI),
+            "spring.datasource.password=")
+        .run(
+            context -> {
+              HikariDataSource dataSource = (HikariDataSource) context.getBean(DataSource.class);
+              assertThat(dataSource.getDriverClassName()).matches("org.postgresql.Driver");
+              assertThat(dataSource.getJdbcUrl())
+                  .isEqualTo(
+                      "jdbc:postgresql:///test-database?"
+                          + "socketFactory=com.google.cloud.alloydb.SocketFactory"
+                          + String.format("&alloydbInstanceName=%s", INSTANCE_URI));
+              assertThat(dataSource.getUsername()).matches("postgres");
+              assertThat(dataSource.getPassword()).isNull();
+            });
+  }
+
+  @Test
+  void testInstanceConnectionUri() {
+    this.contextRunner
+        .withPropertyValues(String.format("spring.cloud.gcp.alloydb.instance-connection-uri=%s", INSTANCE_URI))
+        .run(
+            context -> {
+              assertThat(getSpringDatasourceUrl(context))
+                  .isEqualTo(
+                      "jdbc:postgresql:///test-database?"
+                          + "socketFactory=com.google.cloud.alloydb.SocketFactory"
+                          + String.format("&alloydbInstanceName=%s", INSTANCE_URI));
+              assertThat(getSpringDatasourceDriverClassName(context))
+                  .matches("org.postgresql.Driver");
+            });
+  }
+
+  @Test
+  void testIamAuth() {
+    this.contextRunner
+        .withPropertyValues(
+            String.format("spring.cloud.gcp.alloydb.instance-connection-uri=%s", INSTANCE_URI),
+            "spring.cloud.gcp.alloydb.enable-iam-auth=true")
+        .run(
+            context -> {
+              DataSourceProperties dataSourceProperties = context.getBean(DataSourceProperties.class);
+              assertThat(dataSourceProperties.getUrl())
+                  .contains("&alloydbEnableIAMAuth=true&sslmode=disable");
+            });
+  }
+
+  @Test
+  void testIpType() {
+    this.contextRunner
+        .withPropertyValues(
+            String.format("spring.cloud.gcp.alloydb.instance-connection-uri=%s", INSTANCE_URI),
+            "spring.cloud.gcp.alloydb.ip-type=PUBLIC")
+        .run(
+            context -> {
+              DataSourceProperties dataSourceProperties = context.getBean(DataSourceProperties.class);
+              assertThat(dataSourceProperties.getUrl()).contains("&alloydbIpType=PUBLIC");
+            });
+  }
+
+  @Test
+  void testAdminServiceEndpoint() {
+    this.contextRunner
+        .withPropertyValues(
+            String.format("spring.cloud.gcp.alloydb.instance-connection-uri=%s", INSTANCE_URI),
+            String.format("spring.cloud.gcp.alloydb.admin-service-endpoint=%s", SERVICE_ENDPOINT))
+        .run(
+            context -> {
+              DataSourceProperties dataSourceProperties = context.getBean(DataSourceProperties.class);
+              assertThat(dataSourceProperties.getUrl()).contains(String.format("&alloydbAdminServiceEndpoint=%s", SERVICE_ENDPOINT));
+            });
+  }
+
+  @Test
+  void testQuotaProject() {
+    this.contextRunner
+        .withPropertyValues(
+            String.format("spring.cloud.gcp.alloydb.instance-connection-uri=%s", INSTANCE_URI),
+            "spring.cloud.gcp.alloydb.quota-project=new-project")
+        .run(
+            context -> {
+              DataSourceProperties dataSourceProperties = context.getBean(DataSourceProperties.class);
+              assertThat(dataSourceProperties.getUrl()).contains("&alloydbQuotaProject=new-project");
+            });
+  }
+
+  @Test
+  void testTargetPrincipal() {
+    this.contextRunner
+        .withPropertyValues(
+            String.format("spring.cloud.gcp.alloydb.instance-connection-uri=%s", INSTANCE_URI),
+            "spring.cloud.gcp.alloydb.target-principal=IMPERSONATED_USER")
+        .run(
+            context -> {
+              DataSourceProperties dataSourceProperties = context.getBean(DataSourceProperties.class);
+              assertThat(dataSourceProperties.getUrl()).contains("&alloydbTargetPrincipal=IMPERSONATED_USER");
+            });
+  }
+
+  @Test
+  void testDelegates() {
+    this.contextRunner
+        .withPropertyValues(
+            String.format("spring.cloud.gcp.alloydb.instance-connection-uri=%s", INSTANCE_URI),
+            "spring.cloud.gcp.alloydb.delegates=IMPERSONATED_USER")
+        .run(
+            context -> {
+              DataSourceProperties dataSourceProperties = context.getBean(DataSourceProperties.class);
+              assertThat(dataSourceProperties.getUrl()).contains("&alloydbDelegates=IMPERSONATED_USER");
+            });
+  }
+
+  @Test
+  void testNamedConnector() {
+    this.contextRunner
+        .withPropertyValues(
+            String.format("spring.cloud.gcp.alloydb.instance-connection-uri=%s", INSTANCE_URI),
+            "spring.cloud.gcp.alloydb.named-connector=test-connector")
+        .run(
+            context -> {
+              DataSourceProperties dataSourceProperties = context.getBean(DataSourceProperties.class);
+              assertThat(dataSourceProperties.getUrl()).contains("&alloydbNamedConnector=test-connector");
+            });
+  }
+
+  private String getSpringDatasourceUrl(ApplicationContext context) {
+    return context.getEnvironment().getProperty("spring.datasource.url");
+  }
+
+  private String getSpringDatasourceDriverClassName(ApplicationContext context) {
+    return context.getEnvironment().getProperty("spring.datasource.driver-class-name");
+  }
+
+  @Configuration
+  static class Config {
+
+    @Bean
+    public CredentialsProvider credentialsProvider() {
+      return NoCredentialsProvider.create();
+    }
+  }
+}

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -239,6 +239,24 @@
 				<artifactId>spring-cloud-spanner-spring-data-r2dbc</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>com.google.cloud</groupId>
+				<artifactId>spring-cloud-gcp-starter-alloydb</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<!-- spring-cloud-gcp-starter-alloydb -->
+			<dependency>
+			    <groupId>com.google.cloud</groupId>
+			    <artifactId>alloydb-jdbc-connector</artifactId>
+			    <version>1.1.0</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.postgresql</groupId>
+				<artifactId>postgresql</artifactId>
+				<version>42.7.3</version>
+			</dependency>
 
 			<!-- spring-cloud-gcp-starter-sql -->
 			<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/README.adoc
@@ -1,0 +1,43 @@
+= Spring Framework on Google Cloud AlloyDB Sample
+
+This code sample demonstrates how to connect to a Google Cloud AlloyDB instance using the link:../../spring-cloud-gcp-starters/spring-cloud-gcp-starter-alloydb[Spring Framework on Google Cloud AlloyDB Starter].
+
+You will create a cluster and primary instance, a database within the instance, populate the database and then query it.
+
+== Setup
+
+image:http://gstatic.com/cloudssh/images/open-btn.svg[link=https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fspring-cloud-gcp&cloudshell_open_in_editor=spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/README.adoc]
+
+1. Create a Google AlloyDB cluster and its primary instance following https://cloud.google.com/alloydb/docs/quickstart/create-and-connect[these instructions].
+
+You will be asked to set a password for the `postgres` root user; remember this value.
+
+2. Open the link:src/main/resources/application.properties[application.properties] file and set the following properties:
+- `spring.datasource.password` - Set this to the password that you chose for the `postgres` user.
+- `spring.cloud.gcp.alloydb.database-name` - Set this to the name of the database you created.
+- `spring.cloud.gcp.alloydb.instance-connection-uri` - Set this to the instance URI of your AlloyDB instance.
+The instance-connection-uri should be in the form: `projects/PROJECT_ID/locations/REGION_ID/clusters/CLUSTER_ID/instances/INSTANCE_ID`.
++
+For example, your instance connection name might look like: `projects/my-gcp-project/locations/us-central1/clusters/test-cluster/instances/test-instance`
+
++
+If you would like to use a different user, set the `spring.datasource.username` property appropriately.
+
+3. https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login[If you are authenticated in the Cloud SDK], your credentials will be automatically found by the Spring Boot Starter for Google Cloud AlloyDB.
++
+Alternatively, https://console.cloud.google.com/iam-admin/serviceaccounts[create a service account from the Google Cloud Console] and download its private key.
+Then, uncomment the `spring.cloud.gcp.alloydb.credentials.location` property in the link:src/main/resources/application.properties[application.properties] file and fill its value with the path to your service account private key on your local file system, prepended with `file:`.
+
+4. Run `$ mvn clean install` from the root directory of the project.
+
+== Running the application
+
+You can run the `AlloyDBApplication` Spring Boot app by running the following command in the same directory as this
+sample (spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample):
+
+`$ mvn spring-boot:run`
+
+The database will be populated based on the link:src/main/resources/schema.sql[schema.sql] and link:src/main/resources/data.sql[data.sql] files.
+
+When the application is up, navigate to http://localhost:8080/getTuples in your browser, or use the `Web Preview`
+button in Cloud Shell to preview the app on port 8080. This will print the contents of the `users` table.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/README.adoc
@@ -10,7 +10,7 @@ image:http://gstatic.com/cloudssh/images/open-btn.svg[link=https://ssh.cloud.goo
 
 1. Create a Google AlloyDB cluster and its primary instance following https://cloud.google.com/alloydb/docs/quickstart/create-and-connect[these instructions].
 
-You will be asked to set a password for the `postgres` root user; remember this value.
+  You will be asked to set a password for the `postgres` root user; remember this value.
 
 2. Open the link:src/main/resources/application.properties[application.properties] file and set the following properties:
 - `spring.datasource.password` - Set this to the password that you chose for the `postgres` user.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/README.adoc
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/README.adoc
@@ -8,7 +8,7 @@ You will create a cluster and primary instance, a database within the instance, 
 
 image:http://gstatic.com/cloudssh/images/open-btn.svg[link=https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fspring-cloud-gcp&cloudshell_open_in_editor=spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/README.adoc]
 
-1. Create a Google AlloyDB cluster and its primary instance following https://cloud.google.com/alloydb/docs/quickstart/create-and-connect[these instructions].
+1. Create a Google AlloyDB cluster and its primary instance following https://cloud.google.com/alloydb/docs/quickstart/integrate-cloud-run[these instructions].
 
   You will be asked to set a password for the `postgres` root user; remember this value.
 
@@ -31,6 +31,11 @@ Then, uncomment the `spring.cloud.gcp.alloydb.credentials.location` property in 
 4. Run `$ mvn clean install` from the root directory of the project.
 
 == Running the application
+
+NOTE: You need to run the sample from a VM within the created VPC to connect to AlloyDB using its private IP. 
+To connect using Public IP, enable the AlloyDB instance's for external connections 
+following https://cloud.google.com/alloydb/docs/connect-public-ip[these instructions] and 
+add `spring.cloud.gcp.alloydb.ip-type=PUBLIC` to your `application.properties`.
 
 You can run the `AlloyDBApplication` Spring Boot app by running the following command in the same directory as this
 sample (spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample):

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<!-- Your own application should inherit from spring-boot-starter-parent -->
+		<artifactId>spring-cloud-gcp-samples</artifactId>
+		<groupId>com.google.cloud</groupId>
+		<version>5.1.2</version><!-- {x-version-update:spring-cloud-gcp:current} -->
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>spring-cloud-gcp-alloydb-sample</artifactId>
+	<name>Spring Framework on Google Cloud Code Sample - AlloyDB</name>
+
+	<!-- The Spring Framework on Google Cloud BOM will manage spring-cloud-gcp version numbers for you. -->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.google.cloud</groupId>
+				<artifactId>spring-cloud-gcp-dependencies</artifactId>
+				<version>${project.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>spring-cloud-gcp-starter-alloydb</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!-- Test-related dependencies. -->
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<version>4.2.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.15.1</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/main/java/com/example/AlloyDbApplication.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/main/java/com/example/AlloyDbApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/** Sample application. */
+@SpringBootApplication
+public class AlloyDbApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(AlloyDbApplication.class, args);
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/main/java/com/example/WebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/main/java/com/example/WebController.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Web app controller for sample app. */
+@RestController
+public class WebController {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public WebController(JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @GetMapping("/getTuples")
+  public List<String> getTuples() {
+    return this.jdbcTemplate.queryForList("SELECT * FROM users").stream()
+        .map(m -> m.values().toString())
+        .collect(Collectors.toList());
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/main/resources/application.properties
@@ -1,0 +1,28 @@
+# Set to the Postgres user you want to connect to; 'postgres' is the default user.
+spring.datasource.username=postgres
+spring.datasource.password=[database-user-password]
+
+# spring.cloud.gcp.project-id=
+
+spring.cloud.gcp.alloydb.database-name=[database-name]
+
+# This value is formatted in the form: projects/PROJECT_ID/locations/REGION_ID/clusters/CLUSTER_ID/instances/INSTANCE_ID
+spring.cloud.gcp.alloydb.instance-connection-uri=[instance-connection-uri]
+
+# The IP type options are: PRIVATE (default), PUBLIC, PSC.
+# spring.cloud.gcp.alloydb.ip-type=PUBLIC
+# spring.cloud.gcp.alloydb.target-principal=[target-principal]
+# spring.cloud.gcp.alloydb.delegates=[delegates]
+# spring.cloud.gcp.alloydb.admin-service-endpoint=[admin-service-endpoint]
+# spring.cloud.gcp.alloydb.quota-project=[quota-project]
+# spring.cloud.gcp.alloydb.enable-iam-auth=true
+# spring.cloud.gcp.alloydb.named-connector=[named-connector]
+# spring.cloud.gcp.alloydb.credentials.location=file:/
+
+# So app starts despite "table already exists" errors.
+spring.sql.init.continue-on-error=true
+# Enforces database initialization
+spring.sql.init.mode=always
+
+# Set the logging level
+# logging.level.root=DEBUG

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/main/resources/data.sql
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/main/resources/data.sql
@@ -1,0 +1,4 @@
+INSERT INTO users VALUES
+  ('luisao@example.com', 'Anderson', 'Silva'),
+  ('jonas@example.com', 'Jonas', 'Goncalves'),
+  ('fejsa@example.com', 'Ljubomir', 'Fejsa');

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/main/resources/schema.sql
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/main/resources/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE users (
+  email VARCHAR(255),
+  first_name VARCHAR(255),
+  last_name VARCHAR(255),
+  PRIMARY KEY (email));

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/test/java/com/example/AlloyDbSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/test/java/com/example/AlloyDbSampleApplicationIntegrationTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/** Simple integration test to verify the AlloyDB sample application with Postgres. */
+@EnabledIfSystemProperty(named = "it.alloydb", matches = "true")
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    classes = {AlloyDbApplication.class},
+    properties = {
+      "spring.cloud.gcp.alloydb.database-name=code_samples_test_db",
+      "spring.cloud.gcp.alloydb.instance-connection-uri=projects/${GCLOUD_PROJECT}/locations/us-central1/clusters/testcluster/instances/testpostgres",
+      "spring.datasource.username=postgres",
+      "spring.sql.init.continue-on-error=true"
+    })
+class AlloyDbSampleApplicationIntegrationTests {
+
+  @Autowired private TestRestTemplate testRestTemplate;
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @AfterEach
+  void clearTable() {
+    this.jdbcTemplate.execute("DROP TABLE IF EXISTS users");
+  }
+
+  @Test
+  void testSqlRowsAccess() {
+    ResponseEntity<List<String>> result =
+        this.testRestTemplate.exchange(
+            "/getTuples", HttpMethod.GET, null, new ParameterizedTypeReference<List<String>>() {});
+
+    assertThat(result.getBody())
+        .containsExactlyInAnyOrder(
+            "[luisao@example.com, Anderson, Silva]",
+            "[jonas@example.com, Jonas, Goncalves]",
+            "[fejsa@example.com, Ljubomir, Fejsa]");
+  }
+}

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/test/resources/logback-test.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type
+		ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="INFO">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/spring-cloud-gcp-starters/pom.xml
+++ b/spring-cloud-gcp-starters/pom.xml
@@ -42,5 +42,6 @@
 		<module>spring-cloud-gcp-starter-security-firebase</module>
 		<module>spring-cloud-gcp-starter-secretmanager</module>
 		<module>spring-cloud-gcp-starter-kms</module>
+		<module>spring-cloud-gcp-starter-alloydb</module>
 	</modules>
 </project>

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-alloydb/.repo.metadata.json
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-alloydb/.repo.metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "spring-cloud-gcp-starter-alloydb",
+  "name_pretty": "Spring Cloud GCP Support for AlloyDB (PostgreSQL)",
+  "client_documentation": "https://spring.io/projects/spring-cloud-gcp",
+  "api_description": "Provides support for PostgreSQL databases in Google AlloyDB using Spring JDBC",
+  "release_level": "ga",
+  "language": "java",
+  "repo": "googlecloudplatform/spring-cloud-gcp",
+  "repo_short": "spring-cloud-gcp",
+  "distribution_name": "com.google.cloud:spring-cloud-gcp-starter-alloydb"
+}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-alloydb/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-alloydb/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>spring-cloud-gcp-starters</artifactId>
+        <groupId>com.google.cloud</groupId>
+        <version>5.1.2</version><!-- {x-version-update:spring-cloud-gcp:current} -->
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spring-cloud-gcp-starter-alloydb</artifactId>
+    <name>Spring Framework on Google Cloud Starter - AlloyDB</name>
+    <url>https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-starters/spring-cloud-gcp-starter-alloydb</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>spring-cloud-gcp-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+
+        <!-- AlloyDB Connector and Driver-->
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>alloydb-jdbc-connector</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+
+    </dependencies>
+</project>


### PR DESCRIPTION
This PR adds a component to allow our customers to connect to [Google Cloud AlloyDB](https://cloud.google.com/alloydb) instances using Spring Boot with the [Java Connector](https://github.com/GoogleCloudPlatform/alloydb-java-connector) integration.

It includes a starter, autoconfigure, sample, associated integrations tests and documentation.

Issue related: https://github.com/GoogleCloudPlatform/alloydb-java-connector/issues/151