### PR TITLE
feat: #2576 Added typeadapter to read and write Instant values.

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/spanner/GcpSpannerAutoConfigurationTests.java
@@ -17,7 +17,9 @@
 package com.google.cloud.spring.autoconfigure.spanner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.retrying.RetrySettings;
@@ -31,6 +33,8 @@ import com.google.cloud.spring.data.spanner.core.admin.SpannerDatabaseAdminTempl
 import com.google.cloud.spring.data.spanner.core.admin.SpannerSchemaUtils;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -45,6 +49,14 @@ class GcpSpannerAutoConfigurationTests {
 
   /** Mock Gson object for use in configuration. */
   public static Gson MOCK_GSON = mock(Gson.class);
+
+  @BeforeAll
+  static void beforeAll() {
+    GsonBuilder builderMock = mock(GsonBuilder.class);
+    when(builderMock.registerTypeAdapter(any(), any())).thenReturn(builderMock);
+    when(builderMock.create()).thenReturn(MOCK_GSON);
+    when(MOCK_GSON.newBuilder()).thenReturn(builderMock);
+  }
 
   private ApplicationContextRunner contextRunner =
       new ApplicationContextRunner()

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/typeadapter/InstantTypeAdapter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/mapping/typeadapter/InstantTypeAdapter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.data.spanner.core.mapping.typeadapter;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.time.Instant;
+
+public class InstantTypeAdapter extends TypeAdapter<Instant> {
+  @Override
+  public void write(JsonWriter jsonWriter, Instant instant) throws IOException {
+    if (instant == null) {
+      jsonWriter.nullValue();
+    } else {
+      jsonWriter.value(instant.toString());
+    }
+  }
+
+  @Override
+  public Instant read(JsonReader jsonReader) throws IOException {
+    if (jsonReader.peek() == JsonToken.NULL) {
+      return null;
+    }
+    return Instant.parse(jsonReader.nextString());
+  }
+}

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
@@ -77,8 +77,7 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     this.writeConverter = new SpannerWriteConverter();
     SpannerMappingContext spannerMappingContext = new SpannerMappingContext(new Gson());
     this.spannerEntityWriter =
-        new ConverterAwareMappingSpannerEntityWriter(
-            spannerMappingContext, this.writeConverter);
+        new ConverterAwareMappingSpannerEntityWriter(spannerMappingContext, this.writeConverter);
   }
 
   @Test
@@ -368,6 +367,24 @@ class ConverterAwareMappingSpannerEntityWriterTests {
   }
 
   @Test
+  void writeJsonWithInstantTest() {
+    TestEntities.InstantParam parameters = new TestEntities.InstantParam(Instant.ofEpochSecond(0));
+    TestEntities.TestEntityInstantInJson testEntity =
+        new TestEntities.TestEntityInstantInJson("id1", parameters);
+
+    WriteBuilder writeBuilder = mock(WriteBuilder.class);
+    ValueBinder<WriteBuilder> valueBinder = mock(ValueBinder.class);
+
+    when(writeBuilder.set("id")).thenReturn(valueBinder);
+    when(writeBuilder.set("params")).thenReturn(valueBinder);
+
+    this.spannerEntityWriter.write(testEntity, writeBuilder::set);
+
+    verify(valueBinder).to(testEntity.id);
+    verify(valueBinder).to(Value.json("{\"instant\":\"1970-01-01T00:00:00Z\"}"));
+  }
+
+  @Test
   void writeNullJsonTest() {
     TestEntities.TestEntityJson testEntity = new TestEntities.TestEntityJson("id1", null);
 
@@ -386,7 +403,8 @@ class ConverterAwareMappingSpannerEntityWriterTests {
   @Test
   void writeJsonArrayTest() {
     TestEntities.Params parameters = new TestEntities.Params("some value", "some other value");
-    TestEntities.TestEntityJsonArray testEntity = new TestEntities.TestEntityJsonArray("id1", Arrays.asList(parameters, parameters));
+    TestEntities.TestEntityJsonArray testEntity =
+        new TestEntities.TestEntityJsonArray("id1", Arrays.asList(parameters, parameters));
 
     WriteBuilder writeBuilder = mock(WriteBuilder.class);
     ValueBinder<WriteBuilder> valueBinder = mock(ValueBinder.class);
@@ -407,7 +425,8 @@ class ConverterAwareMappingSpannerEntityWriterTests {
   @Test
   void writeNullEmptyJsonArrayTest() {
     TestEntities.TestEntityJsonArray testNull = new TestEntities.TestEntityJsonArray("id1", null);
-    TestEntities.TestEntityJsonArray testEmpty = new TestEntities.TestEntityJsonArray("id2", new ArrayList<>());
+    TestEntities.TestEntityJsonArray testEmpty =
+        new TestEntities.TestEntityJsonArray("id2", new ArrayList<>());
 
     WriteBuilder writeBuilder = mock(WriteBuilder.class);
     ValueBinder<WriteBuilder> valueBinder = mock(ValueBinder.class);
@@ -432,8 +451,8 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     WriteBuilder writeBuilder = Mutation.newInsertBuilder("faulty_test_table_2");
 
     assertThatThrownBy(() -> this.spannerEntityWriter.write(ft, writeBuilder::set))
-            .isInstanceOf(SpannerDataException.class)
-            .hasMessage("Unsupported mapping for type: interface java.util.List");
+        .isInstanceOf(SpannerDataException.class)
+        .hasMessage("Unsupported mapping for type: interface java.util.List");
   }
 
   @Test
@@ -444,18 +463,18 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     WriteBuilder writeBuilder = Mutation.newInsertBuilder("faulty_test_table");
 
     assertThatThrownBy(() -> this.spannerEntityWriter.write(ft, writeBuilder::set))
-            .isInstanceOf(SpannerDataException.class)
-            .hasMessage("Unsupported mapping for type: "
-                    + "class com.google.cloud.spring.data.spanner.core.convert.TestEntities$TestEntity");
-
+        .isInstanceOf(SpannerDataException.class)
+        .hasMessage(
+            "Unsupported mapping for type: "
+                + "class com.google.cloud.spring.data.spanner.core.convert.TestEntities$TestEntity");
   }
 
   @Test
   void writingNullToKeyShouldThrowException() {
 
     assertThatThrownBy(() -> this.spannerEntityWriter.convertToKey(null))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Key of an entity to be written cannot be null!");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Key of an entity to be written cannot be null!");
   }
 
   @Test
@@ -471,9 +490,10 @@ class ConverterAwareMappingSpannerEntityWriterTests {
         new UserSetUnconvertableColumnType();
     WriteBuilder writeBuilder = Mutation.newInsertBuilder("faulty_test_table");
 
-    assertThatThrownBy(() -> this.spannerEntityWriter.write(userSetUnconvertableColumnType, writeBuilder::set))
-            .isInstanceOf(SpannerDataException.class)
-            .hasMessage("Unsupported mapping for type: boolean");
+    assertThatThrownBy(
+            () -> this.spannerEntityWriter.write(userSetUnconvertableColumnType, writeBuilder::set))
+        .isInstanceOf(SpannerDataException.class)
+        .hasMessage("Unsupported mapping for type: boolean");
   }
 
   @Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
@@ -276,6 +276,20 @@ class TestEntities {
     }
   }
 
+  /** A test class with Json field. */
+  @Table(name = "json_test_table")
+  static class TestEntityInstantInJson {
+    @PrimaryKey String id;
+
+    @Column(spannerType = TypeCode.JSON)
+    InstantParam params;
+
+    TestEntityInstantInJson(String id, InstantParam params) {
+      this.id = id;
+      this.params = params;
+    }
+  }
+
   static class Params {
     String p1;
 
@@ -284,6 +298,14 @@ class TestEntities {
     Params(String p1, String p2) {
       this.p1 = p1;
       this.p2 = p2;
+    }
+  }
+
+  static class InstantParam {
+    Instant instant;
+
+    InstantParam(Instant instant) {
+      this.instant = instant;
     }
   }
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/typeadapter/InstantTypeAdapterTest.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/typeadapter/InstantTypeAdapterTest.java
@@ -1,0 +1,59 @@
+package com.google.cloud.spring.data.spanner.core.mapping.typeadapter;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.time.Instant;
+import org.junit.Test;
+
+public class InstantTypeAdapterTest {
+
+  @Test
+  public void writeInstantTest() throws IOException {
+    InstantTypeAdapter instantTypeAdapter = new InstantTypeAdapter();
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(stringWriter);
+    Instant instant = Instant.ofEpochSecond(0);
+
+    instantTypeAdapter.write(jsonWriter, instant);
+
+    assertThat(stringWriter.toString()).isEqualTo("\"1970-01-01T00:00:00Z\"");
+  }
+
+  @Test
+  public void writeNullInstantTest() throws IOException {
+    InstantTypeAdapter instantTypeAdapter = new InstantTypeAdapter();
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(stringWriter);
+    Instant instant = null;
+
+    instantTypeAdapter.write(jsonWriter, instant);
+
+    assertThat(stringWriter.toString()).isEqualTo("null");
+  }
+
+  @Test
+  public void readInstantTest() throws IOException {
+    InstantTypeAdapter instantTypeAdapter = new InstantTypeAdapter();
+    String instantString = "\"1970-01-01T00:00:00Z\"";
+    Instant instant = Instant.ofEpochSecond(0);
+    StringReader stringReader = new StringReader(instantString);
+    Instant readInstant = instantTypeAdapter.read(new JsonReader(stringReader));
+
+    assertThat(readInstant).isEqualTo(instant);
+  }
+
+  @Test
+  public void readNullInstantTest() throws IOException {
+    InstantTypeAdapter instantTypeAdapter = new InstantTypeAdapter();
+    String instantString = "null";
+    StringReader stringReader = new StringReader(instantString);
+    Instant readInstant = instantTypeAdapter.read(new JsonReader(stringReader));
+
+    assertThat(readInstant).isNull();
+  }
+}


### PR DESCRIPTION
This PR adds a default `TypeAdapter` to the Spanner Mapping Context, enabling seamless mapping of java.time.Instant. Consequently, the need to include `--add-opens java.base/java.time=ALL-UNNAMED` in JVM arguments is eliminated.

Solves https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/2576