### PR TITLE
fix: AlloyDB should not load when Postgres starter is used

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -302,6 +302,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>alloydb-jdbc-connector</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Config -->

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/alloydb/AlloyDbEnvironmentPostProcessor.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/alloydb/AlloyDbEnvironmentPostProcessor.java
@@ -85,11 +85,11 @@ public class AlloyDbEnvironmentPostProcessor implements EnvironmentPostProcessor
       environment
           .getPropertySources()
           .addFirst(new MapPropertySource("ALLOYDB_DATA_SOURCE_URL", primaryMap));
-    }
 
-    // support usage metrics
-    ConnectorRegistry.addArtifactId(
-        "spring-cloud-gcp-alloydb/" + this.getClass().getPackage().getImplementationVersion());
+      // support usage metrics
+      ConnectorRegistry.addArtifactId(
+          "spring-cloud-gcp-alloydb/" + this.getClass().getPackage().getImplementationVersion());
+    }
   }
 
   private String getJdbcUrl(AlloyDbProperties properties) {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/src/test/java/com/example/SqlPostgresSampleApplicationIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/src/test/java/com/example/SqlPostgresSampleApplicationIntegrationTests.java
@@ -32,6 +32,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.util.ClassUtils;
 
 /** Simple integration test to verify the SQL sample application with Postgres. */
 @EnabledIfSystemProperty(named = "it.cloudsql", matches = "true")
@@ -68,5 +69,11 @@ class SqlPostgresSampleApplicationIntegrationTests {
             "[luisao@example.com, Anderson, Silva]",
             "[jonas@example.com, Jonas, Goncalves]",
             "[fejsa@example.com, Ljubomir, Fejsa]");
+  }
+
+  @Test
+  void testNoAllyDbLoaded() {
+    assertThat(ClassUtils.isPresent("com.google.cloud.alloydb.SocketFactory", null))
+        .isFalse();
   }
 }


### PR DESCRIPTION
Making `alloydb-jdbc-connector` optional dependency in autoconfig module.

Fixes: #2847.