### PR TITLE
chore: Fix sync-repo-settings.yaml file

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -11,7 +11,7 @@ branchProtectionRules:
       - 'unitTests (21)'
       - 'releaseCheck'
       - 'conventionalcommits.org'
-      - 'SonarCloud Code Analysis'
+      - 'Build with Sonar'
       - 'parallel-NativeTests (alloydb-sample)'
       - 'parallel-NativeTests (bigquery-sample)'
       - 'parallel-NativeTests (bigquery)'
@@ -50,7 +50,7 @@ branchProtectionRules:
       - 'unitTests (21)'
       - 'releaseCheck'
       - 'conventionalcommits.org'
-      - 'SonarCloud Code Analysis'
+      - 'Build with Sonar'
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false
@@ -63,7 +63,7 @@ branchProtectionRules:
       - 'unitTests (17)'
       - 'releaseCheck'
       - 'conventionalcommits.org'
-      - 'SonarCloud Code Analysis'
+      - 'Build with Sonar'
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false


### PR DESCRIPTION
Use `Build with Sonar` as that's the job name defined: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/8f515d16c03c805cc8cb3ccb1e4a222a537b9b2e/.github/workflows/sonar.yaml#L17

My suspicion is that `SonarCloud Code Analysis` isn't matching and the jobs listed below are ignored.