### PR TITLE
doc: add guide on enable pubsub subscription health indicator for Pub…

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -243,9 +243,6 @@ So, take care not to configure a subscription that has a business impact, or ins
 If you are using Spring Boot Actuator, you can take advantage of the Cloud Pub/Sub subscription health indicator called `pubsub-subscriber`.
 The subscription health indicator will verify whether Pub/Sub subscriptions are actively processing messages from the subscription's backlog.
 To enable it, you need to add the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready[Spring Boot Actuator] to your project and the https://cloud.google.com/monitoring/docs/reference/libraries[GCP Monitoring].
-Also, you need to set the following properties `spring.cloud.gcp.pubsub.health.lagThreshold`, `spring.cloud.gcp.pubsub.health.backlogThreshold`.
-
-The `pubsub-subscriber` indicator will then roll up to the overall application status visible at http://localhost:8080/actuator/health (use the `management.endpoint.health.show-details` property to view per-indicator details).
 
 [source,xml]
 ----
@@ -258,6 +255,12 @@ The `pubsub-subscriber` indicator will then roll up to the overall application s
   <artifactId>google-cloud-monitoring</artifactId>
 </dependency>
 ----
+
+Also, you need to set the following properties `spring.cloud.gcp.pubsub.health.lagThreshold`, `spring.cloud.gcp.pubsub.health.backlogThreshold`.
+
+The `pubsub-subscriber` indicator will then roll up to the overall application status visible at http://localhost:8080/actuator/health (use the `management.endpoint.health.show-details` property to view per-indicator details).
+
+If you use `PubSubInboundChannel` to integrate with Pub/Sub, make sure to call `.setHealthTrackerRegistry()` with the auto-configured `HealthTrackerRegistry` bean.
 
 The health indicator validates a subscriber's health by checking the subscription's message backlog and the last processed message.
 A subscription's backlog is retrieved using Google Cloud's Monitoring Metrics. The metric used is the `num_undelivered_messages` for a subscription.

--- a/docs/src/main/asciidoc/spring-integration-pubsub.adoc
+++ b/docs/src/main/asciidoc/spring-integration-pubsub.adoc
@@ -75,6 +75,8 @@ Then, we declare a `PubSubInboundChannelAdapter` bean.
 It requires the channel we just created and a `SubscriberFactory`, which creates `Subscriber` objects from the Google Cloud Java Client for Pub/Sub.
 The Spring Boot starter for Spring Framework on Google Cloud Pub/Sub provides a configured `PubSubSubscriberOperations` object.
 
+If you want to take advantage of the Cloud Pub/Sub subscription health indicator called pubsub-subscriber, you also need to call `adapter.setHealthTrackerRegistry()` with the auto-configured `HealthTrackerRegistry` bean. Refer to link:pubsub.adoc[Cloud Pub/Sub Subscription Health Indicator] for how to enable Spring Boot Actuator.
+
 ===== Acknowledging messages and handling failures
 When working with Cloud Pub/Sub, it is important to understand the concept of `ackDeadline` -- the amount of time Cloud Pub/Sub will wait until attempting redelivery of an outstanding message.
 Each subscription has a default `ackDeadline` applied to all messages sent to it.


### PR DESCRIPTION
…SubInboundChannel.

fixes #2470

For context:
- Pub/Sub subscriber health check was added in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/613
- Existing test on PubSubInboundChannelAdapter confirms user's finding in #2470 ([this test](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/0caa9b6245cb4281b8d8da7ccb9f8fa993b0b9c4/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/integration/inbound/PubSubInboundChannelAdapterTests.java#L201-L214))