### PR TITLE
fix: update generate-library-list.sh for duplicate api_shortnames

### DIFF
--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -5,7 +5,7 @@ on:
       branch_name:
         description: PR branch name
         required: true
-        default: "renovate/main-gcp-libraries-bom.version"
+        default: "renovate/gcp-libraries-bom.version"
       forked_repo:
         description: Fork name (enter none if repo branch)
         required: true

--- a/spring-cloud-generator/scripts/generate-library-list.sh
+++ b/spring-cloud-generator/scripts/generate-library-list.sh
@@ -24,6 +24,7 @@ filename=${SPRING_GENERATOR_DIR}/scripts/resources/library_list.txt
 echo "# api_shortname, googleapis-folder, distribution_name:version, monorepo_folder" > "$filename"
 
 # loop through configs for the monorepo (google-cloud-java)
+# Note that this logic will not work for non-cloud APIs
 count=0
 configs=$(yq e '.libraries[]' ./google-cloud-java/generate_config.yaml)
 for config_str in $configs; do

--- a/spring-cloud-generator/scripts/generate-library-list.sh
+++ b/spring-cloud-generator/scripts/generate-library-list.sh
@@ -26,48 +26,55 @@ echo "# api_shortname, googleapis-folder, distribution_name:version, monorepo_fo
 # loop through configs for the monorepo (google-cloud-java)
 # Note that this logic will not work for non-cloud APIs
 count=0
-configs=$(jq '.libraries[]' ./google-cloud-java/generate_config.yaml)
-for config_str in $configs; do
-  # parse variables from generation_config.yaml
-  config=$(echo "$config_str" | yq e '.') # Parse config_str back to YAML format
-  unique_module_name=$(echo "$config" | jq -r '.library_name // .api_shortname')
-  # Determine distribution_name
-  distribution_name=$(echo "$config" | jq -r '.distribution_name' // "")
-  if [ -z "$distribution_name" ]; then
-    distribution_name="com.google.cloud:google-cloud-${unique_module_name}"
-  fi
-  library_type=$(echo "$config" | jq -r '.library_type // "GAPIC_AUTO"') # default to GAPIC_AUTO per https://github.com/googleapis/sdk-platform-java/blob/v2.40.0/library_generation/model/library_config.py#L57
-  release_level=$(echo "$config" | jq -r '.release_level // "preview"') # default to preview per https://github.com/googleapis/sdk-platform-java/blob/v2.40.0/library_generation/model/library_config.py#L58
-  monorepo_folder="java/${unique_module_name}"
 
-  group_id=$(echo $distribution_name | cut -f1 -d:)
-  artifact_id=$(echo $distribution_name | cut -f2 -d:)
-  #  filter to in-scope libraries
-  if [[ $library_type != *GAPIC_AUTO* ]] ; then
-    echo "$d: non auto type: $library_type"
-    continue
-  fi
-  if [[ $group_id != "com.google.cloud" ]] ; then
-    echo "$d: group_id not in scope: $group_id"
-    continue
-  fi
-  if [[ $release_level != "stable" ]] ; then
-    echo "$d: release_level: $release_level"
-    continue
-  fi
-  # checks if library is in the manual modules exclusion list
-  if [[ $(cat ${SPRING_GENERATOR_DIR}/scripts/resources/manual_modules_exclusion_list.txt | tail -n+2 | grep $artifact_id | wc -l) -ne 0 ]] ; then
-    echo "$artifact_id is already present in manual modules."
-    continue
-  fi
+configs=$(yq eval '.libraries[]' -o=json ./google-cloud-java/generation_config.yaml)
+# Properly format the configs as a JSON array
+# This includes adding commas between objects and wrapping everything in square brackets
+json_array="[ $(echo "$configs" | tr '\n' ' ' | sed 's/} {/}, {/g') ]"
 
-  # parse proto path from generation_config.yaml, find by unique_module_name, which will match library_name if it exists, or api_shortname if library_name does not exist
-  # then sort and keep latest stable version
-  library=$(yq -r '.libraries[] | select(.library_name == "'"$unique_module_name"'" or .api_shortname == "'"$unique_module_name"'" )' ./google-cloud-java/generation_config.yaml)
-  proto_paths_stable=$(echo "$library" | yq -r '.GAPICs[] | select(.proto_path | test("/v[0-9]+$")) | .proto_path')
-  proto_paths_latest=$(echo "$proto_paths_stable" | sort -d -r | head -n 1)
+# Parse each object in the JSON array
+while IFS= read -r config; do
+    # Extract library_name if present, otherwise use api_shortname
+    unique_module_name=$(echo "$config" | jq -r '.library_name // .api_shortname')
+    # Display the unique module name
+    echo "Unique Module Name: $unique_module_name"
+    distribution_name=$(echo "$config" | jq -r '.distribution_name // ""')
+    if [ -z "$distribution_name" ]; then
+      distribution_name="com.google.cloud:google-cloud-${unique_module_name}"
+    fi
+    echo "Distribution name: $distribution_name"
+    library_type=$(echo "$config" | jq -r '.library_type // "GAPIC_AUTO"') # default to GAPIC_AUTO per https://github.com/googleapis/sdk-platform-java/blob/v2.40.0/library_generation/model/library_config.py#L57
+    echo "library_type: $library_type"
+    release_level=$(echo "$config" | jq -r '.release_level // "preview"') # default to preview per https://github.com/googleapis/sdk-platform-java/blob/v2.40.0/library_generation/model/library_config.py#L58
+    echo "release_level: $release_level"
+    monorepo_folder="java/${unique_module_name}"
+    echo "monorepo folder: $monorepo_folder"
+    group_id=$(echo $distribution_name | cut -f1 -d:)
+    artifact_id=$(echo $distribution_name | cut -f2 -d:)
+    #  filter to in-scope libraries
+    if [[ $library_type != *GAPIC_AUTO* ]] ; then
+      echo "$d: non auto type: $library_type"
+      continue
+    fi
+    if [[ $group_id != "com.google.cloud" ]] ; then
+      echo "$d: group_id not in scope: $group_id"
+      continue
+    fi
+    if [[ $release_level != "stable" ]] ; then
+      echo "$d: release_level: $release_level"
+      continue
+    fi
+    # checks if library is in the manual modules exclusion list
+    if [[ $(cat ${SPRING_GENERATOR_DIR}/scripts/resources/manual_modules_exclusion_list.txt | tail -n+2 | grep $artifact_id | wc -l) -ne 0 ]] ; then
+      echo "$artifact_id is already present in manual modules."
+      continue
+    fi
+    proto_paths_stable=$(echo "$config" | yq -r '.GAPICs[] | select(.proto_path | test("/v[0-9]+$")) | .proto_path')
+    echo "proto_paths_stable : $proto_paths_stable"
+    proto_paths_latest=$(echo "$proto_paths_stable" | sort -d -r | head -n 1)
+    echo "proto_paths_latest : $proto_paths_latest"
 
-  echo "$api_shortname, $proto_paths_latest, $distribution_name, $monorepo_folder" >> $filename
+  echo "$unique_module_name, $proto_paths_latest, $distribution_name, $monorepo_folder" >> $filename
   count=$((count+1))
-done
+done < <(echo "$json_array" | jq -c '.[]')
 echo "Total in-scope client libraries: $count"

--- a/spring-cloud-generator/scripts/generate-library-list.sh
+++ b/spring-cloud-generator/scripts/generate-library-list.sh
@@ -26,7 +26,7 @@ echo "# api_shortname, googleapis-folder, distribution_name:version, monorepo_fo
 # loop through configs for the monorepo (google-cloud-java)
 # Note that this logic will not work for non-cloud APIs
 count=0
-configs=$(yq e '.libraries[]' ./google-cloud-java/generate_config.yaml)
+configs=$(jq '.libraries[]' ./google-cloud-java/generate_config.yaml)
 for config_str in $configs; do
   # parse variables from generation_config.yaml
   config=$(echo "$config_str" | yq e '.') # Parse config_str back to YAML format


### PR DESCRIPTION
Generate Spring Auto-Configurations is currently failing on `securitycenter`'s module due it having a duplicate api_shortname (https://github.com/googleapis/google-cloud-java/blob/main/generation_config.yaml#L1666).

This updates the script to get the values needed from `generation_config.yaml` rather than looping through `google-cloud-java` folders and mimics the hermetic build script logic for those values. It uses `library_name` if it exists (which is the unique moniker if there is a duplicate `api_shortname`).

It removes `language` as a variable as I didn't see it being used elsewhere in the script.

This also updates the default value of the PR branch name to the correct value.