### PR TITLE
fix: update sanity-checks.sh

### DIFF
--- a/spring-cloud-generator/scripts/generate-library-list.sh
+++ b/spring-cloud-generator/scripts/generate-library-list.sh
@@ -21,7 +21,7 @@ fi
 cd ${SPRING_GENERATOR_DIR}
 # start file, always override is present
 filename=${SPRING_GENERATOR_DIR}/scripts/resources/library_list.txt
-echo "# api_shortname, googleapis-folder, distribution_name:version, monorepo_folder" > "$filename"
+echo "# library_name, googleapis_location, coordinates_version, monorepo_folder" > "$filename"
 
 # loop through configs for the monorepo (google-cloud-java)
 # Note that this logic will not work for non-cloud APIs
@@ -49,8 +49,8 @@ while IFS= read -r config; do
     echo "release_level: $release_level"
     monorepo_folder="java/${unique_module_name}"
     echo "monorepo folder: $monorepo_folder"
-    group_id=$(echo $distribution_name | cut -f1 -d:)
-    artifact_id=$(echo $distribution_name | cut -f2 -d:)
+    group_id=$(echo $coordinates_version | cut -f1 -d:)
+    artifact_id=$(echo $coordinates_version | cut -f2 -d:)
     #  filter to in-scope libraries
     if [[ $library_type != *GAPIC_AUTO* ]] ; then
       echo "$d: non auto type: $library_type"

--- a/spring-cloud-generator/scripts/sanity-checks.sh
+++ b/spring-cloud-generator/scripts/sanity-checks.sh
@@ -34,18 +34,17 @@ if [[ $(cat $LIBRARY_LIST_PATH | wc -l) -lt 2 ]]; then fail "library list is emp
 # checks that the contents of each entry in the library list is a string with
 # length >= 1
 libraries=$(cat $LIBRARY_LIST_PATH | tail -n+2)
-while IFS=, read -r library_name googleapis_location coordinates_version googleapis_commitish monorepo_folder; do
+while IFS=, read -r library_name googleapis_location coordinates_version monorepo_folder; do
 
   non_empty_check_items=(
     "$library_name"
     "$googleapis_location"
     "$coordinates_version"
-    "$googleapis_commitish"
     "$monorepo_folder"
   )
   for column in "${non_empty_check_items[@]}"; do
     if [[ -z $column ]]; then
-      echo "$library_name, $googleapis_location, $coordinates_version, $googleapis_commitish, $monorepo_folder"
+      echo "$library_name, $googleapis_location, $coordinates_version, $monorepo_folder"
       fail "the library list entry '$library_name' has an empty required cell - see $LIBRARY_LIST_PATH"
     fi
   done


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/2890

This updates the columns `sanity-checks.sh` checks for to match the ones generated by `generate-library-list.sh`.

Example error: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/9096934589/job/25003567600

```
accessapproval,  google/cloud/accessapproval/v1,  com.google.cloud:google-cloud-accessapproval,  java/accessapproval, 
sanity check failed:
  the library list entry 'accessapproval' has an empty required cell - see /home/runner/work/spring-cloud-gcp/spring-cloud-gcp/spring-cloud-
```

https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/df9f7051807f9a7002674bae5d25f01fa1350947#diff-d70307c629e3ee96cc0a222bda6e4cc1e02a27d95691b81c4c66fa51883ab3a0 removed the `googleapis_committish` column in `spring-cloud-generator/scripts/generate-library-list.sh`, but not `sanity-checks.sh`.