### PR TITLE
chore: cleanup generate-library-list.sh

### DIFF
--- a/spring-cloud-generator/scripts/generate-library-list.sh
+++ b/spring-cloud-generator/scripts/generate-library-list.sh
@@ -49,8 +49,8 @@ while IFS= read -r config; do
     echo "release_level: $release_level"
     monorepo_folder="java/${unique_module_name}"
     echo "monorepo folder: $monorepo_folder"
-    group_id=$(echo $coordinates_version | cut -f1 -d:)
-    artifact_id=$(echo $coordinates_version | cut -f2 -d:)
+    group_id=$(echo $distribution_name | cut -f1 -d:)
+    artifact_id=$(echo $distribution_name | cut -f2 -d:)
     #  filter to in-scope libraries
     if [[ $library_type != *GAPIC_AUTO* ]] ; then
       echo "$d: non auto type: $library_type"


### PR DESCRIPTION
I erroneously mislabeled the variable here: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/2891/files#diff-d70307c629e3ee96cc0a222bda6e4cc1e02a27d95691b81c4c66fa51883ab3a0

This fixes to use `distribution_name` consistently. 

For: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/2890