### PR TITLE
feat: configurable expiration policy on auto-created subscriptions

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/properties/PubSubConsumerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/properties/PubSubConsumerProperties.java
@@ -34,7 +34,8 @@ public class PubSubConsumerProperties extends PubSubCommonProperties {
   /**
    * Policy for how soon the subscription should be deleted after no activity.
    * <p>
-   * Note, a null or unset {@code expirationPolicy} will use the Google-provided default of 31 days TTL. To set no expiration, provide an {@code expirationPolicy} with a null {@link ExpirationPolicy#ttl}.
+   * Note, a null or unset {@code expirationPolicy} will use the Google-provided default of 31 days TTL.
+   * To set no expiration, provide an {@code expirationPolicy} with a zero-duration (e.g. 0d) {@link ExpirationPolicy#ttl}.
    */
   private ExpirationPolicy expirationPolicy = null;
 
@@ -104,11 +105,15 @@ public class PubSubConsumerProperties extends PubSubCommonProperties {
     /**
      * How long the subscription can have no activity before it is automatically deleted.
      * <p>
-     * Provide a non-null Expiration Policy with a null {@code ttl} to never expire.
+     * Provide an Expiration Policy with a zero (e.g. 0d) {@code ttl} to never expire.
      */
     private Duration ttl;
 
     public Duration getTtl() {
+      if (ttl != null && (ttl.isZero() || ttl.isNegative())) {
+        // non-positive is treated as "never expire"
+        return null;
+      }
       return ttl;
     }
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/properties/PubSubConsumerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/properties/PubSubConsumerProperties.java
@@ -16,9 +16,8 @@
 
 package com.google.cloud.spring.stream.binder.pubsub.properties;
 
-import java.time.Duration;
-
 import com.google.cloud.spring.pubsub.integration.AckMode;
+import java.time.Duration;
 
 /** Consumer properties for Pub/Sub. */
 public class PubSubConsumerProperties extends PubSubCommonProperties {
@@ -33,9 +32,10 @@ public class PubSubConsumerProperties extends PubSubCommonProperties {
 
   /**
    * Policy for how soon the subscription should be deleted after no activity.
-   * <p>
-   * Note, a null or unset {@code expirationPolicy} will use the Google-provided default of 31 days TTL.
-   * To set no expiration, provide an {@code expirationPolicy} with a zero-duration (e.g. 0d) {@link ExpirationPolicy#ttl}.
+   *
+   * <p>Note, a null or unset {@code expirationPolicy} will use the Google-provided default of 31
+   * days TTL. To set no expiration, provide an {@code expirationPolicy} with a zero-duration (e.g.
+   * 0d) {@link ExpirationPolicy#ttl}.
    */
   private ExpirationPolicy expirationPolicy = null;
 
@@ -104,8 +104,8 @@ public class PubSubConsumerProperties extends PubSubCommonProperties {
   public static class ExpirationPolicy {
     /**
      * How long the subscription can have no activity before it is automatically deleted.
-     * <p>
-     * Provide an Expiration Policy with a zero (e.g. 0d) {@code ttl} to never expire.
+     *
+     * <p>Provide an Expiration Policy with a zero (e.g. 0d) {@code ttl} to never expire.
      */
     private Duration ttl;
 

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/properties/PubSubConsumerProperties.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/properties/PubSubConsumerProperties.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spring.stream.binder.pubsub.properties;
 
+import java.time.Duration;
+
 import com.google.cloud.spring.pubsub.integration.AckMode;
 
 /** Consumer properties for Pub/Sub. */
@@ -28,6 +30,13 @@ public class PubSubConsumerProperties extends PubSubCommonProperties {
   private String subscriptionName = null;
 
   private DeadLetterPolicy deadLetterPolicy = null;
+
+  /**
+   * Policy for how soon the subscription should be deleted after no activity.
+   * <p>
+   * Note, a null or unset {@code expirationPolicy} will use the Google-provided default of 31 days TTL. To set no expiration, provide an {@code expirationPolicy} with a null {@link ExpirationPolicy#ttl}.
+   */
+  private ExpirationPolicy expirationPolicy = null;
 
   public AckMode getAckMode() {
     return ackMode;
@@ -61,6 +70,14 @@ public class PubSubConsumerProperties extends PubSubCommonProperties {
     this.deadLetterPolicy = deadLetterPolicy;
   }
 
+  public ExpirationPolicy getExpirationPolicy() {
+    return expirationPolicy;
+  }
+
+  public void setExpirationPolicy(ExpirationPolicy expirationPolicy) {
+    this.expirationPolicy = expirationPolicy;
+  }
+
   public static class DeadLetterPolicy {
     private String deadLetterTopic;
 
@@ -80,6 +97,23 @@ public class PubSubConsumerProperties extends PubSubCommonProperties {
 
     public void setMaxDeliveryAttempts(Integer maxDeliveryAttempts) {
       this.maxDeliveryAttempts = maxDeliveryAttempts;
+    }
+  }
+
+  public static class ExpirationPolicy {
+    /**
+     * How long the subscription can have no activity before it is automatically deleted.
+     * <p>
+     * Provide a non-null Expiration Policy with a null {@code ttl} to never expire.
+     */
+    private Duration ttl;
+
+    public Duration getTtl() {
+      return ttl;
+    }
+
+    public void setTtl(Duration ttl) {
+      this.ttl = ttl;
     }
   }
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -181,7 +181,8 @@ public class PubSubChannelProvisioner
 
       if (expirationPolicy.getTtl() != null) {
         long desiredSeconds = expirationPolicy.getTtl().getSeconds();
-        epBuilder.setTtl(com.google.protobuf.Duration.newBuilder().setSeconds(desiredSeconds).build());
+        epBuilder.setTtl(
+            com.google.protobuf.Duration.newBuilder().setSeconds(desiredSeconds).build());
       }
 
       builder.setExpirationPolicy(epBuilder);

--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -21,6 +21,7 @@ import com.google.cloud.spring.pubsub.PubSubAdmin;
 import com.google.cloud.spring.stream.binder.pubsub.properties.PubSubConsumerProperties;
 import com.google.cloud.spring.stream.binder.pubsub.properties.PubSubProducerProperties;
 import com.google.pubsub.v1.DeadLetterPolicy;
+import com.google.pubsub.v1.ExpirationPolicy;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.Topic;
 import com.google.pubsub.v1.TopicName;
@@ -71,8 +72,6 @@ public class PubSubChannelProvisioner
     String customName = properties.getExtension().getSubscriptionName();
 
     boolean autoCreate = properties.getExtension().isAutoCreateResources();
-    PubSubConsumerProperties.DeadLetterPolicy deadLetterPolicy =
-        properties.getExtension().getDeadLetterPolicy();
 
     // topicName may be either the short or fully-qualified version.
     String topicShortName =
@@ -101,7 +100,7 @@ public class PubSubChannelProvisioner
         subscriptionName = "anonymous." + topicShortName + "." + UUID.randomUUID();
         this.anonymousGroupSubscriptionNames.add(subscriptionName);
       }
-      ensureSubscriptionExists(subscriptionName, topicName, deadLetterPolicy, autoCreate);
+      ensureSubscriptionExists(subscriptionName, topicName, properties.getExtension(), autoCreate);
     }
 
     Assert.hasText(subscriptionName, "Subscription Name cannot be null or empty");
@@ -142,11 +141,11 @@ public class PubSubChannelProvisioner
   Subscription ensureSubscriptionExists(
       String subscriptionName,
       String topicName,
-      PubSubConsumerProperties.DeadLetterPolicy deadLetterPolicy,
+      PubSubConsumerProperties properties,
       boolean autoCreate) {
     Subscription subscription = this.pubSubAdmin.getSubscription(subscriptionName);
     if (subscription == null) {
-      return createSubscription(subscriptionName, topicName, deadLetterPolicy, autoCreate);
+      return createSubscription(subscriptionName, topicName, properties, autoCreate);
     }
     return subscription;
   }
@@ -154,11 +153,12 @@ public class PubSubChannelProvisioner
   private Subscription createSubscription(
       String subscriptionName,
       String topicName,
-      PubSubConsumerProperties.DeadLetterPolicy deadLetterPolicy,
+      PubSubConsumerProperties properties,
       boolean autoCreate) {
     Subscription.Builder builder =
         Subscription.newBuilder().setName(subscriptionName).setTopic(topicName);
 
+    PubSubConsumerProperties.DeadLetterPolicy deadLetterPolicy = properties.getDeadLetterPolicy();
     if (deadLetterPolicy != null) {
       String dlTopicName = deadLetterPolicy.getDeadLetterTopic();
       Assert.hasText(dlTopicName, "Dead letter policy cannot have null or empty topic");
@@ -173,6 +173,18 @@ public class PubSubChannelProvisioner
         dlpBuilder.setMaxDeliveryAttempts(maxAttempts);
       }
       builder.setDeadLetterPolicy(dlpBuilder);
+    }
+
+    PubSubConsumerProperties.ExpirationPolicy expirationPolicy = properties.getExpirationPolicy();
+    if (expirationPolicy != null) {
+      ExpirationPolicy.Builder epBuilder = ExpirationPolicy.newBuilder();
+
+      if (expirationPolicy.getTtl() != null) {
+        long desiredSeconds = expirationPolicy.getTtl().getSeconds();
+        epBuilder.setTtl(com.google.protobuf.Duration.newBuilder().setSeconds(desiredSeconds).build());
+      }
+
+      builder.setExpirationPolicy(epBuilder);
     }
 
     return this.pubSubAdmin.createSubscription(builder);

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -26,8 +26,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.assertj.core.data.Offset;
-
 import com.google.api.gax.rpc.AlreadyExistsException;
 import com.google.cloud.spring.pubsub.PubSubAdmin;
 import com.google.cloud.spring.pubsub.support.PubSubSubscriptionUtils;
@@ -37,6 +35,7 @@ import com.google.cloud.spring.stream.binder.pubsub.properties.PubSubProducerPro
 import com.google.pubsub.v1.DeadLetterPolicy;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.Topic;
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -210,8 +209,8 @@ class PubSubChannelProvisionerTests {
     when(this.pubSubAdminMock.createTopic("topic_A"))
         .thenReturn(Topic.newBuilder().setName("projects/test-project/topics/topic_A").build());
 
-    this.pubSubChannelProvisioner.provisionConsumerDestination("topic_A", "group_A",
-        this.extendedConsumerProperties);
+    this.pubSubChannelProvisioner.provisionConsumerDestination(
+        "topic_A", "group_A", this.extendedConsumerProperties);
 
     ArgumentCaptor<Subscription.Builder> argCaptor =
         ArgumentCaptor.forClass(Subscription.Builder.class);
@@ -233,8 +232,8 @@ class PubSubChannelProvisionerTests {
     when(this.pubSubAdminMock.createTopic("topic_A"))
         .thenReturn(Topic.newBuilder().setName("projects/test-project/topics/topic_A").build());
 
-    this.pubSubChannelProvisioner.provisionConsumerDestination("topic_A", "group_A",
-        this.extendedConsumerProperties);
+    this.pubSubChannelProvisioner.provisionConsumerDestination(
+        "topic_A", "group_A", this.extendedConsumerProperties);
 
     ArgumentCaptor<Subscription.Builder> argCaptor =
         ArgumentCaptor.forClass(Subscription.Builder.class);
@@ -258,8 +257,8 @@ class PubSubChannelProvisionerTests {
     when(this.pubSubAdminMock.createTopic("topic_A"))
         .thenReturn(Topic.newBuilder().setName("projects/test-project/topics/topic_A").build());
 
-    this.pubSubChannelProvisioner.provisionConsumerDestination("topic_A", "group_A",
-        this.extendedConsumerProperties);
+    this.pubSubChannelProvisioner.provisionConsumerDestination(
+        "topic_A", "group_A", this.extendedConsumerProperties);
 
     ArgumentCaptor<Subscription.Builder> argCaptor =
         ArgumentCaptor.forClass(Subscription.Builder.class);
@@ -313,14 +312,12 @@ class PubSubChannelProvisionerTests {
   void testProvisionConsumerDestination_concurrentTopicCreation() {
     when(this.pubSubAdminMock.createTopic(any())).thenThrow(AlreadyExistsException.class);
     when(this.pubSubAdminMock.getTopic("already_existing_topic"))
-            .thenReturn(null)
-            .thenReturn(Topic.newBuilder().setName("already_existing_topic").build());
+        .thenReturn(null)
+        .thenReturn(Topic.newBuilder().setName("already_existing_topic").build());
 
     // Ensure no exceptions occur if topic already exists on create call
-    assertThat(
-            this.pubSubChannelProvisioner.ensureTopicExists(
-                    "already_existing_topic", true))
-            .isNotNull();
+    assertThat(this.pubSubChannelProvisioner.ensureTopicExists("already_existing_topic", true))
+        .isNotNull();
   }
 
   @Test
@@ -359,7 +356,6 @@ class PubSubChannelProvisionerTests {
     assertThat(subscription.getTopic()).isEqualTo("topic_A");
   }
 
-
   @Test
   void testProvisionConsumerDestination_createTopic_whenAutoCreateResources_isTrue() {
     doReturn(null).when(this.pubSubAdminMock).getTopic("not_yet_created");
@@ -388,8 +384,9 @@ class PubSubChannelProvisionerTests {
 
   @Test
   void testProvisionProducerDestination_createTopic() {
-    ProducerDestination destination = this.pubSubChannelProvisioner.provisionProducerDestination(
-        "topic_A", extendedProducerProperties);
+    ProducerDestination destination =
+        this.pubSubChannelProvisioner.provisionProducerDestination(
+            "topic_A", extendedProducerProperties);
 
     assertThat(destination.getName()).isEqualTo("topic_A");
   }
@@ -400,8 +397,10 @@ class PubSubChannelProvisionerTests {
     when(this.pubSubAdminMock.getTopic(any())).thenReturn(null);
 
     assertThatExceptionOfType(ProvisioningException.class)
-        .isThrownBy(() -> this.pubSubChannelProvisioner.provisionProducerDestination(
-            "not_yet_created", extendedProducerProperties))
+        .isThrownBy(
+            () ->
+                this.pubSubChannelProvisioner.provisionProducerDestination(
+                    "not_yet_created", extendedProducerProperties))
         .withMessageContaining("Non-existing");
   }
 }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -226,6 +226,7 @@ class PubSubChannelProvisionerTests {
   void testProvisionConsumerDestination_expirationPolicyNever() {
     PubSubConsumerProperties.ExpirationPolicy expirationPolicy =
         new PubSubConsumerProperties.ExpirationPolicy();
+    // null TTL
     when(this.pubSubConsumerProperties.getExpirationPolicy()).thenReturn(expirationPolicy);
 
     when(this.pubSubAdminMock.getTopic("topic_A")).thenReturn(null);


### PR DESCRIPTION
Adds a way to configure the expiration policy on auto-created subscriptions.

The expiration policy contains a single field, `ttl` which is a Duration.

When the `ttl` is not set, the Pub Sub backend sets its own default of 31 (no expirationPolicy set on API request).

When the `ttl` is set to a >0 duration, that duration is configured for auto-created Subscriptions (expirationPolicy with ttl set on API request).

When the `ttl` is set to a <= 0 duration, the `ttl` is interpreted as "Never", and the auto-created Subscriptions will not expire (expirationPolicy with no ttl set on API request).

Fixes #2876 