### PR TITLE
fix: stackdriver logback appender now defaults to flushlevel off (#2906)

### DIFF
--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -72,7 +72,7 @@ The following properties are available (see link:https://github.com/googleapis/j
 | Property | Default Value | Description
 | `log` | `spring.log` | The Cloud Logging Log name.
 This can also be set via the `STACKDRIVER_LOG_NAME` environmental variable.
-| `flushLevel` | `WARN` | If a log entry with this level is encountered, trigger a flush of locally buffered log to Cloud Logging.
+| `flushLevel` | `OFF` | If a log entry with this level is encountered, trigger a flush of locally buffered log to Cloud Logging.
 This can also be set via the `STACKDRIVER_LOG_FLUSH_LEVEL` environmental variable.
 | `enhancer` |  | Fully qualified class name for customizing a logging entry; must implement `com.google.cloud.logging.LoggingEnhancer`.
 | `loggingEventEnhancer` |  | Fully qualified class name for customizing a logging entry given an link:https://logback.qos.ch/apidocs/ch/qos/logback/classic/spi/ILoggingEvent.html[`ILoggingEvent`]; must implement `com.google.cloud.logging.logback.LoggingEventEnhancer`.

--- a/spring-cloud-gcp-logging/src/main/resources/com/google/cloud/spring/logging/logback-appender.xml
+++ b/spring-cloud-gcp-logging/src/main/resources/com/google/cloud/spring/logging/logback-appender.xml
@@ -6,11 +6,11 @@ Stackdriver appender logback configuration provided for import.
 
 <included>
   <property name="STACKDRIVER_LOG_NAME" value="${STACKDRIVER_LOG_NAME:-spring.log}"/>
-  <property name="STACKDRIVER_LOG_FLUSH_LEVEL" value="${STACKDRIVER_LOG_FLUSH_LEVEL:-WARN}"/>
+  <property name="STACKDRIVER_LOG_FLUSH_LEVEL" value="${STACKDRIVER_LOG_FLUSH_LEVEL:-OFF}"/>
 
   <appender name="STACKDRIVER" class="com.google.cloud.spring.logging.LoggingAppender">
     <log>${STACKDRIVER_LOG_NAME}</log> <!-- Optional : default spring.log -->
     <loggingEventEnhancer>com.google.cloud.spring.logging.TraceIdLoggingEnhancer</loggingEventEnhancer>
-    <flushLevel>${STACKDRIVER_LOG_FLUSH_LEVEL}</flushLevel> <!-- Optional : default ERROR -->
+    <flushLevel>${STACKDRIVER_LOG_FLUSH_LEVEL}</flushLevel> <!-- Optional : default OFF -->
   </appender>
 </included>

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/LoggingAppenderTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/LoggingAppenderTests.java
@@ -74,6 +74,7 @@ class LoggingAppenderTests {
   @Test
   void testDisablingFlushLevel() {
     LoggingAppender loggingAppender = new TestLoggingAppender();
+    loggingAppender.setLogDestinationProjectId("my-log-destination-project");
     loggingAppender.setFlushLevel(Level.OFF);
 
     loggingAppender.start();

--- a/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/LoggingAppenderTests.java
+++ b/spring-cloud-gcp-logging/src/test/java/com/google/cloud/spring/logging/LoggingAppenderTests.java
@@ -17,7 +17,15 @@
 package com.google.cloud.spring.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import ch.qos.logback.classic.Level;
+import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.LoggingOptions;
+import com.google.cloud.spring.core.UserAgentHeaderProvider;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -27,9 +35,29 @@ import org.junit.jupiter.api.Test;
  */
 class LoggingAppenderTests {
 
+  private final Logging logging = mock(Logging.class);
+
+  private class TestLoggingAppender extends LoggingAppender {
+    private LoggingOptions loggingOptions;
+
+    @Override
+    protected LoggingOptions getLoggingOptions() {
+      if (loggingOptions == null) {
+        this.loggingOptions = super.getLoggingOptions().toBuilder()
+            // Duplicates logic in base class.
+            // Workaround for https://github.com/googleapis/sdk-platform-java/issues/2821
+            .setHeaderProvider(new UserAgentHeaderProvider(this.getClass()))
+            // Inject mock
+            .setServiceFactory((options) -> logging)
+            .build();
+      }
+      return loggingOptions;
+    }
+  }
+
   @Test
   void testGetLoggingOptions() {
-    LoggingAppender loggingAppender = new LoggingAppender();
+    LoggingAppender loggingAppender = new TestLoggingAppender();
     loggingAppender.setCredentialsFile("src/test/resources/fake-project-key.json");
     assertThat(loggingAppender.getLoggingOptions().getCredentials()).isNotNull();
     assertThat(loggingAppender.getLoggingOptions().getProjectId()).isEqualTo("fake-project");
@@ -37,11 +65,24 @@ class LoggingAppenderTests {
         .isNotNull()
         .contains("spring-cloud-gcp-logging")
         .contains("Spring");
+
+    loggingAppender.start();
+    // java-logging-logback appender default is ERROR
+    verify(logging).setFlushSeverity(com.google.cloud.logging.Severity.ERROR);
+  }
+
+  @Test
+  void testDisablingFlushLevel() {
+    LoggingAppender loggingAppender = new TestLoggingAppender();
+    loggingAppender.setFlushLevel(Level.OFF);
+
+    loggingAppender.start();
+    verify(logging, never()).setFlushSeverity(any());
   }
 
   @Test
   void testSetLogDestinationProjectId() {
-    LoggingAppender loggingAppender = new LoggingAppender();
+    LoggingAppender loggingAppender = new TestLoggingAppender();
     loggingAppender.setCredentialsFile("src/test/resources/fake-project-key.json");
     loggingAppender.setLogDestinationProjectId("my-log-destination-project");
     assertThat(loggingAppender.getLoggingOptions().getCredentials()).isNotNull();


### PR DESCRIPTION
Fixes #2906 

Note that this only changes the Spring Cloud GCP `STACKDRIVER` appender's default. It does not change the base java-logging-logback's appender which [defaults to ERROR](https://github.com/googleapis/java-logging-logback/blob/main/src/main/java/com/google/cloud/logging/logback/LoggingAppender.java#L302).