### PR TITLE
chore: Spring Boot 3.3 updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,12 @@
 
 			<dependency>
 				<groupId>io.zipkin.gcp</groupId>
+				<artifactId>brave-encoder-stackdriver</artifactId>
+				<version>${zipkin-gcp.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.zipkin.gcp</groupId>
 				<artifactId>zipkin-sender-stackdriver</artifactId>
 				<version>${zipkin-gcp.version}</version>
 				<exclusions>
@@ -156,7 +162,7 @@
 			<dependency>
 				<groupId>io.micrometer</groupId>
 				<artifactId>micrometer-tracing-bom</artifactId>
-				<version>${micrometer-tracing.verison}</version>
+				<version>${micrometer-tracing.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<project.parent.version>${project.version}</project.parent.version>
 		<!-- Dependency versions -->
 		<spring-cloud-dependencies.version>2023.0.1</spring-cloud-dependencies.version>
-		<spring-boot-dependencies.version>3.3.0</spring-boot-dependencies.version>
+		<spring-boot-dependencies.version>3.3.1</spring-boot-dependencies.version>
 		<spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
 		<zipkin-gcp.version>2.2.4</zipkin-gcp.version>
 		<java-cfenv.version>2.5.0</java-cfenv.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<spring-cloud-dependencies.version>2023.0.1</spring-cloud-dependencies.version>
 		<spring-boot-dependencies.version>3.3.0</spring-boot-dependencies.version>
 		<spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
-		<zipkin-gcp.version>1.1.1</zipkin-gcp.version>
+		<zipkin-gcp.version>2.2.4</zipkin-gcp.version>
 		<java-cfenv.version>2.5.0</java-cfenv.version>
 		<micrometer-tracing.verison>1.2.5</micrometer-tracing.verison>
 
@@ -109,6 +109,12 @@
 				<groupId>ch.qos.logback.contrib</groupId>
 				<artifactId>logback-json-classic</artifactId>
 				<version>0.1.5</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.zipkin.gcp</groupId>
+				<artifactId>zipkin-encoder-stackdriver</artifactId>
+				<version>${zipkin-gcp.version}</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
 		<zipkin-gcp.version>2.2.4</zipkin-gcp.version>
 		<java-cfenv.version>2.5.0</java-cfenv.version>
-		<micrometer-tracing.verison>1.2.5</micrometer-tracing.verison>
+		<micrometer-tracing.version>1.2.5</micrometer-tracing.version>
 
 		<!-- Plugin versions -->
 		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -183,8 +183,20 @@
         </dependency>
 
         <dependency>
+            <groupId>io.zipkin.zipkin2</groupId>
+            <artifactId>zipkin</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>io.zipkin.reporter2</groupId>
             <artifactId>zipkin-reporter-brave</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.zipkin.gcp</groupId>
+            <artifactId>zipkin-encoder-stackdriver</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -183,12 +183,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.zipkin.zipkin2</groupId>
-            <artifactId>zipkin</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>io.zipkin.reporter2</groupId>
             <artifactId>zipkin-reporter-brave</artifactId>
             <optional>true</optional>
@@ -197,6 +191,12 @@
         <dependency>
             <groupId>io.zipkin.gcp</groupId>
             <artifactId>zipkin-encoder-stackdriver</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.zipkin.gcp</groupId>
+            <artifactId>brave-encoder-stackdriver</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -71,14 +71,14 @@ public class StackdriverTraceAutoConfiguration {
   private static final Log LOGGER = LogFactory.getLog(StackdriverTraceAutoConfiguration.class);
 
   /**
-   * Stackdriver sender bean name. Name of the bean matters for supporting multiple tracing systems.
+   * Stackdriver encoder bean name. Name of the bean matters for supporting multiple tracing systems.
    */
-  public static final String SENDER_BEAN_NAME = "stackdriverSender";
+  public static final String ENCODER_BEAN_NAME = "stackdriverEncoder";
 
   /**
    * Stackdriver sender bean name. Name of the bean matters for supporting multiple tracing systems.
    */
-  public static final String ENCODER_BEAN_NAME = "stackdriverEncoder";
+  public static final String SENDER_BEAN_NAME = "stackdriverSender";
 
   /**
    * Stackdriver span handler bean name. Name of the bean matters for supporting multiple tracing

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -126,8 +126,14 @@ public class StackdriverTraceAutoConfiguration {
   @ConditionalOnMissingBean(name = SPAN_HANDLER_BEAN_NAME)
   public AsyncZipkinSpanHandler stackdriverSpanHandler(
       @Qualifier(SENDER_BEAN_NAME) StackdriverSender sender,
-      @Qualifier(ENCODER_BEAN_NAME) BytesEncoder<MutableSpan> encoder) {
-    return AsyncZipkinSpanHandler.newBuilder(sender).build(encoder);
+      @Qualifier(ENCODER_BEAN_NAME) BytesEncoder<MutableSpan> encoder,
+      ReporterMetrics reporterMetrics,
+      GcpTraceProperties trace) {
+    return AsyncZipkinSpanHandler.newBuilder(sender)
+        .metrics(reporterMetrics)
+        .queuedMaxSpans(1000)
+        .messageTimeout(trace.getMessageTimeout(), TimeUnit.SECONDS)
+        .build(encoder);
   }
 
   @Bean

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import zipkin2.Span;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.CheckResult;
 import zipkin2.reporter.Reporter;
@@ -127,7 +128,7 @@ public class StackdriverTraceAutoConfiguration {
   @Bean(SPAN_HANDLER_BEAN_NAME)
   @ConditionalOnMissingBean(name = SPAN_HANDLER_BEAN_NAME)
   public SpanHandler stackdriverSpanHandler(
-      @Qualifier(REPORTER_BEAN_NAME) Reporter<zipkin2.Span> stackdriverReporter) {
+      @Qualifier(REPORTER_BEAN_NAME) Reporter<Span> stackdriverReporter) {
     return ZipkinSpanHandler.create(stackdriverReporter);
   }
 
@@ -166,12 +167,12 @@ public class StackdriverTraceAutoConfiguration {
 
   @Bean(REPORTER_BEAN_NAME)
   @ConditionalOnMissingBean(name = REPORTER_BEAN_NAME)
-  public AsyncReporter<zipkin2.Span> stackdriverReporter(
+  public AsyncReporter<Span> stackdriverReporter(
       ReporterMetrics reporterMetrics,
       GcpTraceProperties trace,
       @Qualifier(SENDER_BEAN_NAME) StackdriverSender sender) {
 
-    AsyncReporter<zipkin2.Span> asyncReporter =
+    AsyncReporter<Span> asyncReporter =
         AsyncReporter.builder(sender)
             // historical constraint. Note: AsyncReporter supports memory bounds
             .queuedMaxSpans(1000)

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfiguration.java
@@ -16,8 +16,10 @@
 
 package com.google.cloud.spring.autoconfigure.trace;
 
+import brave.Tags;
 import brave.TracingCustomizer;
 import brave.baggage.BaggagePropagation;
+import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.propagation.B3Propagation;
 import brave.propagation.Propagation;
@@ -49,16 +51,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import zipkin2.Span;
-import zipkin2.reporter.AsyncReporter;
-import zipkin2.reporter.CheckResult;
-import zipkin2.reporter.Reporter;
+import zipkin2.reporter.BytesEncoder;
 import zipkin2.reporter.ReporterMetrics;
-import zipkin2.reporter.SpanBytesEncoder;
-import zipkin2.reporter.brave.ZipkinSpanHandler;
+import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
 import zipkin2.reporter.stackdriver.StackdriverSender;
 import zipkin2.reporter.stackdriver.StackdriverSender.Builder;
-import zipkin2.reporter.stackdriver.zipkin.StackdriverEncoder;
+import zipkin2.reporter.stackdriver.brave.StackdriverV2Encoder;
 
 /** Config for Stackdriver Trace. */
 @AutoConfiguration
@@ -73,15 +71,14 @@ public class StackdriverTraceAutoConfiguration {
   private static final Log LOGGER = LogFactory.getLog(StackdriverTraceAutoConfiguration.class);
 
   /**
-   * Stackdriver reporter bean name. Name of the bean matters for supporting multiple tracing
-   * systems.
+   * Stackdriver sender bean name. Name of the bean matters for supporting multiple tracing systems.
    */
-  public static final String REPORTER_BEAN_NAME = "stackdriverReporter";
+  public static final String SENDER_BEAN_NAME = "stackdriverSender";
 
   /**
    * Stackdriver sender bean name. Name of the bean matters for supporting multiple tracing systems.
    */
-  public static final String SENDER_BEAN_NAME = "stackdriverSender";
+  public static final String ENCODER_BEAN_NAME = "stackdriverEncoder";
 
   /**
    * Stackdriver span handler bean name. Name of the bean matters for supporting multiple tracing
@@ -127,9 +124,10 @@ public class StackdriverTraceAutoConfiguration {
 
   @Bean(SPAN_HANDLER_BEAN_NAME)
   @ConditionalOnMissingBean(name = SPAN_HANDLER_BEAN_NAME)
-  public SpanHandler stackdriverSpanHandler(
-      @Qualifier(REPORTER_BEAN_NAME) Reporter<Span> stackdriverReporter) {
-    return ZipkinSpanHandler.create(stackdriverReporter);
+  public AsyncZipkinSpanHandler stackdriverSpanHandler(
+      @Qualifier(SENDER_BEAN_NAME) StackdriverSender sender,
+      @Qualifier(ENCODER_BEAN_NAME) BytesEncoder<MutableSpan> encoder) {
+    return AsyncZipkinSpanHandler.newBuilder(sender).build(encoder);
   }
 
   @Bean
@@ -163,30 +161,6 @@ public class StackdriverTraceAutoConfiguration {
     return ManagedChannelBuilder.forTarget("dns:///cloudtrace.googleapis.com")
         .userAgent(this.headerProvider.getUserAgent())
         .build();
-  }
-
-  @Bean(REPORTER_BEAN_NAME)
-  @ConditionalOnMissingBean(name = REPORTER_BEAN_NAME)
-  public AsyncReporter<Span> stackdriverReporter(
-      ReporterMetrics reporterMetrics,
-      GcpTraceProperties trace,
-      @Qualifier(SENDER_BEAN_NAME) StackdriverSender sender) {
-
-    AsyncReporter<Span> asyncReporter =
-        AsyncReporter.builder(sender)
-            // historical constraint. Note: AsyncReporter supports memory bounds
-            .queuedMaxSpans(1000)
-            .messageTimeout(trace.getMessageTimeout(), TimeUnit.SECONDS)
-            .metrics(reporterMetrics)
-            .build(StackdriverEncoder.V2);
-
-    CheckResult checkResult = asyncReporter.check();
-    if (!checkResult.ok()) {
-      LOGGER.warn(
-          "Error when performing Stackdriver AsyncReporter health check.", checkResult.error());
-    }
-
-    return asyncReporter;
   }
 
   @Bean(SENDER_BEAN_NAME)
@@ -251,11 +225,10 @@ public class StackdriverTraceAutoConfiguration {
     return BaggagePropagation.newFactoryBuilder(StackdriverTracePropagation.newFactory(primary));
   }
 
-  // Add this bean to suppress other encoding schema, e.g., JSON.
-  @Bean
-  @ConditionalOnMissingBean
-  public SpanBytesEncoder spanBytesEncoder() {
-    return SpanBytesEncoder.PROTO3;
+  @Bean(ENCODER_BEAN_NAME)
+  @ConditionalOnMissingBean(name = ENCODER_BEAN_NAME)
+  public BytesEncoder<MutableSpan> spanBytesEncoder() {
+    return new StackdriverV2Encoder(Tags.ERROR);
   }
 
   @PreDestroy

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/StackdriverTraceAutoConfigurationTests.java
@@ -62,6 +62,7 @@ import zipkin2.reporter.Encoding;
 import zipkin2.reporter.SpanBytesEncoder;
 import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
 import zipkin2.reporter.stackdriver.StackdriverSender;
+import zipkin2.reporter.stackdriver.brave.StackdriverV2Encoder;
 
 /** Tests for auto-config. */
 class StackdriverTraceAutoConfigurationTests {
@@ -105,7 +106,7 @@ class StackdriverTraceAutoConfigurationTests {
         .run(
             context -> assertThat(
                 context.getBean(BytesEncoder.class))
-                .isEqualTo(SpanBytesEncoder.PROTO3));
+                .isInstanceOf(StackdriverV2Encoder.class));
   }
 
   @Test

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/TracePubSubAutoConfigurationTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/TracePubSubAutoConfigurationTest.java
@@ -45,6 +45,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import zipkin2.reporter.Reporter;
 import zipkin2.reporter.Sender;
+import zipkin2.reporter.stackdriver.StackdriverSender;
 
 /** Tests for Trace Pub/Sub auto-config. */
 class TracePubSubAutoConfigurationTest {
@@ -78,7 +79,7 @@ class TracePubSubAutoConfigurationTest {
     this.contextRunner.run(
         context -> {
           assertThat(
-                  context.getBean(StackdriverTraceAutoConfiguration.SENDER_BEAN_NAME, Sender.class))
+                  context.getBean(StackdriverTraceAutoConfiguration.SENDER_BEAN_NAME, StackdriverSender.class))
               .isNotNull();
           assertThat(context.getBean(ManagedChannel.class)).isNotNull();
         });

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/TracePubSubAutoConfigurationTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/trace/pubsub/TracePubSubAutoConfigurationTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spring.autoconfigure.trace.pubsub;
 
-import static com.google.cloud.spring.autoconfigure.trace.StackdriverTraceAutoConfiguration.REPORTER_BEAN_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -68,8 +67,6 @@ class TracePubSubAutoConfigurationTest {
                 StackdriverTraceAutoConfiguration.SPAN_HANDLER_BEAN_NAME,
                 SpanHandler.class,
                 () -> SpanHandler.NOOP)
-            // Prevent health-check from triggering a real call to Trace.
-            .withBean(REPORTER_BEAN_NAME, Reporter.class, () -> mock(Reporter.class))
             .withPropertyValues(
                 "spring.cloud.gcp.project-id=proj");
   }

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/repository/query/PartTreeDatastoreQueryTests.java
@@ -73,6 +73,7 @@ import org.springframework.data.projection.ProjectionInformation;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
 import org.springframework.data.repository.query.DefaultParameters;
+import org.springframework.data.repository.query.ParametersSource;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 
@@ -1058,7 +1059,7 @@ class PartTreeDatastoreQueryTests {
           boolean mockOptionalNullable,
           ProjectionInformation projectionInformation) {
     when(this.queryMethod.getName()).thenReturn(queryName);
-    doReturn(new DefaultParameters(m)).when(this.queryMethod).getParameters();
+    doReturn(new DefaultParameters(ParametersSource.of(m))).when(this.queryMethod).getParameters();
     if (mockOptionalNullable) {
       DefaultRepositoryMetadata mockMetadata = mock(DefaultRepositoryMetadata.class);
       doReturn(m.getReturnType()).when(mockMetadata).getReturnedDomainClass(m);

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
@@ -51,6 +51,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.repository.query.DefaultParameters;
+import org.springframework.data.repository.query.ParametersSource;
 
 /** Tests Spanner statement queries. */
 class SpannerStatementQueryTests {
@@ -173,7 +174,7 @@ class SpannerStatementQueryTests {
             List.class,
             BigDecimal.class);
     when(this.queryMethod.getQueryMethod()).thenReturn(method);
-    doReturn(new DefaultParameters(method)).when(this.queryMethod).getParameters();
+    doReturn(new DefaultParameters(ParametersSource.of(method))).when(this.queryMethod).getParameters();
 
     this.partTreeSpannerQuery.execute(params);
     verify(this.spannerTemplate, times(1)).query((Class<Object>) any(), any(), any());
@@ -221,7 +222,7 @@ class SpannerStatementQueryTests {
             Object.class,
             Object.class,
             Object.class);
-    doReturn(new DefaultParameters(method)).when(this.queryMethod).getParameters();
+    doReturn(new DefaultParameters(ParametersSource.of(method))).when(this.queryMethod).getParameters();
 
     when(this.spannerTemplate.query((Function<Struct, Object>) any(), any(), any()))
         .thenAnswer(
@@ -295,7 +296,7 @@ class SpannerStatementQueryTests {
     when(this.spannerTemplate.query((Function<Struct, Object>) any(), any(), any()))
         .thenReturn(Collections.singletonList(1L));
 
-    doReturn(new DefaultParameters(method)).when(this.queryMethod).getParameters();
+    doReturn(new DefaultParameters(ParametersSource.of(method))).when(this.queryMethod).getParameters();
 
     when(this.spannerTemplate.query((Class) any(), any(), any()))
         .thenAnswer(
@@ -340,7 +341,7 @@ class SpannerStatementQueryTests {
     when(this.spannerTemplate.query((Function<Struct, Object>) any(), any(), any()))
         .thenReturn(Collections.singletonList(1L));
 
-    doReturn(new DefaultParameters(method)).when(this.queryMethod).getParameters();
+    doReturn(new DefaultParameters(ParametersSource.of(method))).when(this.queryMethod).getParameters();
 
     when(this.spannerTemplate.query((Class) any(), any(), any()))
         .thenAnswer(
@@ -377,7 +378,7 @@ class SpannerStatementQueryTests {
     this.partTreeSpannerQuery = createQuery();
     Method method =
         QueryHolder.class.getMethod("repositoryMethod4", Object.class, Object.class, Object.class);
-    doReturn(new DefaultParameters(method)).when(this.queryMethod).getParameters();
+    doReturn(new DefaultParameters(ParametersSource.of(method))).when(this.queryMethod).getParameters();
 
     // There are too few params specified, so the exception will occur.
     Object[] params =
@@ -408,7 +409,7 @@ class SpannerStatementQueryTests {
             Trade.class,
             Object.class);
 
-    doReturn(new DefaultParameters(method)).when(this.queryMethod).getParameters();
+    doReturn(new DefaultParameters(ParametersSource.of(method))).when(this.queryMethod).getParameters();
 
     // This parameter is an unsupported type for Spanner SQL.
     Object[] params =
@@ -426,7 +427,7 @@ class SpannerStatementQueryTests {
   void unSupportedPredicateTest() throws NoSuchMethodException {
     when(this.queryMethod.getName()).thenReturn("countByTraderIdBetween");
     Method method = Object.class.getMethod("toString");
-    doReturn(new DefaultParameters(method)).when(this.queryMethod).getParameters();
+    doReturn(new DefaultParameters(ParametersSource.of(method))).when(this.queryMethod).getParameters();
 
     this.partTreeSpannerQuery = createQuery();
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
@@ -69,6 +69,7 @@ import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.repository.query.DefaultParameters;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.query.Parameters;
+import org.springframework.data.repository.query.ParametersSource;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
@@ -174,7 +175,7 @@ class SqlSpannerQueryTests {
     Method method = QueryHolder.class.getMethod("dummyMethod2");
     when(this.queryMethod.getQueryMethod()).thenReturn(method);
     Mockito.<Parameters>when(this.queryMethod.getParameters())
-        .thenReturn(new DefaultParameters(method));
+        .thenReturn(new DefaultParameters(ParametersSource.of(method)));
 
     sqlSpannerQuery.execute(new Object[] {});
 
@@ -240,7 +241,7 @@ class SqlSpannerQueryTests {
         QueryHolder.class.getMethod("dummyMethod4", String.class, String.class, Pageable.class);
     when(this.queryMethod.getQueryMethod()).thenReturn(method);
     Mockito.<Parameters>when(this.queryMethod.getParameters())
-        .thenReturn(new DefaultParameters(method));
+        .thenReturn(new DefaultParameters(ParametersSource.of(method)));
 
     sqlSpannerQuery.execute(params);
 
@@ -303,7 +304,7 @@ class SqlSpannerQueryTests {
         QueryHolder.class.getMethod("dummyMethod5", String.class, String.class, Sort.class);
     when(this.queryMethod.getQueryMethod()).thenReturn(method);
     Mockito.<Parameters>when(this.queryMethod.getParameters())
-        .thenReturn(new DefaultParameters(method));
+        .thenReturn(new DefaultParameters(ParametersSource.of(method)));
 
     sqlSpannerQuery.execute(params);
 
@@ -367,7 +368,7 @@ class SqlSpannerQueryTests {
             "sortAndPageable", String.class, String.class, Sort.class, Pageable.class);
     when(this.queryMethod.getQueryMethod()).thenReturn(method);
     Mockito.<Parameters>when(this.queryMethod.getParameters())
-        .thenReturn(new DefaultParameters(method));
+        .thenReturn(new DefaultParameters(ParametersSource.of(method)));
 
     sqlSpannerQuery.execute(params);
 
@@ -499,7 +500,7 @@ class SqlSpannerQueryTests {
             List.class);
     when(this.queryMethod.getQueryMethod()).thenReturn(method);
     Mockito.<Parameters>when(this.queryMethod.getParameters())
-        .thenReturn(new DefaultParameters(method));
+        .thenReturn(new DefaultParameters(ParametersSource.of(method)));
     sqlSpannerQuery.execute(params);
 
     verify(this.spannerTemplate, times(1)).executeQuery(any(), any());
@@ -523,7 +524,7 @@ class SqlSpannerQueryTests {
     Method method = QueryHolder.class.getMethod("noParamMethod");
 
     Mockito.<Parameters>when(this.queryMethod.getParameters())
-        .thenReturn(new DefaultParameters(method));
+        .thenReturn(new DefaultParameters(ParametersSource.of(method)));
 
     SqlSpannerQuery sqlSpannerQuery = spy(createQuery(sql, Trade.class, true));
 
@@ -592,7 +593,7 @@ class SqlSpannerQueryTests {
     Method method = QueryHolder.class.getMethod("dummyMethod3", String.class, String.class);
     when(this.queryMethod.getQueryMethod()).thenReturn(method);
     Mockito.<Parameters>when(this.queryMethod.getParameters())
-        .thenReturn(new DefaultParameters(method));
+        .thenReturn(new DefaultParameters(ParametersSource.of(method)));
 
     when(sqlSpannerQuery.getReturnedSimpleConvertableItemType()).thenReturn(long.class);
 
@@ -642,7 +643,7 @@ class SqlSpannerQueryTests {
         QueryHolder.class.getMethod("dummyMethod6", String.class);
     when(this.queryMethod.getQueryMethod()).thenReturn(arrayParameterTriggeringMethod);
     Mockito.<Parameters>when(this.queryMethod.getParameters())
-        .thenReturn(new DefaultParameters(arrayParameterTriggeringMethod));
+        .thenReturn(new DefaultParameters(ParametersSource.of(arrayParameterTriggeringMethod)));
 
     sqlSpannerQuery.execute(params);
     // capturing the row function and verifying it's the correct one with mock data
@@ -705,7 +706,7 @@ class SqlSpannerQueryTests {
         QueryHolder.class.getMethod("dummyMethod6", String.class);
     when(this.queryMethod.getQueryMethod()).thenReturn(arrayParameterTriggeringMethod);
     Mockito.<Parameters>when(this.queryMethod.getParameters())
-        .thenReturn(new DefaultParameters(arrayParameterTriggeringMethod));
+        .thenReturn(new DefaultParameters(ParametersSource.of(arrayParameterTriggeringMethod)));
 
     sqlSpannerQuery.execute(params);
     // capturing the row function and verifying it's the correct one with mock data

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.5</version>
+		<version>3.3.0</version>
 		<relativePath/>
 	</parent>
 

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1</version>
 		<relativePath/>
 	</parent>
 

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-trace/pom.xml
@@ -57,6 +57,10 @@
 			<artifactId>brave-propagation-stackdriver</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.zipkin.gcp</groupId>
+			<artifactId>brave-encoder-stackdriver</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-core-grpc</artifactId>
 			<exclusions>


### PR DESCRIPTION
Note some questionable changes:

1. Changing the `Sender` bean to `StackdriverSender` due to the change in zipkin-gcp shown here: https://github.com/openzipkin/zipkin-gcp/pull/214/files
  * `StackdriverSender` does not extend `Sender`.
  * However, this is consistent with Spring Boot's upgrade: https://github.com/spring-projects/spring-boot/pull/39049/files

2. `SpanBytesEncoder` has changed packages.

3. `StackdriverEncoder` has changed packages - and as indicated in https://github.com/openzipkin/zipkin-gcp/releases/tag/2.0.0 we are now using `StackdriverV2Encoder` to eliminate the direct dependency on `io.zipkin.zipkin2:zipkin`.