### PR TITLE
Revert "deps: bump cloud-sql-socket-factory.version from 1.18.0 to 1.18.1"

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -35,7 +35,7 @@
 
 	<properties>
 		<gcp-libraries-bom.version>26.39.0</gcp-libraries-bom.version>
-		<cloud-sql-socket-factory.version>1.18.1</cloud-sql-socket-factory.version>
+		<cloud-sql-socket-factory.version>1.18.0</cloud-sql-socket-factory.version>
 		<r2dbc-postgres-driver.version>1.0.5.RELEASE</r2dbc-postgres-driver.version>
 		<cloud-spanner-r2dbc.version>1.3.0</cloud-spanner-r2dbc.version>
 	</properties>


### PR DESCRIPTION
Reverts GoogleCloudPlatform/spring-cloud-gcp#2885

The following error occurs in native test CI.
```
Error: Could not find option 'BuildReport' from 'jar:file:///home/runner/.m2/repository/com/google/cloud/sql/jdbc-socket-factory-core/1.18.1/jdbc-socket-factory-core-1.18.1.jar!/META-INF/native-image/com.google.cloud.sql/cloud-sql-jdbc-socket-factory-parent/native-image.properties'. Use -H:PrintFlags= to list all available options.
Could not find option 'UnlockExperimentalVMOptions' from 'jar:file:///home/runner/.m2/repository/com/google/cloud/sql/jdbc-socket-factory-core/1.18.1/jdbc-socket-factory-core-1.18.1.jar!/META-INF/native-image/com.google.cloud.sql/cloud-sql-jdbc-socket-factory-parent/native-image.properties'. Use -H:PrintFlags= to list all available options.
Error: Image build request failed with exit status 1
```