### PR TITLE
chore: remove micrometer-tracing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
 		<spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
 		<zipkin-gcp.version>1.1.1</zipkin-gcp.version>
 		<java-cfenv.version>2.5.0</java-cfenv.version>
-		<micrometer-tracing.verison>1.3.0</micrometer-tracing.verison>
 
 		<!-- Plugin versions -->
 		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
@@ -145,14 +144,6 @@
 				<groupId>io.pivotal.cfenv</groupId>
 				<artifactId>java-cfenv-test-support</artifactId>
 				<version>${java-cfenv.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>io.micrometer</groupId>
-				<artifactId>micrometer-tracing-bom</artifactId>
-				<version>${micrometer-tracing.verison}</version>
-				<type>pom</type>
-				<scope>import</scope>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
In this PR:
- Remove `micrometer-tracing-bom` from pom.xml because this dependency is managed by spring-boot.