### PR TITLE
chore: fix autoconfig module generation

### DIFF
--- a/spring-cloud-generator/scripts/generate-library-list.sh
+++ b/spring-cloud-generator/scripts/generate-library-list.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 # If not set, assume working directory is spring-cloud-generator
 if [[ -z "$SPRING_GENERATOR_DIR" ]]; then
   SPRING_GENERATOR_DIR=`pwd`
@@ -27,7 +29,7 @@ echo "# library_name, googleapis_location, coordinates_version, monorepo_folder"
 # Note that this logic will not work for non-cloud APIs
 count=0
 
-configs=$(yq eval '.libraries[]' -o=json ./google-cloud-java/generation_config.yaml)
+configs=$(yq '.libraries[]' ./google-cloud-java/generation_config.yaml)
 # Properly format the configs as a JSON array
 # This includes adding commas between objects and wrapping everything in square brackets
 json_array="[ $(echo "$configs" | tr '\n' ' ' | sed 's/} {/}, {/g') ]"

--- a/spring-cloud-generator/scripts/resources/manual_modules_exclusion_list.txt
+++ b/spring-cloud-generator/scripts/resources/manual_modules_exclusion_list.txt
@@ -1,4 +1,4 @@
-# this is a list of libraries that are already in the spring-cloud-gcp-starters folder and will be ignored by generate-library-list.sh
+# this is a list of libraries that are either already in the spring-cloud-gcp-starters folder or are proto only libraries and will be ignored by generate-library-list.sh
 google-cloud-bigquery
 google-cloud-pubsub
 google-cloud-datastore
@@ -11,3 +11,5 @@ google-cloud-secretmanager
 google-cloud-resourcemanager
 google-cloud-storage
 google-cloud-vision
+google-cloud-alloydb-connectors
+google-cloud-gke-connect-gateway


### PR DESCRIPTION
This fixes the autoconfig generation by excluding two libraries that do not have a `java_gapic_library` rule in their BUILD.bazel files ([example](https://github.com/googleapis/googleapis/blob/master/google/cloud/alloydb/connectors/v1/BUILD.bazel) for alloydbconnectors).