### PR TITLE
fix: Revert "deps: bump org.springframework.boot:spring-boot-starter-parent from 3.2.5 to 3.3.1"

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.1</version>
+		<version>3.2.5</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/spring-cloud-gcp#2975