### PR TITLE
chore: use showcase autoconfig check only on PRs against `main`

### DIFF
--- a/.github/workflows/showcaseTests.yaml
+++ b/.github/workflows/showcaseTests.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
     paths:
       - 'spring-cloud-generator/**'
+    branches:
+      - 'main'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This prevents the check from showing on PRs that target other release branches (`3.x` and `4.x`)