### PR TITLE
docs: update compatibility table

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,10 +54,29 @@ This project has dependency and transitive dependencies on Spring Projects. The 
 |===
 | Spring Framework on Google Cloud | Spring Cloud | Spring Boot | Spring Framework | Supported
 
-|5.x | https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2023.0-Release-Notes[2023.0.x] (Leyton) |https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.2-Release-Notes[3.2.x]| https://github.com/spring-projects/spring-framework/wiki/What%27s-New-in-Spring-Framework-6.x#whats-new-in-version-61[6.1.x]| Yes
-|4.x | https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2022.0-Release-Notes[2022.0.x] (Kilburn) |https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes[3.0.x], https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.1-Release-Notes[3.1.x]| https://github.com/spring-projects/spring-framework/wiki/What%27s-New-in-Spring-Framework-6.x#whats-new-in-version-60[6.x]| Yes
-|3.x | https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2021.0-Release-Notes[2021.0.x] (Jubilee) |2.6.x, 2.7.x | 5.3.x| Yes
-|2.0.x |https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2020.0-Release-Notes[2020.0.x] (Ilford) |2.4.x, 2.5.x|5.3.x| No
+|5.x
+|https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2023.0-Release-Notes[2023.0.x] (Leyton)
+|https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.2-Release-Notes[3.2.x], https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.3-Release-Notes[3.3.x]
+|https://github.com/spring-projects/spring-framework/wiki/What%27s-New-in-Spring-Framework-6.x#whats-new-in-version-61[6.1.x]
+|Yes
+
+|4.x
+|https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2022.0-Release-Notes[2022.0.x] (Kilburn)
+|https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes[3.0.x], https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.1-Release-Notes[3.1.x]
+|https://github.com/spring-projects/spring-framework/wiki/What%27s-New-in-Spring-Framework-6.x#whats-new-in-version-60[6.0.x]
+|Yes
+
+|3.x
+|https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2021.0-Release-Notes[2021.0.x] (Jubilee)
+|https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes[2.6.x], https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes[2.7.x]
+|https://github.com/spring-projects/spring-framework/wiki/What%27s-New-in-Spring-Framework-5.x#whats-new-in-version-53[5.3.x]
+|Yes
+
+|2.x
+|https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2020.0-Release-Notes[2020.0.x] (Ilford)
+|https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes[2.4.x], https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes[2.5.x]
+|https://github.com/spring-projects/spring-framework/wiki/What%27s-New-in-Spring-Framework-5.x#whats-new-in-version-53[5.3.x]
+|No
 |===
 
 == Spring Initializr


### PR DESCRIPTION
This pull request adds the recently released Spring Boot 3.3.x to the compatibility table. Just like Spring Boot 3.2.x, Spring Boot 3.3.x is compatible with Spring Cloud 2023.0.x and Spring Framework 6.1.x.

I've also included these minor improvements in this PR:

- More precise Spring Framework compatibility for Spring Cloud GCP 4.x: 6.x → 6.0.x
- Spring Cloud GCP 2.0.x → 2.x, for consistency with the other $MAJOR.x entries
- Added links for all versions