### PR TITLE
chore(test): update protobuf version in spring-cloud-generator to 3.25.3

### DIFF
--- a/spring-cloud-generator/pom.xml
+++ b/spring-cloud-generator/pom.xml
@@ -18,7 +18,7 @@
         <gapic-generator-java-bom.version>2.41.0</gapic-generator-java-bom.version>
         <!-- [gapic-test]: protobuf.version for compiling protos used in unit testing
              this should be consistent with version in gapic-generator-java-bom -->
-        <protobuf.version>3.23.2</protobuf.version>
+        <protobuf.version>3.25.3</protobuf.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This has been out of sync for a while. Update to be consistent with [gapic-generator-java](https://github.com/renovate-bot/gapic-generator-java/blob/308aeafc9f04795d2e1df8206c84689b11c4323a/gapic-generator-java-pom-parent/pom.xml#L34)