### PR TITLE
ci: use dependabot config wildcards to cover all boot and cloud artifacts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,24 +40,12 @@ updates:
     - dependency-name: "com.google.googlejavaformat:google-java-format"
     # Ignore dependencies that will be manually upgraded with Spring Boot 3.0 support: 
     # Spring Boot dependencies
-    - dependency-name: "org.springframework.boot:spring-boot-dependencies"
-      versions: ["3.x"]
-    - dependency-name: "org.springframework.boot:spring-boot-starter-parent"
+    - dependency-name: "org.springframework.boot:spring-boot-*"
       versions: ["3.x"]
     # Spring Cloud dependencies
-    - dependency-name: "org.springframework.cloud:spring-cloud-dependencies"
-      versions: ["2022.x", "2023.x"]
     # spring-cloud-dependencies-parent should be eventually removed per #1294
-    - dependency-name: "org.springframework.cloud:spring-cloud-dependencies-parent"
-      versions: ["4.x"]
-    - dependency-name: "org.springframework.cloud:spring-cloud-config"
-      versions: ["4.x"]
-    - dependency-name: "org.springframework.cloud:spring-cloud-config-dependencies"
-      versions: ["4.x"]
-    - dependency-name: "org.springframework.cloud:spring-cloud-function"
-      versions: ["4.x"]
-    - dependency-name: "org.springframework.cloud:spring-cloud-starter-bootstrap"
-      versions: ["4.x"]
+    - dependency-name: "org.springframework.cloud:spring-cloud-*"
+      versions: ["2022.x", "2023.x", "4.x"]
     # Spring Shell dependencies
     - dependency-name: "org.springframework.shell:spring-shell-starter"
       versions: ["3.x"]
@@ -84,21 +72,11 @@ updates:
     - dependency-name: "com.google.googlejavaformat:google-java-format"
     # Ignore dependencies corresponding to Spring Boot 3.2+, Spring Cloud 2023.x:
     # Spring Boot dependencies
-    - dependency-name: "org.springframework.boot:spring-boot-dependencies"
-      versions: [">=3.2.0"]
-    - dependency-name: "org.springframework.boot:spring-boot-starter-parent"
+    - dependency-name: "org.springframework.boot:spring-boot-*"
       versions: [">=3.2.0"]
     # Spring Cloud dependencies
-    - dependency-name: "org.springframework.cloud:spring-cloud-dependencies"
+    - dependency-name: "org.springframework.cloud:spring-cloud-*"
       versions: ["2023.x"]
-    - dependency-name: "org.springframework.cloud:spring-cloud-config"
-      versions: [">=4.1.0"]
-    - dependency-name: "org.springframework.cloud:spring-cloud-config-dependencies"
-      versions: [">=4.1.0"]
-    - dependency-name: "org.springframework.cloud:spring-cloud-function"
-      versions: [">=4.1.0"]
-    - dependency-name: "org.springframework.cloud:spring-cloud-starter-bootstrap"
-      versions: [">=4.1.0"]
     # Spring Shell dependencies
     - dependency-name: "org.springframework.shell:spring-shell-starter"
       versions: [">=3.2.0"]


### PR DESCRIPTION
I'm hoping this will prevent dependabot PRs like this one which are incorrectly trying to update 4.x's Spring Boot version due to some un-ignored dependencies having updates: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/2995