### PR TITLE
docs: add Google Cloud Support link to new issues templates and choices

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,10 @@ labels: waiting-for-triage
 assignees: ''
 
 ---
+**PLEASE READ**: If you have a support contract with Google, please create an issue in the 
+[support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure 
+a timely response.
+
 We'd love to accept your patches and contributions to this project. There are just a few small
 guidelines you need to follow before opening an issue or a PR:
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Google Cloud Support
+    url: https://cloud.google.com/support/
+    about: If you have a support contract with Google, please use the Google Cloud Support portal.


### PR DESCRIPTION
config.yml mirrors https://github.com/googleapis/google-cloud-java/blob/main/.github/ISSUE_TEMPLATE/config.yml