### PR TITLE
deps: Update Java client library dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<maven-failsafe-plugin.version>3.3.1</maven-failsafe-plugin.version>
 		<maven-flatten-plugin.version>1.6.0</maven-flatten-plugin.version>
-		<maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
+		<maven-gpg-plugin.version>3.2.5</maven-gpg-plugin.version>
 		<maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
 		<maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
 		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>
@@ -174,7 +174,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -34,7 +34,7 @@
 	</distributionManagement>
 
 	<properties>
-		<gcp-libraries-bom.version>26.43.0</gcp-libraries-bom.version>
+		<gcp-libraries-bom.version>26.44.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.19.1</cloud-sql-socket-factory.version>
 		<r2dbc-postgres-driver.version>1.0.5.RELEASE</r2dbc-postgres-driver.version>
 		<cloud-spanner-r2dbc.version>1.3.0</cloud-spanner-r2dbc.version>
@@ -319,7 +319,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.4</version>
+						<version>3.2.5</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-alloydb-sample/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-config-sample/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-basic-sample/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-template-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-template-sample/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-json-sample/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-polling-receiver/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-polling-receiver/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-pubsub-sample/spring-cloud-gcp-integration-pubsub-sample-receiver/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-logging-sample/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-metrics-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-metrics-sample/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>4.2.1</version>
+      <version>4.2.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-reactive-sample/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-sample/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-dead-letter-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-stream-dead-letter-sample/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-security-iap-sample/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-mysql-sample/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-sql-postgres-sample/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-starter-firestore-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-starter-firestore-sample/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-trace-sample/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-api-sample/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-vision-ocr-demo/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-vision-ocr-demo/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.2.1</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-generator/pom.xml
+++ b/spring-cloud-generator/pom.xml
@@ -15,7 +15,7 @@
     <description>Spring Code Generator for Google Cloud</description>
 
     <properties>
-        <gapic-generator-java-bom.version>2.42.0</gapic-generator-java-bom.version>
+        <gapic-generator-java-bom.version>2.43.0</gapic-generator-java-bom.version>
         <!-- [gapic-test]: protobuf.version for compiling protos used in unit testing
              this should be consistent with version in gapic-generator-java-bom -->
         <protobuf.version>3.25.3</protobuf.version>


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE 
chore(deps): update dependency org.apache.maven.plugins:maven-gpg-plugin to v3.2.5
 chore(deps): update dependency org.apache.maven.plugins:maven-gpg-plugin to v3.2.5
 chore(deps): update dependency org.awaitility:awaitility to v4.2.2
 chore(deps): update gapic-generator-java-bom.version to v2.43.0 (com.google.api:gapic-generator-java, com.google.api:gapic-generator-java-bom)
 fix(deps): update dependency com.google.cloud:libraries-bom to v26.44.0
END_COMMIT_OVERRIDE