### PR TITLE
fix: Don't try to access blob if autocreate is enabled

### DIFF
--- a/spring-cloud-gcp-storage/src/main/java/com/google/cloud/spring/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/com/google/cloud/spring/storage/GoogleStorageResource.java
@@ -320,10 +320,12 @@ public class GoogleStorageResource implements WritableResource {
           "Cannot open an output stream to a bucket: '" + getURI() + "'");
     }
 
-    Blob blob = getBlob();
+    if (!this.autoCreateFiles) {
+      Blob blob = getBlob();
 
-    if ((blob == null || !blob.exists()) && !this.autoCreateFiles) {
-      throw new FileNotFoundException("The blob was not found: " + getURI());
+      if (blob == null || !blob.exists()) {
+        throw new FileNotFoundException("The blob was not found: " + getURI());
+      }
     }
 
     return Channels.newOutputStream(this.storage.writer(BlobInfo.newBuilder(getBlobId()).build()));


### PR DESCRIPTION
The account used to write the blob in Google Cloud Storage may not have the necessary permissions to also read the file. In this case the getOutputStream() implementation would be broken, and unconditionally throw a permission error.

Fix this by not accessing the blob if the autoCreateFiles option is enabled.
