### PR TITLE
fix: change to generation script in manipulating googleapis/WORKSPACE.

### DIFF
--- a/.github/workflows/showcaseTests.yaml
+++ b/.github/workflows/showcaseTests.yaml
@@ -43,6 +43,6 @@ jobs:
           bash scripts/generate-showcase.sh
       - name: Unit tests for showcase-spring-starter
         # Runs showcase-spring-starter unit tests
-        working-directory: spring-cloud-generator
+        working-directory: spring-cloud-generator/showcase/showcase-spring-starter
         run: |
-          cd showcase/showcase-spring-starter && mvn verify
+          ../../../mvnw verify

--- a/spring-cloud-generator/scripts/generate-steps.sh
+++ b/spring-cloud-generator/scripts/generate-steps.sh
@@ -91,7 +91,7 @@ function modify_workspace_file(){
   # delete existing maven_install rules
   buildozer 'delete' ${path_to_workspace}:%maven_install
   # add custom maven_install rules
-  perl -pi -e "s{(^_gapic_generator_java_version[^\n]*)}{\$1\n$(cat ${path_to_modification_string})}" ${path_to_workspace}
+  perl -pi -e "s{(^api_dependencies()[^\n]*)}{\$1\n$(cat ${path_to_modification_string})}" ${path_to_workspace}
 }
 
 # For individual library, set up bazel rules

--- a/spring-cloud-generator/scripts/resources/googleapis_modification_string.txt
+++ b/spring-cloud-generator/scripts/resources/googleapis_modification_string.txt
@@ -2,8 +2,11 @@ _spring_cloud_generator_version = "5.5.1-SNAPSHOT" # {x-version-update:spring-cl
 
 maven_install(
     artifacts = [
-        "com.google.cloud:spring-cloud-generator:" + _spring_cloud_generator_version,
-    ],
+      "com.google.cloud:spring-cloud-generator:" + _spring_cloud_generator_version,
+      ] +
+      IO_GRPC_GRPC_JAVA_ARTIFACTS,
+    generate_compat_repositories = True,
+    override_targets = IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS,
     #Update this False for local development
     fail_on_missing_checksum = False,
     repositories = [

--- a/spring-cloud-generator/showcase/showcase-spring-starter/src/test/java/com/google/showcase/v1beta1/spring/EchoAutoConfigurationTests.java
+++ b/spring-cloud-generator/showcase/showcase-spring-starter/src/test/java/com/google/showcase/v1beta1/spring/EchoAutoConfigurationTests.java
@@ -17,11 +17,10 @@
 package com.google.showcase.v1beta1.spring;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.TransportChannel;
@@ -189,27 +188,21 @@ class EchoAutoConfigurationTests {
 
   @Test
   void testCustomTransportChannelProviderUsedWhenProvided() throws IOException {
-    when(mockTransportChannelProvider.getTransportName()).thenReturn("grpc");
-    when(mockTransportChannelProvider.getTransportChannel()).thenReturn(mockTransportChannel);
-    when(mockTransportChannel.getEmptyCallContext()).thenReturn(mockApiCallContext);
-    // Mock no-ops for ApiCallContext since this test only intends to verify override of
-    // TransportChannelProvider bean
-    when(mockApiCallContext.withCredentials(any())).thenReturn(mockApiCallContext);
-    when(mockApiCallContext.withTransportChannel(any())).thenReturn(mockApiCallContext);
-    when(mockApiCallContext.withStreamWaitTimeoutDuration(any())).thenReturn(mockApiCallContext);
-    when(mockApiCallContext.withStreamIdleTimeoutDuration(any())).thenReturn(mockApiCallContext);
-    when(mockApiCallContext.withEndpointContext(any())).thenReturn(mockApiCallContext);
-
+    InstantiatingGrpcChannelProvider channelProvider =
+        InstantiatingGrpcChannelProvider.newBuilder()
+            .setEndpoint("localhost:7469")
+            .setMaxInboundMessageSize(Integer.MAX_VALUE)
+            .build();
     contextRunner
         .withBean(
             TRANSPORT_CHANNEL_PROVIDER_QUALIFIER_NAME,
             TransportChannelProvider.class,
-            () -> mockTransportChannelProvider)
+            () -> channelProvider)
         .run(
             ctx -> {
               EchoClient client = ctx.getBean(EchoClient.class);
               assertThat(client.getSettings().getTransportChannelProvider())
-                  .isSameAs(mockTransportChannelProvider);
+                  .isSameAs(channelProvider);
             });
   }
 

--- a/spring-cloud-generator/showcase/showcase-spring-starter/src/test/java/com/google/showcase/v1beta1/spring/EchoAutoConfigurationTests.java
+++ b/spring-cloud-generator/showcase/showcase-spring-starter/src/test/java/com/google/showcase/v1beta1/spring/EchoAutoConfigurationTests.java
@@ -196,8 +196,8 @@ class EchoAutoConfigurationTests {
     // TransportChannelProvider bean
     when(mockApiCallContext.withCredentials(any())).thenReturn(mockApiCallContext);
     when(mockApiCallContext.withTransportChannel(any())).thenReturn(mockApiCallContext);
-    when(mockApiCallContext.withStreamWaitTimeout(any())).thenReturn(mockApiCallContext);
-    when(mockApiCallContext.withStreamIdleTimeout(any())).thenReturn(mockApiCallContext);
+    when(mockApiCallContext.withStreamWaitTimeoutDuration(any())).thenReturn(mockApiCallContext);
+    when(mockApiCallContext.withStreamIdleTimeoutDuration(any())).thenReturn(mockApiCallContext);
     when(mockApiCallContext.withEndpointContext(any())).thenReturn(mockApiCallContext);
 
     contextRunner

--- a/spring-cloud-generator/showcase/showcase-spring-starter/src/test/java/com/google/showcase/v1beta1/spring/EchoAutoConfigurationTests.java
+++ b/spring-cloud-generator/showcase/showcase-spring-starter/src/test/java/com/google/showcase/v1beta1/spring/EchoAutoConfigurationTests.java
@@ -190,8 +190,6 @@ class EchoAutoConfigurationTests {
   void testCustomTransportChannelProviderUsedWhenProvided() throws IOException {
     InstantiatingGrpcChannelProvider channelProvider =
         InstantiatingGrpcChannelProvider.newBuilder()
-            .setEndpoint("localhost:7469")
-            .setMaxInboundMessageSize(Integer.MAX_VALUE)
             .build();
     contextRunner
         .withBean(


### PR DESCRIPTION
Need this adjustment due to changes in `googleapis/WORKSPACE` change [here](https://github.com/googleapis/googleapis/commit/cf16946acfefb6f5a33122802ebbaebf5bb45645).

To fix: 
Spring Auto Generation is failing: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/10376314314
```
[INFO] Scanning for projects...
Error: ] Some problems were encountered while processing the POMs:
Error:  Child module /home/runner/work/spring-cloud-gcp/spring-cloud-gcp/spring-cloud-previews/google-cloud-workstations-spring-starter of /home/runner/work/spring-cloud-gcp/spring-cloud-gcp/spring-cloud-previews/pom.xml does not exist @ 
Error:  Child module /home/runner/work/spring-cloud-gcp/spring-cloud-gcp/spring-cloud-previews/google-cloud-workflows-spring-starter of /home/runner/work/spring-cloud-gcp/spring-cloud-gcp/spring-cloud-previews/pom.xml does not exist @ 
Error:  Child module /home/runner/work/spring-cloud-gcp/spring-cloud-gcp/spring-cloud-previews/google-cloud-workflow-executions-spring-starter of /home/runner/work/spring-cloud-gcp/spring-cloud-gcp/spring-cloud-previews/pom.xml does not exist @ 
...
```

Root cause is due to location change of `maven_install` target in WORKSPACE, the substitution is done with `sed` command targeting after a previous line. This is not the right place to have this `maven_install` target anymore because it needs to come after [these lines](https://github.com/googleapis/googleapis/blob/906736032699b7e943ef2155edbda05470723647/WORKSPACE#L285-L291).

Generation process tested successfully in local.


Also added in this pr: 
--
- showcase test mock method changes due to internal workflow changes introduced by https://github.com/googleapis/sdk-platform-java/pull/1872