### PR TITLE
fix: noSuchMethodError in BigQuerySampleApplicationIntegrationTests #3140

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -298,6 +298,13 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+
+			<!-- spring dependency overrides -->
+			<dependency>
+				<groupId>io.opentelemetry</groupId>
+				<artifactId>opentelemetry-api</artifactId>
+				<version>1.32.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
This issue occurred due to a mismatch in the OpenTelemetry library include in the BigQuery google cloud library and the Open telemetry version included in sprint-boot.  Fix: add correct version of OpenTelemetry dependency in spring-cloud-gcp for google cloud libraries to work with older versions of spring.
