### PR TITLE
fix: Descendants entities losing database ID from parent (#3142)

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/util/KeyUtil.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/util/KeyUtil.java
@@ -46,6 +46,7 @@ public final class KeyUtil {
           Key.newBuilder(entityKey.getProjectId(), entityKey.getKind(), entityKey.getId());
     }
     ancestorLookupKey.setNamespace(entityKey.getNamespace());
+    ancestorLookupKey.setDatabaseId(entityKey.getDatabaseId());
 
     return ancestorLookupKey.build();
   }

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/util/KeyUtilTest.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/util/KeyUtilTest.java
@@ -47,4 +47,28 @@ class KeyUtilTest {
     Key processedKey = KeyUtil.getKeyWithoutAncestors(idKey);
     assertThat(processedKey.getAncestors()).isEmpty();
   }
+
+  @Test
+  void testAncestorKeys_containsAllDataStoreMetaData() {
+    String projectId = "project-id";
+    String kind = "kind";
+    Long id = 13L;
+    String databaseId = "database-id";
+    String namespace = "namespace";
+
+    Key idKey =
+            Key.newBuilder(projectId, kind, id, databaseId).setNamespace(namespace)
+                    .addAncestor(PathElement.of("person", 22L))
+                    .addAncestor(PathElement.of("person", 18L))
+                    .build();
+
+    Key processedKey = KeyUtil.getKeyWithoutAncestors(idKey);
+
+    assertThat(processedKey.getAncestors()).isEmpty();
+    assertThat(processedKey.getId()).isEqualTo(id);
+    assertThat(processedKey.getKind()).isEqualTo(kind);
+    assertThat(processedKey.getDatabaseId()).isEqualTo(databaseId);
+    assertThat(processedKey.getNamespace()).isEqualTo(namespace);
+    assertThat(processedKey.getProjectId()).isEqualTo(projectId);
+  }
 }

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/util/KeyUtilTest.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/util/KeyUtilTest.java
@@ -57,10 +57,11 @@ class KeyUtilTest {
     String namespace = "namespace";
 
     Key idKey =
-            Key.newBuilder(projectId, kind, id, databaseId).setNamespace(namespace)
-                    .addAncestor(PathElement.of("person", 22L))
-                    .addAncestor(PathElement.of("person", 18L))
-                    .build();
+        Key.newBuilder(projectId, kind, id, databaseId)
+            .setNamespace(namespace)
+            .addAncestor(PathElement.of("person", 22L))
+            .addAncestor(PathElement.of("person", 18L))
+            .build();
 
     Key processedKey = KeyUtil.getKeyWithoutAncestors(idKey);
 


### PR DESCRIPTION
If you override the default database ID and are using `@Descendants` annotation the database ID wasn't getting copied over when migrating keys from ancestor to child 
