### PR TITLE
feat: add properties to set universe domain and endpoint in bigquery

### DIFF
--- a/docs/src/main/asciidoc/bigquery.adoc
+++ b/docs/src/main/asciidoc/bigquery.adoc
@@ -38,6 +38,8 @@ The following application properties may be configured with Spring Framework on 
 | `spring.cloud.gcp.bigquery.credentials.location` | Credentials file location for authenticating with the Google Cloud BigQuery APIs, if different from the ones in the <<spring-cloud-gcp-core,Spring Framework on Google Cloud Core Module>> | No | Inferred from https://cloud.google.com/docs/authentication/production[Application Default Credentials], typically set by https://cloud.google.com/sdk/gcloud/reference/auth/application-default[`gcloud`].
 | `spring.cloud.gcp.bigquery.jsonWriterBatchSize` | Batch size which will be used by `BigQueryJsonDataWriter` while using https://cloud.google.com/bigquery/docs/write-api[BigQuery Storage Write API]. Note too large or too low values might impact performance. | No | 1000
 | `spring.cloud.gcp.bigquery.threadPoolSize` | The size of thread pool of `ThreadPoolTaskScheduler` which is used by `BigQueryTemplate` | No | 4
+| `spring.cloud.gcp.bigquery.universe-domain` | Universe domain of the Bigquery service. The universe domain is a part of the endpoint which is formatted as ${service}.${universeDomain}:${port} | Relies on client library’s default universe domain which is googleapis.com
+| `spring.cloud.gcp.bigquery.endpoint` | Endpoint of the Bigquery service. Follows the ${service}.${universeDomain}:${port} format for the BigqueryWriteClient otherwise reformats it to `https://${service}.${universeDomain}/` when setting it to Bigquery client. 
 |===========================================================================
 
 ==== BigQuery Client Object

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
@@ -162,14 +162,10 @@ public class GcpBigQueryAutoConfiguration {
   }
 
   private String resolveToHost(String endpoint) throws URISyntaxException {
-    if (!endpoint.contains("://")) {
-      endpoint = "https://" + endpoint;
+    int portIndex = endpoint.indexOf(":");
+    if (portIndex != -1){
+      return "https://" + endpoint.substring(0,portIndex) + "/";
     }
-    URI uri = new URI(endpoint);
-
-    // Construct the new URL with https:// and no port
-    String newUrl = new URI("https", uri.getUserInfo(), uri.getHost(), -1,
-        uri.getPath(), uri.getQuery(), uri.getFragment()).toString();
-    return newUrl;
+    return "https://" + endpoint + "/";
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
@@ -26,7 +26,6 @@ import com.google.cloud.spring.bigquery.core.BigQueryTemplate;
 import com.google.cloud.spring.core.DefaultCredentialsProvider;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.core.UserAgentHeaderProvider;
-import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
@@ -167,7 +167,7 @@ public class GcpBigQueryAutoConfiguration {
     }
     URI uri = new URI(endpoint);
 
-    // Construct the new URL with https and no port
+    // Construct the new URL with https:// and no port
     String newUrl = new URI("https", uri.getUserInfo(), uri.getHost(), -1,
         uri.getPath(), uri.getQuery(), uri.getFragment()).toString();
     return newUrl;

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
@@ -58,7 +58,9 @@ public class GcpBigQueryAutoConfiguration {
   private int threadPoolSize;
 
   private String universeDomain;
-  private String endpoint;
+  private String jsonWriterEndpoint;
+
+  private String host;
 
   GcpBigQueryAutoConfiguration(
       GcpBigQueryProperties gcpBigQueryProperties,
@@ -83,7 +85,8 @@ public class GcpBigQueryAutoConfiguration {
     this.threadPoolSize = getThreadPoolSize(gcpBigQueryProperties.getThreadPoolSize());
 
     this.universeDomain = gcpBigQueryProperties.getUniverseDomain();
-    this.endpoint = gcpBigQueryProperties.getEndpoint();
+    this.jsonWriterEndpoint = gcpBigQueryProperties.getJsonWriterEndpoint();
+    this.host = gcpBigQueryProperties.getHost();
   }
 
   /**
@@ -111,6 +114,9 @@ public class GcpBigQueryAutoConfiguration {
     if (this.universeDomain != null) {
       bigQueryOptionsBuilder.setUniverseDomain(this.universeDomain);
     }
+    if (this.host != null) {
+      bigQueryOptionsBuilder.setHost(this.host);
+    }
     return bigQueryOptionsBuilder.build().getService();
   }
 
@@ -125,8 +131,8 @@ public class GcpBigQueryAutoConfiguration {
     if (this.universeDomain != null) {
       bigQueryWriteSettingsBuilder.setUniverseDomain(this.universeDomain);
     }
-    if (this.endpoint != null) {
-      bigQueryWriteSettingsBuilder.setEndpoint(this.endpoint);
+    if (this.jsonWriterEndpoint != null) {
+      bigQueryWriteSettingsBuilder.setEndpoint(this.jsonWriterEndpoint);
     }
     return BigQueryWriteClient.create(bigQueryWriteSettingsBuilder.build());
   }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfiguration.java
@@ -27,7 +27,6 @@ import com.google.cloud.spring.core.DefaultCredentialsProvider;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.core.UserAgentHeaderProvider;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
@@ -163,8 +162,8 @@ public class GcpBigQueryAutoConfiguration {
 
   private String resolveToHost(String endpoint) throws URISyntaxException {
     int portIndex = endpoint.indexOf(":");
-    if (portIndex != -1){
-      return "https://" + endpoint.substring(0,portIndex) + "/";
+    if (portIndex != -1) {
+      return "https://" + endpoint.substring(0, portIndex) + "/";
     }
     return "https://" + endpoint + "/";
   }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryProperties.java
@@ -45,6 +45,9 @@ public class GcpBigQueryProperties implements CredentialsSupplier {
   /** The size of thread pool of ThreadPoolTaskScheduler used by GcpBigQueryAutoConfiguration */
   private int threadPoolSize;
 
+  private String universeDomain;
+  private String endpoint;
+
   public int getJsonWriterBatchSize() {
     return jsonWriterBatchSize;
   }
@@ -79,5 +82,21 @@ public class GcpBigQueryProperties implements CredentialsSupplier {
 
   public void setDatasetName(String datasetName) {
     this.datasetName = datasetName;
+  }
+
+  public String getUniverseDomain() {
+    return universeDomain;
+  }
+
+  public void setUniverseDomain(String universeDomain) {
+    this.universeDomain = universeDomain;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryProperties.java
@@ -48,15 +48,9 @@ public class GcpBigQueryProperties implements CredentialsSupplier {
   private String universeDomain;
 
   /**
-   * Endpoint (formatted as `${service}.${universeDomain}:${port}`) that will be used by
-   * BigQueryJsonDataWriter.
+   * Endpoint (formatted as `{service}.{universeDomain}:${port}`)
    */
-  private String jsonWriterEndpoint;
-
-  /**
-   * Host (formatted as `https://{service}.{universeDomain}`) that will be used by BigQueryOptions.
-   */
-  private String host;
+  private String endpoint;
 
   public int getJsonWriterBatchSize() {
     return jsonWriterBatchSize;
@@ -102,20 +96,12 @@ public class GcpBigQueryProperties implements CredentialsSupplier {
     this.universeDomain = universeDomain;
   }
 
-  public String getJsonWriterEndpoint() {
-    return jsonWriterEndpoint;
+  public String getEndpoint() {
+    return endpoint;
   }
 
-  public void setJsonWriterEndpoint(String jsonWriterEndpoint) {
-    this.jsonWriterEndpoint = jsonWriterEndpoint;
-  }
-
-  public String getHost() {
-    return host;
-  }
-
-  public void setHost(String host) {
-    this.host = host;
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
   }
 
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryProperties.java
@@ -46,7 +46,12 @@ public class GcpBigQueryProperties implements CredentialsSupplier {
   private int threadPoolSize;
 
   private String universeDomain;
-  private String endpoint;
+
+  /** Endpoint that will be used by BigQueryJsonDataWriter. */
+  private String jsonWriterEndpoint;
+
+  /** Host (endpoint without the port) that will be used by BigQueryOptions. */
+  private String host;
 
   public int getJsonWriterBatchSize() {
     return jsonWriterBatchSize;
@@ -92,11 +97,20 @@ public class GcpBigQueryProperties implements CredentialsSupplier {
     this.universeDomain = universeDomain;
   }
 
-  public String getEndpoint() {
-    return endpoint;
+  public String getJsonWriterEndpoint() {
+    return jsonWriterEndpoint;
   }
 
-  public void setEndpoint(String endpoint) {
-    this.endpoint = endpoint;
+  public void setJsonWriterEndpoint(String jsonWriterEndpoint) {
+    this.jsonWriterEndpoint = jsonWriterEndpoint;
   }
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryProperties.java
@@ -47,10 +47,15 @@ public class GcpBigQueryProperties implements CredentialsSupplier {
 
   private String universeDomain;
 
-  /** Endpoint that will be used by BigQueryJsonDataWriter. */
+  /**
+   * Endpoint (formatted as `${service}.${universeDomain}:${port}`) that will be used by
+   * BigQueryJsonDataWriter.
+   */
   private String jsonWriterEndpoint;
 
-  /** Host (endpoint without the port) that will be used by BigQueryOptions. */
+  /**
+   * Host (formatted as `https://{service}.{universeDomain}`) that will be used by BigQueryOptions.
+   */
   private String host;
 
   public int getJsonWriterBatchSize() {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
@@ -69,16 +69,42 @@ class GcpBigQueryAutoConfigurationTests {
             ctx -> {
               BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
               assertThat(options.getUniverseDomain()).isEqualTo("myUniverseDomain");
+              assertThat(options.getHost()).isEqualTo("https://www.googleapis.com");
             });
   }
 
   @Test
-  void testBigQuery_noUniverseDomainSet_useClientDefault() {
+  void testBigQuery_noUniverseDomainAndHostSet_useClientDefault() {
     this.contextRunner.run(
         ctx -> {
           BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
           assertThat(options.getUniverseDomain()).isNull();
+          assertThat(options.getHost()).isEqualTo("https://www.googleapis.com");
         });
+  }
+
+  @Test
+  void testBigQuery_host() {
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.bigquery.host=bigquery.example.com")
+        .run(
+            ctx -> {
+              BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
+              assertThat(options.getHost()).isEqualTo("bigquery.example.com");
+            });
+  }
+
+  @Test
+  void testBigQuery_bothHostAndUniverseDomainSet() {
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.bigquery.host=bigquery.example.com")
+        .withPropertyValues("spring.cloud.gcp.bigquery.universe-domain=myUniverseDomain")
+        .run(
+            ctx -> {
+              BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
+              assertThat(options.getHost()).isEqualTo("bigquery.example.com");
+              assertThat(options.getUniverseDomain()).isEqualTo("myUniverseDomain");
+            });
   }
 
   @Test
@@ -96,11 +122,13 @@ class GcpBigQueryAutoConfigurationTests {
   @Test
   void testBigQueryWrite_endpoint() {
     this.contextRunner
-        .withPropertyValues("spring.cloud.gcp.bigquery.endpoint=kms.example.com:123")
+        .withPropertyValues(
+            "spring.cloud.gcp.bigquery.jsonWriterEndpoint=bigquerystorage.example.com:123")
         .run(
             ctx -> {
               BigQueryWriteClient client = ctx.getBean(BigQueryWriteClient.class);
-              assertThat(client.getSettings().getEndpoint()).isEqualTo("kms.example.com:123");
+              assertThat(client.getSettings().getEndpoint())
+                  .isEqualTo("bigquerystorage.example.com:123");
             });
   }
 
@@ -108,12 +136,14 @@ class GcpBigQueryAutoConfigurationTests {
   void testBigQueryWrite_bothUniverseDomainAndEndpointSet() {
     this.contextRunner
         .withPropertyValues("spring.cloud.gcp.bigquery.universe-domain=myUniverseDomain")
-        .withPropertyValues("spring.cloud.gcp.bigquery.endpoint=kms.example.com:123")
+        .withPropertyValues(
+            "spring.cloud.gcp.bigquery.jsonWriterEndpoint=bigquerystorage.example.com:123")
         .run(
             ctx -> {
               BigQueryWriteClient client = ctx.getBean(BigQueryWriteClient.class);
               assertThat(client.getSettings().getUniverseDomain()).isEqualTo("myUniverseDomain");
-              assertThat(client.getSettings().getEndpoint()).isEqualTo("kms.example.com:123");
+              assertThat(client.getSettings().getEndpoint())
+                  .isEqualTo("bigquerystorage.example.com:123");
             });
   }
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
@@ -68,7 +68,7 @@ class GcpBigQueryAutoConfigurationTests {
         .run(
             ctx -> {
               BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
-              assertThat(options.getUniverseDomain()).isNull();
+              assertThat(options.getUniverseDomain()).isEqualTo("myUniverseDomain");
             });
   }
 
@@ -77,7 +77,7 @@ class GcpBigQueryAutoConfigurationTests {
     this.contextRunner.run(
         ctx -> {
           BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
-          assertThat(options.getUniverseDomain()).isEqualTo("googleapis.com");
+          assertThat(options.getUniverseDomain()).isNull();
         });
   }
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
@@ -93,7 +93,7 @@ class GcpBigQueryAutoConfigurationTests {
             ctx -> {
               BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
               assertThat(options.getResolvedApiaryHost("bigquery"))
-                  .isEqualTo("https://bigquery.example.com");
+                  .isEqualTo("https://bigquery.example.com/");
             });
   }
 
@@ -106,7 +106,7 @@ class GcpBigQueryAutoConfigurationTests {
             ctx -> {
               BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
               assertThat(options.getResolvedApiaryHost("bigquery"))
-                  .isEqualTo("https://bigquery.example.com");
+                  .isEqualTo("https://bigquery.example.com/");
               assertThat(options.getUniverseDomain()).isEqualTo("myUniverseDomain");
             });
   }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
@@ -75,7 +75,7 @@ class GcpBigQueryAutoConfigurationTests {
   }
 
   @Test
-  void testBigQuery_noUniverseDomainAndHostSet_useClientDefault() {
+  void testBigQuery_noUniverseDomainAndEndpointSet_useClientDefault() {
     this.contextRunner.run(
         ctx -> {
           BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
@@ -86,7 +86,7 @@ class GcpBigQueryAutoConfigurationTests {
   }
 
   @Test
-  void testBigQuery_host() {
+  void testBigQuery_endpoint() {
     this.contextRunner
         .withPropertyValues("spring.cloud.gcp.bigquery.endpoint=bigquery.example.com:443")
         .run(
@@ -98,7 +98,7 @@ class GcpBigQueryAutoConfigurationTests {
   }
 
   @Test
-  void testBigQuery_bothHostAndUniverseDomainSet() {
+  void testBigQuery_bothEndpointAndUniverseDomainSet() {
     this.contextRunner
         .withPropertyValues("spring.cloud.gcp.bigquery.endpoint=bigquery.example.com:123")
         .withPropertyValues("spring.cloud.gcp.bigquery.universe-domain=myUniverseDomain")

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
@@ -69,7 +69,8 @@ class GcpBigQueryAutoConfigurationTests {
             ctx -> {
               BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
               assertThat(options.getUniverseDomain()).isEqualTo("myUniverseDomain");
-              assertThat(options.getHost()).isEqualTo("https://www.googleapis.com");
+              assertThat(options.getResolvedApiaryHost("bigquery"))
+                  .isEqualTo("https://bigquery.myUniverseDomain/");
             });
   }
 
@@ -79,7 +80,8 @@ class GcpBigQueryAutoConfigurationTests {
         ctx -> {
           BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
           assertThat(options.getUniverseDomain()).isNull();
-          assertThat(options.getHost()).isEqualTo("https://www.googleapis.com");
+          assertThat(options.getResolvedApiaryHost("bigquery"))
+              .isEqualTo("https://bigquery.googleapis.com/");
         });
   }
 
@@ -90,7 +92,8 @@ class GcpBigQueryAutoConfigurationTests {
         .run(
             ctx -> {
               BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
-              assertThat(options.getHost()).isEqualTo("bigquery.example.com");
+              assertThat(options.getResolvedApiaryHost("bigquery"))
+                  .isEqualTo("bigquery.example.com");
             });
   }
 
@@ -102,7 +105,8 @@ class GcpBigQueryAutoConfigurationTests {
         .run(
             ctx -> {
               BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
-              assertThat(options.getHost()).isEqualTo("bigquery.example.com");
+              assertThat(options.getResolvedApiaryHost("bigquery"))
+                  .isEqualTo("bigquery.example.com");
               assertThat(options.getUniverseDomain()).isEqualTo("myUniverseDomain");
             });
   }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
@@ -88,25 +88,25 @@ class GcpBigQueryAutoConfigurationTests {
   @Test
   void testBigQuery_host() {
     this.contextRunner
-        .withPropertyValues("spring.cloud.gcp.bigquery.host=bigquery.example.com")
+        .withPropertyValues("spring.cloud.gcp.bigquery.endpoint=bigquery.example.com:443")
         .run(
             ctx -> {
               BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
               assertThat(options.getResolvedApiaryHost("bigquery"))
-                  .isEqualTo("bigquery.example.com");
+                  .isEqualTo("https://bigquery.example.com");
             });
   }
 
   @Test
   void testBigQuery_bothHostAndUniverseDomainSet() {
     this.contextRunner
-        .withPropertyValues("spring.cloud.gcp.bigquery.host=bigquery.example.com")
+        .withPropertyValues("spring.cloud.gcp.bigquery.endpoint=bigquery.example.com:123")
         .withPropertyValues("spring.cloud.gcp.bigquery.universe-domain=myUniverseDomain")
         .run(
             ctx -> {
               BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
               assertThat(options.getResolvedApiaryHost("bigquery"))
-                  .isEqualTo("bigquery.example.com");
+                  .isEqualTo("https://bigquery.example.com");
               assertThat(options.getUniverseDomain()).isEqualTo("myUniverseDomain");
             });
   }
@@ -127,7 +127,7 @@ class GcpBigQueryAutoConfigurationTests {
   void testBigQueryWrite_endpoint() {
     this.contextRunner
         .withPropertyValues(
-            "spring.cloud.gcp.bigquery.jsonWriterEndpoint=bigquerystorage.example.com:123")
+            "spring.cloud.gcp.bigquery.endpoint=bigquerystorage.example.com:123")
         .run(
             ctx -> {
               BigQueryWriteClient client = ctx.getBean(BigQueryWriteClient.class);
@@ -141,7 +141,7 @@ class GcpBigQueryAutoConfigurationTests {
     this.contextRunner
         .withPropertyValues("spring.cloud.gcp.bigquery.universe-domain=myUniverseDomain")
         .withPropertyValues(
-            "spring.cloud.gcp.bigquery.jsonWriterEndpoint=bigquerystorage.example.com:123")
+            "spring.cloud.gcp.bigquery.endpoint=bigquerystorage.example.com:123")
         .run(
             ctx -> {
               BigQueryWriteClient client = ctx.getBean(BigQueryWriteClient.class);

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/bigquery/GcpBigQueryAutoConfigurationTests.java
@@ -23,6 +23,7 @@ import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
 import com.google.cloud.spring.bigquery.core.BigQueryTemplate;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,73 @@ class GcpBigQueryAutoConfigurationTests {
           assertThat(bigQueryTemplate.getDatasetName()).isEqualTo("test-dataset");
 
           assertThat(bigQueryTemplate.getJsonWriterBatchSize()).isEqualTo(2000);
+        });
+  }
+
+  @Test
+  void testBigQuery_universeDomain() {
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.bigquery.universe-domain=myUniverseDomain")
+        .run(
+            ctx -> {
+              BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
+              assertThat(options.getUniverseDomain()).isNull();
+            });
+  }
+
+  @Test
+  void testBigQuery_noUniverseDomainSet_useClientDefault() {
+    this.contextRunner.run(
+        ctx -> {
+          BigQueryOptions options = ctx.getBean(BigQuery.class).getOptions();
+          assertThat(options.getUniverseDomain()).isEqualTo("googleapis.com");
+        });
+  }
+
+  @Test
+  void testBigQueryWrite_universeDomain() {
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.bigquery.universe-domain=myUniverseDomain")
+        .run(
+            ctx -> {
+              BigQueryWriteClient writeClient = ctx.getBean(BigQueryWriteClient.class);
+              assertThat(writeClient.getSettings().getUniverseDomain())
+                  .isEqualTo("myUniverseDomain");
+            });
+  }
+
+  @Test
+  void testBigQueryWrite_endpoint() {
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.bigquery.endpoint=kms.example.com:123")
+        .run(
+            ctx -> {
+              BigQueryWriteClient client = ctx.getBean(BigQueryWriteClient.class);
+              assertThat(client.getSettings().getEndpoint()).isEqualTo("kms.example.com:123");
+            });
+  }
+
+  @Test
+  void testBigQueryWrite_bothUniverseDomainAndEndpointSet() {
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.bigquery.universe-domain=myUniverseDomain")
+        .withPropertyValues("spring.cloud.gcp.bigquery.endpoint=kms.example.com:123")
+        .run(
+            ctx -> {
+              BigQueryWriteClient client = ctx.getBean(BigQueryWriteClient.class);
+              assertThat(client.getSettings().getUniverseDomain()).isEqualTo("myUniverseDomain");
+              assertThat(client.getSettings().getEndpoint()).isEqualTo("kms.example.com:123");
+            });
+  }
+
+  @Test
+  void testBigQueryWrite_noUniverseDomainOrEndpointSet_useClientDefault() {
+    this.contextRunner.run(
+        ctx -> {
+          BigQueryWriteClient client = ctx.getBean(BigQueryWriteClient.class);
+          assertThat(client.getSettings().getUniverseDomain()).isEqualTo("googleapis.com");
+          assertThat(client.getSettings().getEndpoint())
+              .isEqualTo("bigquerystorage.googleapis.com:443");
         });
   }
 


### PR DESCRIPTION
This PR introduces the following changes:

- Introduces `spring.cloud.gcp.bigquery.universe-domain` property to customize the universe domain in `BigqueryOptions` (option to customize endpoint is not provided in the client library) and `BigQueryWriteClient` if these values aren't `null`. 
- Introduces `spring.cloud.gcp.bigquery.endpoint` property to customize the endpoint and host in `BigQueryWriteClient` and if this value isn't `null`. Since Biqguery accepts `host` instead of `endpoint`, the endpoint is formatted to the `https://service.universeDomain` format before being set to Bigquery. 
- Adds unit tests in `GcpBigQueryAutoConfigurationTests` verify that the client settings have been correctly set. 

End-to-end verification with test environment endpoints have been documented in a separate test plan document. 