### PR TITLE
fix: handle null primary keys between parent and child objects

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerMutationFactoryImpl.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerMutationFactoryImpl.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
@@ -163,7 +164,7 @@ public class SpannerMutationFactoryImpl implements SpannerMutationFactory {
     Iterator childKeyParts = this.spannerSchemaUtils.getKey(childObject).getParts().iterator();
     int partNum = 1;
     while (parentKeyParts.hasNext()) {
-      if (!childKeyParts.hasNext() || !parentKeyParts.next().equals(childKeyParts.next())) {
+      if (!childKeyParts.hasNext() || !Objects.equals(parentKeyParts.next(), childKeyParts.next())) {
         throw new SpannerDataException(
             "A child entity's common primary key parts with its parent must "
                 + "have the same values. Primary key component "

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerMutationFactoryImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerMutationFactoryImplTests.java
@@ -39,7 +39,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerMutationFactoryImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerMutationFactoryImplTests.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -159,6 +160,19 @@ class SpannerMutationFactoryImplTests {
   }
 
   @Test
+  void insertChildrenNullIdTest() {
+    Parent parent = new Parent();
+    parent.keyOne = "a";
+    Child child = new Child();
+    child.keyOne = "a";
+    child.keyThree = 3L;
+    parent.children = Collections.singletonList(child);
+
+    List<Mutation> mutations = this.spannerMutationFactory.insert(parent);
+    assertThat(mutations).hasSize(2);
+  }
+
+  @Test
   void updateTest() {
     executeWriteTest(t -> this.spannerMutationFactory.update(t, null), Op.UPDATE);
   }
@@ -269,5 +283,34 @@ class SpannerMutationFactoryImplTests {
 
     @PrimaryKey(keyOrder = 2)
     String id2;
+  }
+
+  @Table
+  private static class Parent {
+    @PrimaryKey
+    @Column
+    String keyOne;
+
+    @PrimaryKey(keyOrder = 2)
+    @Column
+    Long keyTwo;
+
+    @Interleaved
+    List<Child> children;
+  }
+
+  @Table
+  private static class Child {
+    @PrimaryKey
+    @Column
+    String keyOne;
+
+    @PrimaryKey(keyOrder = 2)
+    @Column
+    Long keyTwo;
+
+    @PrimaryKey(keyOrder = 3)
+    @Column
+    Long keyThree;
   }
 }


### PR DESCRIPTION
In the case that parent and child have multiple primary keys, do not fail key match validation if both have a null value.