### PR TITLE
chore: fix javadoc job by updating to the new javadoc output path

### DIFF
--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -19,7 +19,7 @@ python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 mvn clean javadoc:aggregate -Drelease=true
 
 # Move into generated docs directory
-pushd target/site/apidocs/
+pushd target/reports/apidocs/
 
 python3 -m docuploader create-metadata \
      --name spring-cloud-gcp \


### PR DESCRIPTION
The default javadoc output path was changed from target/site to target/reports in https://github.com/apache/maven-reporting-impl/pull/26 and was introduced in maven-javadoc-plugin:3.10.0 in https://github.com/apache/maven-javadoc-plugin/pull/204.

The maven-javadoc-plugin was updated from 3.8.0 to 3.10.0 in v5.6.0 ([PR](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3164)). This fix aims to address the current failure in the publish_javadoc job:
```

# Move into generated docs directory
pushd target/site/apidocs/
github/spring-cloud-gcp/.kokoro/publish_javadoc.sh: line 29: pushd: target/site/apidocs/: No such file or directory


[ID: 8846228] Command finished after 191 secs, exit value: 1
```