### PR TITLE
chore(3.x): fix javadoc publish job by updating to the new javadoc output path

### DIFF
--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -26,7 +26,7 @@ python3 -m pip install gcp-docuploader
 ./mvnw clean javadoc:aggregate -Drelease=true
 
 # Move into generated docs directory
-pushd target/site/apidocs/
+pushd target/reports/apidocs/
 
 python3 -m docuploader create-metadata \
     --name spring-cloud-gcp \


### PR DESCRIPTION
Backporting https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3184 to 3.x branch. 