### PR TITLE
chore(4.x): fix javadoc publish job by updating to the new javadoc output path

### DIFF
--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -19,7 +19,7 @@ python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 mvn clean javadoc:aggregate -Drelease=true
 
 # Move into generated docs directory
-pushd target/site/apidocs/
+pushd target/reports/apidocs/
 
 python3 -m docuploader create-metadata \
      --name spring-cloud-gcp \


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3185