### PR TITLE
fix: added native image class initialization workaround to storage samples

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/main/resources/META-INF/native-image/com/google/cloud/storage-integration/native-image.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-integration-storage-sample/src/main/resources/META-INF/native-image/com/google/cloud/storage-integration/native-image.properties
@@ -1,0 +1,1 @@
+Args=--initialize-at-build-time=org.apache.commons.logging.LogFactory,org.apache.commons.logging.LogFactoryService

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/src/main/resources/META-INF/native-image/com/google/cloud/storage-sample-scgcp/native-image.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample/src/main/resources/META-INF/native-image/com/google/cloud/storage-sample-scgcp/native-image.properties
@@ -1,0 +1,1 @@
+Args=--initialize-at-build-time=org.apache.commons.logging.LogFactory,org.apache.commons.logging.LogFactoryService


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3147