### PR TITLE
fix(dep): update actions/upload-artifact@v2 to v4 as v2 was deprecated and now fails workflows

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Archive logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Integration Test Logs - ${{ matrix.it}}
           path: |
@@ -220,7 +220,7 @@ jobs:
       - name: Archive logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Integration Test Logs - ${{ matrix.it}}
           path: |

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -80,7 +80,7 @@ jobs:
     - name: Archive logs
       if: always()
       continue-on-error: true
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Unit Test Logs - Java ${{ matrix.java }}
         path: |
@@ -137,7 +137,7 @@ jobs:
       - name: Archive Artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Release Artifacts
           path: |


### PR DESCRIPTION
see: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/