### PR TITLE
feat: Add all additional Cloud SQL Java Connector parameters 

### DIFF
--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -177,6 +177,13 @@ Used to authenticate and authorize new connections to a Google Cloud SQL instanc
 Used to authenticate and authorize new connections to a Google Cloud SQL instance. | No
 | Default credentials provided by the Spring Framework on Google Cloud Core Starter
 | `spring.cloud.gcp.sql.enableIamAuth` | Specifies whether to enable IAM database authentication (PostgreSQL only). | No | `False`
+| `spring.cloud.gcp.sql.refreshStrategy` | The strategy used to refresh the Google Cloud SQL authentication tokens. Valid values: `background` - refresh credentials using a background thread, `lazy` - refresh credentials during connection attempts. | No | "background"
+| `spring.cloud.gcp.sql.targetPrincipal` | The service account to impersonate when connecting to the database and database admin API. | No | (empty)
+| `spring.cloud.gcp.sql.delegates` | A comma-separated list of service accounts delegates. | No | (empty)
+| `spring.cloud.gcp.sql.universeDomain` | A universe domain for the TPC environment. | No | "googleapis.com"
+| `spring.cloud.gcp.sql.adminRootUrl` | An alternate root url for the Cloud SQL admin API. | No | (empty)
+| `spring.cloud.gcp.sql.adminServicePath` | An alternate path to the SQL Admin API endpoint. | No | (empty)
+| `spring.cloud.gcp.sql.adminQuotaProject` | A project ID for quota and billing. | No | (empty)
 |===
 
 === Troubleshooting tips

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/GcpCloudSqlProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/GcpCloudSqlProperties.java
@@ -36,6 +36,44 @@ public class GcpCloudSqlProperties {
 
   /** Specifies whether to enable IAM database authentication (PostgreSQL only). */
   private boolean enableIamAuth;
+  /**
+   * The target principal to use for service account impersonation. Corresponds to
+   * Cloud SQL Java Connector JDBC property cloudSqlTargetPrincipal
+   */
+  private String targetPrincipal;
+
+  /**
+   * The chain of delegated service accounts to use for service account impersonation.
+   * Corresponds to Cloud SQL Java Connector JDBC property cloudSqlDelegates
+   */
+  private String delegates;
+
+  /**
+   * The alternate admin root url for the Cloud SQL Admin API.
+   * Corresponds to Cloud SQL Java Connector JDBC property cloudSqlAdminRootUrl.
+   */
+  private String adminRootUrl;
+  /**
+   * The alternate service path for the Cloud SQL Admin API
+   * Corresponds to Cloud SQL Java Connector JDBC property cloudSqlAdminServicePath.
+   */
+  private String adminServicePath;
+  /**
+   * The quota project to use for API requests.
+   * Corresponds to Cloud SQL Java Connector JDBC property cloudSqlAdminQuotaProject
+   */
+  private String adminQuotaProject;
+  /**
+   * The universe domain to use for API requests
+   * Corresponds to Cloud SQL Java Connector JDBC property cloudSqlUniverseDomain
+   */
+  private String universeDomain;
+  /**
+   * The refresh strategy to use for API requests
+   * Corresponds to Cloud SQL Java Connector JDBC property cloudSqlRefreshStrategy
+   */
+  private String refreshStrategy;
+
 
   public String getDatabaseName() {
     return this.databaseName;
@@ -75,5 +113,61 @@ public class GcpCloudSqlProperties {
 
   public void setEnableIamAuth(boolean enableIamAuth) {
     this.enableIamAuth = enableIamAuth;
+  }
+
+  public String getTargetPrincipal() {
+    return targetPrincipal;
+  }
+
+  public void setTargetPrincipal(String targetPrincipal) {
+    this.targetPrincipal = targetPrincipal;
+  }
+
+  public String getDelegates() {
+    return delegates;
+  }
+
+  public void setDelegates(String delegates) {
+    this.delegates = delegates;
+  }
+
+  public String getAdminRootUrl() {
+    return adminRootUrl;
+  }
+
+  public void setAdminRootUrl(String adminRootUrl) {
+    this.adminRootUrl = adminRootUrl;
+  }
+
+  public String getAdminServicePath() {
+    return adminServicePath;
+  }
+
+  public void setAdminServicePath(String adminServicePath) {
+    this.adminServicePath = adminServicePath;
+  }
+
+  public String getAdminQuotaProject() {
+    return adminQuotaProject;
+  }
+
+  public void setAdminQuotaProject(String adminQuotaProject) {
+    this.adminQuotaProject = adminQuotaProject;
+  }
+
+  public String getUniverseDomain() {
+    return universeDomain;
+  }
+
+  public void setUniverseDomain(String universeDomain) {
+    this.universeDomain = universeDomain;
+  }
+
+  public String getRefreshStrategy() {
+    return refreshStrategy;
+  }
+
+  public void setRefreshStrategy(String refreshStrategy) {
+    this.refreshStrategy = refreshStrategy;
   }
 }


### PR DESCRIPTION
This adds JDBC properties needed for lazy refresh, service account impersonation, universe domains, and alternate 
SQL Admin API endpoints to the JDBC configuration for a Cloud SQL JDBC connection. 

See #3285 

This is related to https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/2065.
