### PR TITLE
chore: fix generate workflow to compile on non-autgen libraries

### DIFF
--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -77,6 +77,7 @@ jobs:
             --threads 1.5C \
             --define maven.test.skip=true \
             --define maven.javadoc.skip=true \
+            -P non-previews,\!default \
             install
       - name: Generate libraries
         continue-on-error: false

--- a/pom.xml
+++ b/pom.xml
@@ -487,6 +487,38 @@
 			</modules>
 		</profile>
 		<profile>
+			<id>non-previews</id>
+			<modules>
+				<!-- POM Modules-->
+				<module>spring-cloud-gcp-starters</module>
+				<module>spring-cloud-gcp-dependencies</module>
+
+				<!-- Code Modules -->
+				<module>spring-cloud-gcp-autoconfigure</module>
+				<module>spring-cloud-gcp-bigquery</module>
+				<module>spring-cloud-gcp-cloudfoundry</module>
+				<module>spring-cloud-gcp-core</module>
+				<module>spring-cloud-gcp-data-datastore</module>
+				<module>spring-cloud-gcp-data-firestore</module>
+				<module>spring-cloud-gcp-data-spanner</module>
+				<module>spring-cloud-gcp-logging</module>
+				<module>spring-cloud-gcp-pubsub</module>
+				<module>spring-cloud-gcp-pubsub-stream-binder</module>
+				<module>spring-cloud-gcp-security-iap</module>
+				<module>spring-cloud-gcp-storage</module>
+				<module>spring-cloud-gcp-secretmanager</module>
+				<module>spring-cloud-gcp-security-firebase</module>
+				<module>spring-cloud-gcp-vision</module>
+				<module>spring-cloud-gcp-kms</module>
+
+				<module>spring-cloud-generator</module>
+				<module>spring-cloud-spanner-spring-data-r2dbc</module>
+				<!-- Docs and Samples -->
+				<module>docs</module>
+				<module>spring-cloud-gcp-samples</module>
+			</modules>
+		</profile>
+		<profile>
 			<!-- cloud RAD generation -->
 			<id>docFX</id>
 			<activation>


### PR DESCRIPTION
This workflow step "Compile non-autogen libraries" but is trying to install all modules. This leads to failures https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3304#issuecomment-2423226206 because certain rpcs are removed (https://github.com/googleapis/google-cloud-java/pull/11237).

duplicating the profiles might not be the best way, but `-pl '!spring-cloud-previews' ` is not working for me. This is to  unblock release.