### PR TITLE
feat: add property to customize universe domain in Pub/Sub

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfiguration.java
@@ -373,6 +373,7 @@ public class GcpPubSubAutoConfiguration {
     batchingSettings.ifAvailable(factory::setBatchingSettings);
     factory.setEnableMessageOrdering(gcpPubSubProperties.getPublisher().getEnableMessageOrdering());
     factory.setEndpoint(gcpPubSubProperties.getPublisher().getEndpoint());
+    factory.setUniverseDomain(gcpPubSubProperties.getPublisher().getUniverseDomain());
 
     List<PublisherCustomizer> customizers = customizersProvider.orderedStream()
         .collect(Collectors.toList());

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -1458,6 +1458,8 @@ class GcpPubSubAutoConfigurationTests {
                   ctx.getBean("defaultPublisherFactory", CachingPublisherFactory.class);
               assertThat(gcpPubSubProperties.getPublisher().getUniverseDomain())
                   .isEqualTo("example.com");
+              assertThat(publisherFactory)
+                  .hasFieldOrPropertyWithValue("delegate.universeDomain", "example.com");
             });
   }
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -1413,7 +1413,7 @@ class GcpPubSubAutoConfigurationTests {
   }
 
   @Test
-  void universeDomain_selectiveConfigurationSet() {
+  void subscriberUniverseDomain_selectiveConfigurationSet() {
     contextRunner
         .withPropertyValues(
             "spring.cloud.gcp.pubsub.subscription.subscription-name.universe-domain=example.com")
@@ -1430,7 +1430,7 @@ class GcpPubSubAutoConfigurationTests {
   }
 
   @Test
-  void universeDomain_globalAndSelectiveConfigurationSet_selectiveTakesPrecedence() {
+  void subscriberUniverseDomain_globalAndSelectiveConfigurationSet_selectiveTakesPrecedence() {
     contextRunner
         .withPropertyValues(
             "spring.cloud.gcp.pubsub.subscriber.universe-domain=example1.com",
@@ -1444,6 +1444,20 @@ class GcpPubSubAutoConfigurationTests {
                       gcpPubSubProperties.computeSubscriberUniverseDomain(
                           "subscription-name", projectIdProvider.getProjectId()))
                   .isEqualTo("example2.com");
+            });
+  }
+
+  @Test
+  void publisherUniverseDomain() {
+    contextRunner
+        .withPropertyValues("spring.cloud.gcp.pubsub.publisher.universe-domain=example.com")
+        .run(
+            ctx -> {
+              GcpPubSubProperties gcpPubSubProperties = ctx.getBean(GcpPubSubProperties.class);
+              CachingPublisherFactory publisherFactory =
+                  ctx.getBean("defaultPublisherFactory", CachingPublisherFactory.class);
+              assertThat(gcpPubSubProperties.getPublisher().getUniverseDomain())
+                  .isEqualTo("example.com");
             });
   }
 

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/GcpPubSubAutoConfigurationTests.java
@@ -1412,6 +1412,40 @@ class GcpPubSubAutoConfigurationTests {
             });
   }
 
+  @Test
+  void universeDomain_selectiveConfigurationSet() {
+    contextRunner
+        .withPropertyValues(
+            "spring.cloud.gcp.pubsub.subscription.subscription-name.universe-domain=example.com")
+        .run(
+            ctx -> {
+              GcpPubSubProperties gcpPubSubProperties = ctx.getBean(GcpPubSubProperties.class);
+              GcpProjectIdProvider projectIdProvider = ctx.getBean(GcpProjectIdProvider.class);
+
+              assertThat(
+                      gcpPubSubProperties.computeSubscriberUniverseDomain(
+                          "subscription-name", projectIdProvider.getProjectId()))
+                  .isEqualTo("example.com");
+            });
+  }
+
+  @Test
+  void universeDomain_globalAndSelectiveConfigurationSet_selectiveTakesPrecedence() {
+    contextRunner
+        .withPropertyValues(
+            "spring.cloud.gcp.pubsub.subscriber.universe-domain=example1.com",
+            "spring.cloud.gcp.pubsub.subscription.subscription-name.universe-domain=example2.com")
+        .run(
+            ctx -> {
+              GcpPubSubProperties gcpPubSubProperties = ctx.getBean(GcpPubSubProperties.class);
+              GcpProjectIdProvider projectIdProvider = ctx.getBean(GcpProjectIdProvider.class);
+
+              assertThat(
+                      gcpPubSubProperties.computeSubscriberUniverseDomain(
+                          "subscription-name", projectIdProvider.getProjectId()))
+                  .isEqualTo("example2.com");
+            });
+  }
 
   @Configuration
   static class CustomizerConfig {

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/core/PubSubConfiguration.java
@@ -292,6 +292,22 @@ public class PubSubConfiguration {
   }
 
   /**
+   * Returns the universe domain. The subscription-specific property takes precedence if both global
+   * and subscription-specific properties are set. If subscription-specific configuration is not set
+   * then the global configuration is picked.
+   *
+   * @param subscriptionName subscription name
+   * @param projectId project id
+   * @return pull endpoint
+   */
+  public String computeSubscriberUniverseDomain(String subscriptionName, String projectId) {
+    String universeDomain =
+            getSubscriptionProperties(PubSubSubscriptionUtils.toProjectSubscriptionName(subscriptionName, projectId))
+                    .getUniverseDomain();
+    return universeDomain != null ? universeDomain : this.globalSubscriber.getUniverseDomain();
+  }
+
+  /**
    * Computes the retry settings. The subscription-specific property takes precedence if both global
    * and subscription-specific properties are set. If subscription-specific settings are not set
    * then the global settings are picked.
@@ -384,6 +400,8 @@ public class PubSubConfiguration {
     /** Set publisher endpoint. Example: "us-east1-pubsub.googleapis.com:443". */
     private String endpoint;
 
+    private String universeDomain;
+
     public Batching getBatching() {
       return this.batching;
     }
@@ -441,6 +459,14 @@ public class PubSubConfiguration {
     public void setEndpoint(String endpoint) {
       this.endpoint = endpoint;
     }
+
+    public String getUniverseDomain() {
+      return universeDomain;
+    }
+
+    public void setUniverseDomain(String universeDomain) {
+      this.universeDomain = universeDomain;
+    }
   }
 
   /** Subscriber settings. */
@@ -486,6 +512,12 @@ public class PubSubConfiguration {
 
     /** RPC status codes that should be retried when pulling messages. */
     private Code[] retryableCodes = null;
+
+    /**
+     * Universe domain of the client which is part of the endpoint that is formatted as
+     * `${service}.${universeDomain}:${port}`.
+     */
+    private String universeDomain;
 
     public String getFullyQualifiedName() {
       return fullyQualifiedName;
@@ -570,6 +602,14 @@ public class PubSubConfiguration {
 
     public void setMaxAcknowledgementThreads(int maxAcknowledgementThreads) {
       this.maxAcknowledgementThreads = maxAcknowledgementThreads;
+    }
+
+    public String getUniverseDomain() {
+      return universeDomain;
+    }
+
+    public void setUniverseDomain(String universeDomain) {
+      this.universeDomain = universeDomain;
     }
   }
 

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactory.java
@@ -56,6 +56,8 @@ public class DefaultPublisherFactory implements PublisherFactory {
 
   private String endpoint;
 
+  private String universeDomain;
+
   private List<PublisherCustomizer> customizers;
 
   /**
@@ -151,6 +153,10 @@ public class DefaultPublisherFactory implements PublisherFactory {
     this.endpoint = endpoint;
   }
 
+  public void setUniverseDomain(String universeDomain) {
+    this.universeDomain = universeDomain;
+  }
+
   /**
    * Accepts a list of {@link Publisher.Builder} customizers.
    * The customizers are applied in the order provided, so the later customizers can override
@@ -221,6 +227,10 @@ public class DefaultPublisherFactory implements PublisherFactory {
 
     if (this.endpoint != null) {
       publisherBuilder.setEndpoint(this.endpoint);
+    }
+
+    if (this.universeDomain != null) {
+      publisherBuilder.setUniverseDomain(this.universeDomain);
     }
   }
 

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
@@ -597,7 +597,7 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
     this.retrySettingsMap = retrySettingsMap;
   }
 
-  public void setUniverseDomain(String universeDomain){
+  public void setUniverseDomain(String universeDomain) {
     this.universeDomain = universeDomain;
   }
 

--- a/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
+++ b/spring-cloud-gcp-pubsub/src/main/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactory.java
@@ -70,6 +70,8 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 
   private String pullEndpoint;
 
+  private String universeDomain;
+
   private ApiClock apiClock;
 
   private RetrySettings subscriberStubRetrySettings;
@@ -299,6 +301,12 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
     if (pullCount != null) {
       subscriberBuilder.setParallelPullCount(pullCount);
     }
+
+    String universeDomain = getUniverseDomain(subscriptionName);
+    if (universeDomain != null) {
+      subscriberBuilder.setUniverseDomain(universeDomain);
+    }
+
 
     Subscriber subscriber = subscriberBuilder.build();
 
@@ -557,6 +565,13 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
     return this.pubSubConfiguration.computeRetryableCodes(subscriptionName, projectId);
   }
 
+  String getUniverseDomain(String subscriptionName) {
+    if (this.universeDomain != null) {
+      return this.universeDomain;
+    }
+    return this.pubSubConfiguration.computeSubscriberUniverseDomain(subscriptionName, projectId);
+  }
+
   public void setExecutorProviderMap(Map<ProjectSubscriptionName, ExecutorProvider> executorProviderMap) {
     this.executorProviderMap = executorProviderMap;
   }
@@ -580,6 +595,10 @@ public class DefaultSubscriberFactory implements SubscriberFactory {
 
   public void setRetrySettingsMap(Map<ProjectSubscriptionName, RetrySettings> retrySettingsMap) {
     this.retrySettingsMap = retrySettingsMap;
+  }
+
+  public void setUniverseDomain(String universeDomain){
+    this.universeDomain = universeDomain;
   }
 
   public void setGlobalRetrySettings(RetrySettings retrySettings) {

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactoryTests.java
@@ -56,7 +56,6 @@ class DefaultPublisherFactoryTests {
 
   @Test
   void testGetPublisher() {
-
     Publisher publisher = factory.createPublisher("testTopic");
 
     assertThat(((ProjectTopicName) publisher.getTopicName()).getTopic()).isEqualTo("testTopic");

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultPublisherFactoryTests.java
@@ -56,6 +56,7 @@ class DefaultPublisherFactoryTests {
 
   @Test
   void testGetPublisher() {
+
     Publisher publisher = factory.createPublisher("testTopic");
 
     assertThat(((ProjectTopicName) publisher.getTopicName()).getTopic()).isEqualTo("testTopic");

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -363,17 +363,20 @@ class DefaultSubscriberFactoryTests {
             "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(2L);
     when(mockPubSubConfiguration.computeMinDurationPerAckExtension(
-        "defaultSubscription", projectIdProvider.getProjectId()))
+            "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(3L);
     when(mockPubSubConfiguration.computeMaxDurationPerAckExtension(
-        "defaultSubscription", projectIdProvider.getProjectId()))
+            "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(4L);
     when(mockPubSubConfiguration.computeParallelPullCount(
             "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(2);
     when(mockPubSubConfiguration.computePullEndpoint(
-        "defaultSubscription", projectIdProvider.getProjectId()))
+            "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn("test.endpoint");
+    when(mockPubSubConfiguration.computeSubscriberUniverseDomain(
+            "defaultSubscription", projectIdProvider.getProjectId()))
+        .thenReturn("example.com");
 
     Subscriber expectedSubscriber =
         factory.createSubscriber("defaultSubscription", (message, consumer) -> {});
@@ -385,7 +388,8 @@ class DefaultSubscriberFactoryTests {
         .hasFieldOrPropertyWithValue("minDurationPerAckExtension", Duration.ofSeconds(3L))
         .hasFieldOrPropertyWithValue("maxDurationPerAckExtension", Duration.ofSeconds(4L))
         .hasFieldOrPropertyWithValue("numPullers", 2)
-        .hasFieldOrPropertyWithValue("subStubSettings.endpoint", "test.endpoint");
+        .hasFieldOrPropertyWithValue("subStubSettings.endpoint", "test.endpoint")
+        .hasFieldOrPropertyWithValue("universeDomain", "example.com");
   }
 
   @Test

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -84,7 +84,8 @@ class DefaultSubscriberFactoryTests {
 
   @Test
   void testNewSubscriber() {
-    DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
+    DefaultSubscriberFactory factory =
+        new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
     factory.setCredentialsProvider(this.credentialsProvider);
 
     Subscriber subscriber = factory.createSubscriber("midnight cowboy", (message, consumer) -> {});
@@ -110,25 +111,24 @@ class DefaultSubscriberFactoryTests {
   void testNewSubscriber_constructorWithPubSubConfiguration_nullPubSubConfiguration() {
 
     assertThatThrownBy(() -> new DefaultSubscriberFactory(() -> "angeldust", null))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("The pub/sub configuration can't be null.");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("The pub/sub configuration can't be null.");
   }
 
   @Test
   void testNewDefaultSubscriberFactory_nullProjectProvider() {
 
     assertThatThrownBy(() -> new DefaultSubscriberFactory(null, pubSubConfig))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("The project ID provider can't be null.");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("The project ID provider can't be null.");
   }
 
   @Test
   void testNewDefaultSubscriberFactory_nullProject() {
 
     assertThatThrownBy(() -> new DefaultSubscriberFactory(() -> null, pubSubConfig))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("The project ID can't be null or empty.");
-
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("The project ID can't be null or empty.");
   }
 
   @Test
@@ -137,8 +137,8 @@ class DefaultSubscriberFactoryTests {
     factory.setCredentialsProvider(this.credentialsProvider);
 
     assertThatThrownBy(() -> factory.createPullRequest("test", -1, true))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("The maxMessages must be greater than 0.");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("The maxMessages must be greater than 0.");
   }
 
   @Test
@@ -163,9 +163,11 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
-    ConcurrentHashMap<ProjectSubscriptionName, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
+    ConcurrentHashMap<ProjectSubscriptionName, ExecutorProvider> executorProviderMap =
+        new ConcurrentHashMap<>();
     executorProviderMap.put(
-        ProjectSubscriptionName.parse("projects/project/subscriptions/subscription-name"), mockExecutorProvider);
+        ProjectSubscriptionName.parse("projects/project/subscriptions/subscription-name"),
+        mockExecutorProvider);
     factory.setExecutorProviderMap(executorProviderMap);
 
     assertThat(factory.getExecutorProvider("subscription-name")).isSameAs(mockExecutorProvider);
@@ -176,9 +178,11 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
-    ConcurrentHashMap<ProjectSubscriptionName, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
+    ConcurrentHashMap<ProjectSubscriptionName, ExecutorProvider> executorProviderMap =
+        new ConcurrentHashMap<>();
     executorProviderMap.put(
-        ProjectSubscriptionName.parse("projects/project/subscriptions/subscription-name"), mockExecutorProvider);
+        ProjectSubscriptionName.parse("projects/project/subscriptions/subscription-name"),
+        mockExecutorProvider);
     factory.setExecutorProviderMap(executorProviderMap);
     factory.setExecutorProvider(mockGlobalExecutorProvider);
 
@@ -240,8 +244,11 @@ class DefaultSubscriberFactoryTests {
             .setRpcTimeoutMultiplier(10)
             .setMaxRpcTimeout(Duration.ofSeconds(10))
             .build();
-    ConcurrentHashMap<ProjectSubscriptionName, RetrySettings> settingsMap = new ConcurrentHashMap<>();
-    settingsMap.put(ProjectSubscriptionName.parse("projects/project/subscriptions/mySubscription"), expectedRetrySettings);
+    ConcurrentHashMap<ProjectSubscriptionName, RetrySettings> settingsMap =
+        new ConcurrentHashMap<>();
+    settingsMap.put(
+        ProjectSubscriptionName.parse("projects/project/subscriptions/mySubscription"),
+        expectedRetrySettings);
     factory.setRetrySettingsMap(settingsMap);
 
     RetrySettings actualRetrySettings = factory.getRetrySettings("mySubscription");
@@ -317,8 +324,7 @@ class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  void testBuildGlobalSubscriberStubSettings_retry_pickGlobalConfiguration()
-      throws IOException {
+  void testBuildGlobalSubscriberStubSettings_retry_pickGlobalConfiguration() throws IOException {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
     when(mockPubSubConfiguration.getSubscriber()).thenReturn(mockSubscriber);
@@ -389,7 +395,7 @@ class DefaultSubscriberFactoryTests {
         .hasFieldOrPropertyWithValue("maxDurationPerAckExtension", Duration.ofSeconds(4L))
         .hasFieldOrPropertyWithValue("numPullers", 2)
         .hasFieldOrPropertyWithValue("subStubSettings.endpoint", "test.endpoint")
-        .hasFieldOrPropertyWithValue("universeDomain", "example.com");
+        .hasFieldOrPropertyWithValue("subStubSettings.universeDomain", "example.com");
   }
 
   @Test
@@ -399,14 +405,11 @@ class DefaultSubscriberFactoryTests {
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
     factory.setCredentialsProvider(this.credentialsProvider);
     when(mockPubSubConfiguration.computeMinDurationPerAckExtension(
-        "defaultSubscription", projectIdProvider.getProjectId()))
+            "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(-4L);
 
     assertThatThrownBy(
-        () -> factory.createSubscriber(
-            "defaultSubscription",
-            (message, consumer) -> { }
-        ))
+            () -> factory.createSubscriber("defaultSubscription", (message, consumer) -> {}))
         .isExactlyInstanceOf(IllegalArgumentException.class);
   }
 
@@ -417,14 +420,11 @@ class DefaultSubscriberFactoryTests {
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
     factory.setCredentialsProvider(this.credentialsProvider);
     when(mockPubSubConfiguration.computeMaxDurationPerAckExtension(
-        "defaultSubscription", projectIdProvider.getProjectId()))
+            "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(-2L);
 
     assertThatThrownBy(
-        () -> factory.createSubscriber(
-            "defaultSubscription",
-            (message, consumer) -> { }
-        ))
+            () -> factory.createSubscriber("defaultSubscription", (message, consumer) -> {}))
         .isExactlyInstanceOf(IllegalArgumentException.class);
   }
 
@@ -435,17 +435,14 @@ class DefaultSubscriberFactoryTests {
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
     factory.setCredentialsProvider(this.credentialsProvider);
     when(mockPubSubConfiguration.computeMinDurationPerAckExtension(
-        "defaultSubscription", projectIdProvider.getProjectId()))
+            "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(4L);
     when(mockPubSubConfiguration.computeMaxDurationPerAckExtension(
-        "defaultSubscription", projectIdProvider.getProjectId()))
+            "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(3L);
 
     assertThatThrownBy(
-        () -> factory.createSubscriber(
-            "defaultSubscription",
-            (message, consumer) -> { }
-        ))
+            () -> factory.createSubscriber("defaultSubscription", (message, consumer) -> {}))
         .isExactlyInstanceOf(IllegalArgumentException.class);
   }
 
@@ -474,10 +471,13 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
-    ConcurrentHashMap<ProjectSubscriptionName, FlowControlSettings> settingsMap = new ConcurrentHashMap<>();
+    ConcurrentHashMap<ProjectSubscriptionName, FlowControlSettings> settingsMap =
+        new ConcurrentHashMap<>();
     FlowControlSettings expectedFlowSettings =
         FlowControlSettings.newBuilder().setMaxOutstandingRequestBytes(10L).build();
-    settingsMap.put(ProjectSubscriptionName.parse("projects/project/subscriptions/defaultSubscription1"), expectedFlowSettings);
+    settingsMap.put(
+        ProjectSubscriptionName.parse("projects/project/subscriptions/defaultSubscription1"),
+        expectedFlowSettings);
     factory.setFlowControlSettingsMap(settingsMap);
 
     FlowControlSettings actualFlowSettings = factory.getFlowControlSettings("defaultSubscription1");
@@ -543,7 +543,7 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
     when(mockPubSubConfiguration.computeMinDurationPerAckExtension(
-        "subscription-name", projectIdProvider.getProjectId()))
+            "subscription-name", projectIdProvider.getProjectId()))
         .thenReturn(1L);
 
     assertThat(factory.getMinDurationPerAckExtension("subscription-name"))
@@ -556,8 +556,9 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
 
-    when(mockPubSubConfiguration.computeMinDurationPerAckExtension("subscription-name",
-        projectIdProvider.getProjectId())).thenReturn(3L);
+    when(mockPubSubConfiguration.computeMinDurationPerAckExtension(
+            "subscription-name", projectIdProvider.getProjectId()))
+        .thenReturn(3L);
 
     // subscription level setting is used when factory-level one is not provided
     assertThat(factory.getMinDurationPerAckExtension("subscription-name"))
@@ -577,8 +578,9 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
 
-    when(mockPubSubConfiguration.computeMaxDurationPerAckExtension("subscription-name",
-        projectIdProvider.getProjectId())).thenReturn(3L);
+    when(mockPubSubConfiguration.computeMaxDurationPerAckExtension(
+            "subscription-name", projectIdProvider.getProjectId()))
+        .thenReturn(3L);
 
     // subscription level setting is used when factory-level one is not provided
     assertThat(factory.getMaxDurationPerAckExtension("subscription-name"))
@@ -598,8 +600,7 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
 
-    assertThat(factory.getMinDurationPerAckExtension("subscription-name"))
-        .isNull();
+    assertThat(factory.getMinDurationPerAckExtension("subscription-name")).isNull();
   }
 
   @Test
@@ -608,7 +609,7 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
     when(mockPubSubConfiguration.computeMaxDurationPerAckExtension(
-        "subscription-name", projectIdProvider.getProjectId()))
+            "subscription-name", projectIdProvider.getProjectId()))
         .thenReturn(2L);
 
     assertThat(factory.getMaxDurationPerAckExtension("subscription-name"))
@@ -621,8 +622,7 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
 
-    assertThat(factory.getMaxDurationPerAckExtension("subscription-name"))
-        .isNull();
+    assertThat(factory.getMaxDurationPerAckExtension("subscription-name")).isNull();
   }
 
   @Test
@@ -755,8 +755,7 @@ class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  void testBuildGlobalSubscriberStubSettings_retryableCodes_pickConfiguration()
-      throws IOException {
+  void testBuildGlobalSubscriberStubSettings_retryableCodes_pickConfiguration() throws IOException {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
@@ -809,7 +808,8 @@ class DefaultSubscriberFactoryTests {
 
     when(healthTrackerRegistry.isTracked(subscriptionName)).thenReturn(true);
 
-    DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
+    DefaultSubscriberFactory factory =
+        new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
     factory.setCredentialsProvider(this.credentialsProvider);
     factory.setHealthTrackerRegistry(healthTrackerRegistry);
 
@@ -828,7 +828,8 @@ class DefaultSubscriberFactoryTests {
 
     when(healthTrackerRegistry.isTracked(subscriptionName)).thenReturn(false);
 
-    DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
+    DefaultSubscriberFactory factory =
+        new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
     factory.setCredentialsProvider(this.credentialsProvider);
     factory.setHealthTrackerRegistry(healthTrackerRegistry);
 

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/support/DefaultSubscriberFactoryTests.java
@@ -84,8 +84,7 @@ class DefaultSubscriberFactoryTests {
 
   @Test
   void testNewSubscriber() {
-    DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
+    DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
     factory.setCredentialsProvider(this.credentialsProvider);
 
     Subscriber subscriber = factory.createSubscriber("midnight cowboy", (message, consumer) -> {});
@@ -111,24 +110,25 @@ class DefaultSubscriberFactoryTests {
   void testNewSubscriber_constructorWithPubSubConfiguration_nullPubSubConfiguration() {
 
     assertThatThrownBy(() -> new DefaultSubscriberFactory(() -> "angeldust", null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("The pub/sub configuration can't be null.");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The pub/sub configuration can't be null.");
   }
 
   @Test
   void testNewDefaultSubscriberFactory_nullProjectProvider() {
 
     assertThatThrownBy(() -> new DefaultSubscriberFactory(null, pubSubConfig))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("The project ID provider can't be null.");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The project ID provider can't be null.");
   }
 
   @Test
   void testNewDefaultSubscriberFactory_nullProject() {
 
     assertThatThrownBy(() -> new DefaultSubscriberFactory(() -> null, pubSubConfig))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("The project ID can't be null or empty.");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The project ID can't be null or empty.");
+
   }
 
   @Test
@@ -137,8 +137,8 @@ class DefaultSubscriberFactoryTests {
     factory.setCredentialsProvider(this.credentialsProvider);
 
     assertThatThrownBy(() -> factory.createPullRequest("test", -1, true))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("The maxMessages must be greater than 0.");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The maxMessages must be greater than 0.");
   }
 
   @Test
@@ -163,11 +163,9 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
-    ConcurrentHashMap<ProjectSubscriptionName, ExecutorProvider> executorProviderMap =
-        new ConcurrentHashMap<>();
+    ConcurrentHashMap<ProjectSubscriptionName, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
     executorProviderMap.put(
-        ProjectSubscriptionName.parse("projects/project/subscriptions/subscription-name"),
-        mockExecutorProvider);
+        ProjectSubscriptionName.parse("projects/project/subscriptions/subscription-name"), mockExecutorProvider);
     factory.setExecutorProviderMap(executorProviderMap);
 
     assertThat(factory.getExecutorProvider("subscription-name")).isSameAs(mockExecutorProvider);
@@ -178,11 +176,9 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
-    ConcurrentHashMap<ProjectSubscriptionName, ExecutorProvider> executorProviderMap =
-        new ConcurrentHashMap<>();
+    ConcurrentHashMap<ProjectSubscriptionName, ExecutorProvider> executorProviderMap = new ConcurrentHashMap<>();
     executorProviderMap.put(
-        ProjectSubscriptionName.parse("projects/project/subscriptions/subscription-name"),
-        mockExecutorProvider);
+        ProjectSubscriptionName.parse("projects/project/subscriptions/subscription-name"), mockExecutorProvider);
     factory.setExecutorProviderMap(executorProviderMap);
     factory.setExecutorProvider(mockGlobalExecutorProvider);
 
@@ -244,11 +240,8 @@ class DefaultSubscriberFactoryTests {
             .setRpcTimeoutMultiplier(10)
             .setMaxRpcTimeout(Duration.ofSeconds(10))
             .build();
-    ConcurrentHashMap<ProjectSubscriptionName, RetrySettings> settingsMap =
-        new ConcurrentHashMap<>();
-    settingsMap.put(
-        ProjectSubscriptionName.parse("projects/project/subscriptions/mySubscription"),
-        expectedRetrySettings);
+    ConcurrentHashMap<ProjectSubscriptionName, RetrySettings> settingsMap = new ConcurrentHashMap<>();
+    settingsMap.put(ProjectSubscriptionName.parse("projects/project/subscriptions/mySubscription"), expectedRetrySettings);
     factory.setRetrySettingsMap(settingsMap);
 
     RetrySettings actualRetrySettings = factory.getRetrySettings("mySubscription");
@@ -324,7 +317,8 @@ class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  void testBuildGlobalSubscriberStubSettings_retry_pickGlobalConfiguration() throws IOException {
+  void testBuildGlobalSubscriberStubSettings_retry_pickGlobalConfiguration()
+      throws IOException {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
     when(mockPubSubConfiguration.getSubscriber()).thenReturn(mockSubscriber);
@@ -369,16 +363,16 @@ class DefaultSubscriberFactoryTests {
             "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(2L);
     when(mockPubSubConfiguration.computeMinDurationPerAckExtension(
-            "defaultSubscription", projectIdProvider.getProjectId()))
+        "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(3L);
     when(mockPubSubConfiguration.computeMaxDurationPerAckExtension(
-            "defaultSubscription", projectIdProvider.getProjectId()))
+        "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(4L);
     when(mockPubSubConfiguration.computeParallelPullCount(
             "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(2);
     when(mockPubSubConfiguration.computePullEndpoint(
-            "defaultSubscription", projectIdProvider.getProjectId()))
+        "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn("test.endpoint");
     when(mockPubSubConfiguration.computeSubscriberUniverseDomain(
             "defaultSubscription", projectIdProvider.getProjectId()))
@@ -405,11 +399,14 @@ class DefaultSubscriberFactoryTests {
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
     factory.setCredentialsProvider(this.credentialsProvider);
     when(mockPubSubConfiguration.computeMinDurationPerAckExtension(
-            "defaultSubscription", projectIdProvider.getProjectId()))
+        "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(-4L);
 
     assertThatThrownBy(
-            () -> factory.createSubscriber("defaultSubscription", (message, consumer) -> {}))
+        () -> factory.createSubscriber(
+            "defaultSubscription",
+            (message, consumer) -> { }
+        ))
         .isExactlyInstanceOf(IllegalArgumentException.class);
   }
 
@@ -420,11 +417,14 @@ class DefaultSubscriberFactoryTests {
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
     factory.setCredentialsProvider(this.credentialsProvider);
     when(mockPubSubConfiguration.computeMaxDurationPerAckExtension(
-            "defaultSubscription", projectIdProvider.getProjectId()))
+        "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(-2L);
 
     assertThatThrownBy(
-            () -> factory.createSubscriber("defaultSubscription", (message, consumer) -> {}))
+        () -> factory.createSubscriber(
+            "defaultSubscription",
+            (message, consumer) -> { }
+        ))
         .isExactlyInstanceOf(IllegalArgumentException.class);
   }
 
@@ -435,14 +435,17 @@ class DefaultSubscriberFactoryTests {
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
     factory.setCredentialsProvider(this.credentialsProvider);
     when(mockPubSubConfiguration.computeMinDurationPerAckExtension(
-            "defaultSubscription", projectIdProvider.getProjectId()))
+        "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(4L);
     when(mockPubSubConfiguration.computeMaxDurationPerAckExtension(
-            "defaultSubscription", projectIdProvider.getProjectId()))
+        "defaultSubscription", projectIdProvider.getProjectId()))
         .thenReturn(3L);
 
     assertThatThrownBy(
-            () -> factory.createSubscriber("defaultSubscription", (message, consumer) -> {}))
+        () -> factory.createSubscriber(
+            "defaultSubscription",
+            (message, consumer) -> { }
+        ))
         .isExactlyInstanceOf(IllegalArgumentException.class);
   }
 
@@ -471,13 +474,10 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(() -> "project", mockPubSubConfiguration);
 
-    ConcurrentHashMap<ProjectSubscriptionName, FlowControlSettings> settingsMap =
-        new ConcurrentHashMap<>();
+    ConcurrentHashMap<ProjectSubscriptionName, FlowControlSettings> settingsMap = new ConcurrentHashMap<>();
     FlowControlSettings expectedFlowSettings =
         FlowControlSettings.newBuilder().setMaxOutstandingRequestBytes(10L).build();
-    settingsMap.put(
-        ProjectSubscriptionName.parse("projects/project/subscriptions/defaultSubscription1"),
-        expectedFlowSettings);
+    settingsMap.put(ProjectSubscriptionName.parse("projects/project/subscriptions/defaultSubscription1"), expectedFlowSettings);
     factory.setFlowControlSettingsMap(settingsMap);
 
     FlowControlSettings actualFlowSettings = factory.getFlowControlSettings("defaultSubscription1");
@@ -543,7 +543,7 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
     when(mockPubSubConfiguration.computeMinDurationPerAckExtension(
-            "subscription-name", projectIdProvider.getProjectId()))
+        "subscription-name", projectIdProvider.getProjectId()))
         .thenReturn(1L);
 
     assertThat(factory.getMinDurationPerAckExtension("subscription-name"))
@@ -556,9 +556,8 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
 
-    when(mockPubSubConfiguration.computeMinDurationPerAckExtension(
-            "subscription-name", projectIdProvider.getProjectId()))
-        .thenReturn(3L);
+    when(mockPubSubConfiguration.computeMinDurationPerAckExtension("subscription-name",
+        projectIdProvider.getProjectId())).thenReturn(3L);
 
     // subscription level setting is used when factory-level one is not provided
     assertThat(factory.getMinDurationPerAckExtension("subscription-name"))
@@ -578,9 +577,8 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
 
-    when(mockPubSubConfiguration.computeMaxDurationPerAckExtension(
-            "subscription-name", projectIdProvider.getProjectId()))
-        .thenReturn(3L);
+    when(mockPubSubConfiguration.computeMaxDurationPerAckExtension("subscription-name",
+        projectIdProvider.getProjectId())).thenReturn(3L);
 
     // subscription level setting is used when factory-level one is not provided
     assertThat(factory.getMaxDurationPerAckExtension("subscription-name"))
@@ -600,7 +598,8 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
 
-    assertThat(factory.getMinDurationPerAckExtension("subscription-name")).isNull();
+    assertThat(factory.getMinDurationPerAckExtension("subscription-name"))
+        .isNull();
   }
 
   @Test
@@ -609,7 +608,7 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
     when(mockPubSubConfiguration.computeMaxDurationPerAckExtension(
-            "subscription-name", projectIdProvider.getProjectId()))
+        "subscription-name", projectIdProvider.getProjectId()))
         .thenReturn(2L);
 
     assertThat(factory.getMaxDurationPerAckExtension("subscription-name"))
@@ -622,7 +621,8 @@ class DefaultSubscriberFactoryTests {
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, this.pubSubConfig);
 
-    assertThat(factory.getMaxDurationPerAckExtension("subscription-name")).isNull();
+    assertThat(factory.getMaxDurationPerAckExtension("subscription-name"))
+        .isNull();
   }
 
   @Test
@@ -755,7 +755,8 @@ class DefaultSubscriberFactoryTests {
   }
 
   @Test
-  void testBuildGlobalSubscriberStubSettings_retryableCodes_pickConfiguration() throws IOException {
+  void testBuildGlobalSubscriberStubSettings_retryableCodes_pickConfiguration()
+      throws IOException {
     GcpProjectIdProvider projectIdProvider = () -> "project";
     DefaultSubscriberFactory factory =
         new DefaultSubscriberFactory(projectIdProvider, mockPubSubConfiguration);
@@ -808,8 +809,7 @@ class DefaultSubscriberFactoryTests {
 
     when(healthTrackerRegistry.isTracked(subscriptionName)).thenReturn(true);
 
-    DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
+    DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
     factory.setCredentialsProvider(this.credentialsProvider);
     factory.setHealthTrackerRegistry(healthTrackerRegistry);
 
@@ -828,8 +828,7 @@ class DefaultSubscriberFactoryTests {
 
     when(healthTrackerRegistry.isTracked(subscriptionName)).thenReturn(false);
 
-    DefaultSubscriberFactory factory =
-        new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
+    DefaultSubscriberFactory factory = new DefaultSubscriberFactory(() -> "angeldust", pubSubConfig);
     factory.setCredentialsProvider(this.credentialsProvider);
     factory.setHealthTrackerRegistry(healthTrackerRegistry);
 


### PR DESCRIPTION
Notable Changes:
- Adds subscription-specific property for universe domain to customize `Subscriber`
- Adds global subscriber property for universe domain. In terms of priority. The subscription-specific property takes precedence if both global and subscription-specific properties are set. If subscription-specific configuration is not set then the global configuration is picked.
- Adds global publisher property for universe domain to customize `Publisher`. 


Verified behavior manually in separate test plan document. 
