### PR TITLE
fix: migrate logic to create tmpdir to build script

### DIFF
--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -21,7 +21,8 @@ set -eov pipefail
 setup_environment_secrets() {
   export GPG_PASSPHRASE=$(cat ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-passphrase)
   export GPG_TTY=$(tty)
-  export GPG_HOMEDIR=/tmpfs/src/gpg
+  export TMPDIR=$(mktemp -d)
+  export GPG_HOMEDIR=${TMPDIR}/gpg
   mkdir $GPG_HOMEDIR
   mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-pubkeyring $GPG_HOMEDIR/pubring.gpg
   mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-keyring $GPG_HOMEDIR/secring.gpg

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -23,6 +23,8 @@ setup_environment_secrets() {
   export GPG_TTY=$(tty)
   export GPG_HOMEDIR=${TMPDIR}/gpg
   mkdir $GPG_HOMEDIR
+  echo "content of '$KOKORO_KEYSTORE_DIR'"
+  ls -l "${KOKORO_KEYSTORE_DIR}"
   mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-pubkeyring $GPG_HOMEDIR/pubring.gpg
   mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-keyring $GPG_HOMEDIR/secring.gpg
   export SONATYPE_USERNAME=$(cat ${KOKORO_KEYSTORE_DIR}/70247_sonatype-credentials | cut -f1 -d'|')

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -21,10 +21,8 @@ set -eov pipefail
 setup_environment_secrets() {
   export GPG_PASSPHRASE=$(cat ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-passphrase)
   export GPG_TTY=$(tty)
-  export GPG_HOMEDIR=${TMPDIR}/gpg
+  export GPG_HOMEDIR=/tmpfs/src/gpg
   mkdir $GPG_HOMEDIR
-  echo "content of '$KOKORO_KEYSTORE_DIR'"
-  ls -l "${KOKORO_KEYSTORE_DIR}"
   mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-pubkeyring $GPG_HOMEDIR/pubring.gpg
   mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-keyring $GPG_HOMEDIR/secring.gpg
   export SONATYPE_USERNAME=$(cat ${KOKORO_KEYSTORE_DIR}/70247_sonatype-credentials | cut -f1 -d'|')

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -13,7 +13,7 @@ pushd $dir/../
 PROJECT_VERSION=$(grep "^spring-cloud-gcp:" "./versions.txt" | cut -d: -f3)
 
 # install docuploader package
-sudo python3 -m pip install --require-hashes -r .kokoro/requirements.txt
+su python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 
 # Build the javadocs
 mvn clean javadoc:aggregate -Drelease=true

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -13,8 +13,7 @@ pushd $dir/../
 PROJECT_VERSION=$(grep "^spring-cloud-gcp:" "./versions.txt" | cut -d: -f3)
 
 # install docuploader package
-python3 -m ensurepip --upgrade
-python3 -m pip install --require-hashes -r .kokoro/requirements.txt
+sudo python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 
 # Build the javadocs
 mvn clean javadoc:aggregate -Drelease=true

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -13,6 +13,8 @@ pushd $dir/../
 PROJECT_VERSION=$(grep "^spring-cloud-gcp:" "./versions.txt" | cut -d: -f3)
 
 # install docuploader package
+pip3 --version
+python3 -m ensurepip --upgrade
 python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 
 # Build the javadocs

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -13,7 +13,7 @@ pushd $dir/../
 PROJECT_VERSION=$(grep "^spring-cloud-gcp:" "./versions.txt" | cut -d: -f3)
 
 # install docuploader package
-su python3 -m pip install --require-hashes -r .kokoro/requirements.txt
+python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 
 # Build the javadocs
 mvn clean javadoc:aggregate -Drelease=true

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -13,7 +13,6 @@ pushd $dir/../
 PROJECT_VERSION=$(grep "^spring-cloud-gcp:" "./versions.txt" | cut -d: -f3)
 
 # install docuploader package
-pip3 --version
 python3 -m ensurepip --upgrade
 python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 


### PR DESCRIPTION
There was logic in the original trampoline.py script we are migrating off of to create the tmpdir.  Moved to the common.sh script where its required.