### PR TITLE
fix: migrate logic to create tmpdir to build script (#3367)

### DIFF
--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -21,6 +21,7 @@ set -eov pipefail
 setup_environment_secrets() {
   export GPG_PASSPHRASE=$(cat ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-passphrase)
   export GPG_TTY=$(tty)
+  export TMPDIR=$(mktemp -d)
   export GPG_HOMEDIR=${TMPDIR}/gpg
   mkdir $GPG_HOMEDIR
   mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-pubkeyring $GPG_HOMEDIR/pubring.gpg


### PR DESCRIPTION
Since we're no longer using trampoline.py, the logic to create a tmp dir needs to be migrated from it directly to the build script