### PR TITLE
fix: include limit in query for findFirst and findTop support in Firestore

### DIFF
--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/repository/query/PartTreeFirestoreQuery.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/repository/query/PartTreeFirestoreQuery.java
@@ -156,8 +156,8 @@ public class PartTreeFirestoreQuery implements RepositoryQuery {
       sort = paramAccessor.getSort();
     }
 
-    if (getQueryMethod().getName().startsWith("findFirst") ||
-            getQueryMethod().getName().startsWith("findTop")) {
+    if (getQueryMethod().getName().startsWith("findFirst")
+        || getQueryMethod().getName().startsWith("findTop")) {
       builder.setLimit(Int32Value.newBuilder().setValue(1));
     }
 

--- a/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/repository/query/PartTreeFirestoreQuery.java
+++ b/spring-cloud-gcp-data-firestore/src/main/java/com/google/cloud/spring/data/firestore/repository/query/PartTreeFirestoreQuery.java
@@ -156,6 +156,11 @@ public class PartTreeFirestoreQuery implements RepositoryQuery {
       sort = paramAccessor.getSort();
     }
 
+    if (getQueryMethod().getName().startsWith("findFirst") ||
+            getQueryMethod().getName().startsWith("findTop")) {
+      builder.setLimit(Int32Value.newBuilder().setValue(1));
+    }
+
     if (sort == null || sort.isUnsorted()) {
       sort = this.tree.getSort();
     }

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/entities/UserRepository.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/entities/UserRepository.java
@@ -28,6 +28,10 @@ import reactor.core.publisher.Mono;
 public interface UserRepository extends FirestoreReactiveRepository<User> {
   Flux<User> findBy(Pageable pageable);
 
+  Mono<User> findFirstByAge(Integer age);
+
+  Mono<User> findTopByAge(Integer age);
+
   Flux<User> findByAge(Integer age);
 
   Flux<User> findByAge(Integer age, Sort sort);

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/it/FirestoreRepositoryIntegrationTests.java
@@ -343,4 +343,34 @@ class FirestoreRepositoryIntegrationTests {
     userRepository.save(user).block();
     // no optimistic locking exception expected
   }
+
+  @Test
+  public void testFirstByAge() {
+    User alice = new User("Alice", 99);
+    User bob = new User("Bob", 99);
+    User zelda = new User("Zelda", 23);
+    this.userRepository
+        .save(alice)
+        .then(this.userRepository.save(bob))
+        .then(this.userRepository.save(zelda))
+        .block();
+
+    Mono<User> testUser = this.userRepository.findFirstByAge(99);
+    assertThat(testUser.block().getName()).isEqualTo("Alice");
+  }
+
+  @Test
+  public void testTopByAge() {
+    User alice = new User("Alice", 99);
+    User bob = new User("Bob", 99);
+    User zelda = new User("Zelda", 23);
+    this.userRepository
+            .save(alice)
+            .then(this.userRepository.save(bob))
+            .then(this.userRepository.save(zelda))
+            .block();
+
+    Mono<User> testUser = this.userRepository.findTopByAge(99);
+    assertThat(testUser.block().getName()).isEqualTo("Alice");
+  }
 }

--- a/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/repository/query/PartTreeFirestoreQueryTests.java
+++ b/spring-cloud-gcp-data-firestore/src/test/java/com/google/cloud/spring/data/firestore/repository/query/PartTreeFirestoreQueryTests.java
@@ -31,9 +31,8 @@ import com.google.cloud.spring.data.firestore.mapping.FirestoreDefaultClassMappe
 import com.google.cloud.spring.data.firestore.mapping.FirestoreMappingContext;
 import com.google.firestore.v1.StructuredQuery;
 import com.google.firestore.v1.Value;
-import java.util.function.Consumer;
-
 import com.google.protobuf.Int32Value;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.springframework.data.repository.query.Parameters;

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserRepository.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserRepository.java
@@ -26,5 +26,4 @@ public interface UserRepository extends FirestoreReactiveRepository<User> {
 
   Flux<User> findByAge(int age);
 
-  Flux<User> findFirstByAge(Integer age);
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserRepository.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserRepository.java
@@ -25,4 +25,6 @@ import reactor.core.publisher.Flux;
 public interface UserRepository extends FirestoreReactiveRepository<User> {
 
   Flux<User> findByAge(int age);
+
+  Flux<User> findFirstByAge(Integer age);
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserRepository.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-firestore-sample/src/main/java/com/example/UserRepository.java
@@ -25,5 +25,4 @@ import reactor.core.publisher.Flux;
 public interface UserRepository extends FirestoreReactiveRepository<User> {
 
   Flux<User> findByAge(int age);
-
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/2859 

This PR always includes a query limit of 1 when either findFirst or findTop are used. 