### PR TITLE
fix: increase default pubsub health indicator timeout from 2000ms to 5000ms

### DIFF
--- a/docs/src/main/asciidoc/pubsub.adoc
+++ b/docs/src/main/asciidoc/pubsub.adoc
@@ -237,7 +237,7 @@ So, take care not to configure a subscription that has a business impact, or ins
 | Name | Description | Required | Default value
 | `management.health.pubsub.enabled` | Whether to enable the Pub/Sub health indicator | No | `true` with Spring Boot Actuator, `false` otherwise
 | `spring.cloud.gcp.pubsub.health.subscription` | Subscription to health check against by pulling a message | No | Random non-existent
-| `spring.cloud.gcp.pubsub.health.timeout-millis` | Milliseconds to wait for response from Pub/Sub before timing out | No | `2000`
+| `spring.cloud.gcp.pubsub.health.timeout-millis` | Milliseconds to wait for response from Pub/Sub before timing out | No | `5000`
 | `spring.cloud.gcp.pubsub.health.acknowledge-messages` | Whether to acknowledge messages pulled from the optionally specified subscription | No | `false`
 |===
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicatorProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicatorProperties.java
@@ -26,7 +26,7 @@ public class PubSubHealthIndicatorProperties {
   private String subscription;
 
   /** Milliseconds to wait for response from Pub/Sub before timing out. */
-  private Long timeoutMillis = 2000L;
+  private Long timeoutMillis = 5000L;
 
   /** Whether to acknowledge messages pulled from {@link #subscription}. */
   private boolean acknowledgeMessages = false;

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/pubsub/health/PubSubHealthIndicatorAutoConfigurationTests.java
@@ -70,7 +70,7 @@ class PubSubHealthIndicatorAutoConfigurationTests {
               PubSubHealthIndicator healthIndicator = ctx.getBean(PubSubHealthIndicator.class);
               assertThat(healthIndicator).isNotNull();
               assertThat(healthIndicator.getSubscription()).matches(UUID_PATTERN);
-              assertThat(healthIndicator.getTimeoutMillis()).isEqualTo(2000);
+              assertThat(healthIndicator.getTimeoutMillis()).isEqualTo(5000);
               assertThat(healthIndicator.isAcknowledgeMessages()).isFalse();
               assertThat(healthIndicator.isSpecifiedSubscription()).isFalse();
             });


### PR DESCRIPTION
We have received an internal request from the Pub/Sub team to increase the default from its current 2s value. (See b/380915972)

(There was a previous default timeout value increase from 1s to 2s: #419)