### PR TITLE
chore: remove override_targets

### DIFF
--- a/spring-cloud-generator/scripts/resources/googleapis_modification_string.txt
+++ b/spring-cloud-generator/scripts/resources/googleapis_modification_string.txt
@@ -6,7 +6,6 @@ maven_install(
       ] +
       IO_GRPC_GRPC_JAVA_ARTIFACTS,
     generate_compat_repositories = True,
-    override_targets = IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS,
     #Update this False for local development
     fail_on_missing_checksum = False,
     repositories = [


### PR DESCRIPTION
`override_targets` is removed from googleapis/WORKSPACE in cl/696966324