### PR TITLE
deps: revert spring-cloud-config.version from 4.2.0 to 4.1.3"

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
@@ -14,7 +14,7 @@
     <name>Spring Framework on Google Cloud Code Sample - Pub/Sub Bus Configuration Management</name>
 
     <properties>
-        <spring-cloud-config.version>4.2.0</spring-cloud-config.version>
+        <spring-cloud-config.version>4.1.3</spring-cloud-config.version>
     </properties>
 
     <!-- The Spring Framework on Google Cloud BOM will manage spring-cloud-gcp version numbers for you. -->


### PR DESCRIPTION
Reverts GoogleCloudPlatform/spring-cloud-gcp#3433

According to https://github.com/spring-cloud/spring-cloud-release/wiki/Supported-Versions 4.2.x is compatible with Spring Cloud 2023.0 and 2024.0 (our 5.x, 6.x), 4.1.x compatible with 2022.0 (4.x branch)