### PR TITLE
chore: update dependabot to ignore spring-cloud-config updates for 4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,3 +80,8 @@ updates:
     # Spring Shell dependencies
     - dependency-name: "org.springframework.shell:spring-shell-starter"
       versions: [">=3.2.0"]
+    # Spring Cloud Config dependencies
+    - dependency-name: "org.springframework.cloud:spring-cloud-config-dependencies"
+      versions: [">=4.2.0"]
+    - dependency-name: "org.springframework.cloud:spring-cloud-starter-bootstrap"
+      versions: [">=4.2.0"]


### PR DESCRIPTION
context: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3448

our 4.x branch should be compatible with Spring Cloud 2022.0, and thus Spring Cloud Config 4.1.x 