### PR TITLE
docs: fix references about other integrations in spanner doc (#3413)

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -956,7 +956,7 @@ This feature requires a bean of `SpannerTransactionManager`, which is provided w
 If a method annotated with `@Transactional` calls another method also annotated, then both methods will work within the same transaction.
 `performReadOnlyTransaction` and `performReadWriteTransaction` cannot be used in `@Transactional` annotated methods because Cloud Spanner does not support transactions within transactions.
 
-Other Google Cloud database-related integrations like Spanner and Firestore can introduce `PlatformTransactionManager` beans, and can interfere with Datastore Transaction Manager. To disambiguate, explicitly specify the name of the transaction manager bean for such `@Transactional` methods. Example:
+Other Google Cloud database-related integrations like Datastore and Firestore can introduce `PlatformTransactionManager` beans, and can interfere with Spanner Transaction Manager. To disambiguate, explicitly specify the name of the transaction manager bean for such `@Transactional` methods. Example:
 
 [source,java]
 ----


### PR DESCRIPTION

backport https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3413