### PR TITLE
chore: update native tests actions/upload-artifact to v4.

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -106,7 +106,7 @@ jobs:
       - name: Archive logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Native Test Logs
           path: |


### PR DESCRIPTION
See deprecation notice: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Native test workflows are failing now:
https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/12811784967

Other workflows are already upgraded in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3204

This change should also be backported to 4.x (failed workflow [log](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/12811782688))