### PR TITLE
fix: do not explicitly set python version for publish-javadoc script

### DIFF
--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -5,8 +5,6 @@ if [[ -z "${CREDENTIALS}" ]]; then
   CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
 fi
 
-pyenv global 3.7.2
-
 # Get into the spring-cloud-gcp repo directory
 dir=$(dirname "$0")
 pushd $dir/../


### PR DESCRIPTION
use one provided in docker image
