### PR TITLE
chore: Disable Sonar if PR comes from a fork

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -16,6 +16,8 @@ jobs:
   sonar:
     name: Build with Sonar
     runs-on: ubuntu-20.04
+    # Sonar Token can't be passed to PRs from forks. Disable Sonar workflow unless PR is from a branch.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Get current date
         id: date


### PR DESCRIPTION
sonar checks from forks does not have access to secret so sonar ci constantly failing for them