### PR TITLE
docs: update secret manager documentation

### DIFF
--- a/docs/src/main/asciidoc/secretmanager.adoc
+++ b/docs/src/main/asciidoc/secretmanager.adoc
@@ -51,28 +51,31 @@ If set to `true`, `null` will be returned when accessing a non-existent secret; 
 The Spring Framework on Google Cloud integration for Google Cloud Secret Manager enables you to use Secret Manager as an external config data resource.
 This allows you to specify and load secrets from Google Cloud Secret Manager as properties into the application context using https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4[Spring Boot's Config Data API].
 
+**NOTE**: In `6.0.0`, we introduced a new syntax for secrets `sm@secret_id`. This new syntax is the recommended one and usage of the old
+`sm://secret_id` syntax will issue a warning discouraging its usage.
+
 The Secret Manager config data resource uses the following syntax to specify secrets:
 
 [source]
 ----
 # 1. Long form - specify the project ID, secret ID, and version
-sm://projects/<project-id>/secrets/<secret-id>/versions/<version-id>}
+sm@projects/<project-id>/secrets/<secret-id>/versions/<version-id>}
 
 # 2.  Long form - specify project ID, secret ID, and use latest version
-sm://projects/<project-id>/secrets/<secret-id>
+sm@projects/<project-id>/secrets/<secret-id>
 
 # 3. Short form - specify project ID, secret ID, and version
-sm://<project-id>/<secret-id>/<version-id>
+sm@<project-id>/<secret-id>/<version-id>
 
 # 4. Short form - default project; specify secret + version
 #
 # The project is inferred from the spring.cloud.gcp.secretmanager.project-id setting
 # in your application.properties (see Configuration) or from application-default credentials if
 # this is not set.
-sm://<secret-id>/<version>
+sm@<secret-id>/<version>
 
 # 5. Shortest form - specify secret ID, use default project and latest version.
-sm://<secret-id>
+sm@<secret-id>
 ----
 
 You can use this syntax in the following places:
@@ -82,8 +85,8 @@ You can use this syntax in the following places:
 [source]
 ----
 # Example of the project-secret long-form syntax.
-spring.config.import=sm://
-spring.datasource.password=${sm://projects/my-gcp-project/secrets/my-secret}
+spring.config.import=sm@
+spring.datasource.password=${sm@projects/my-gcp-project/secrets/my-secret}
 ----
 The former is used to enable https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4[Spring Boot's Config Data API].
 
@@ -92,7 +95,7 @@ The former is used to enable https://spring.io/blog/2020/08/14/config-file-proce
 [source]
 ----
 // Example of using shortest form syntax.
-@Value("${sm://my-secret}")
+@Value("${sm@my-secret}")
 ----
 
 === Secret Manager Template
@@ -149,7 +152,7 @@ However, if your want to use a default value in such a scenario, you can add the
 `spring.cloud.gcp.secretmanager.allow-default-secret=true`
 ----
 
-Therefore, a variable annotated with `@Value("${${sm://application-fake}:DEFAULT}")` will be resolved as `DEFAULT` when there is no `application-fake` in Secret Manager and `application-fake` is NOT a valid application property.
+Therefore, a variable annotated with `@Value("${${sm@application-fake}:DEFAULT}")` will be resolved as `DEFAULT` when there is no `application-fake` in Secret Manager and `application-fake` is NOT a valid application property.
 
 === Sample
 


### PR DESCRIPTION
This PR explains the introduction of the `sm@` syntax introduced by https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3411

From its description:
We will introduce support for resolving values of the form `sm@secret_id` in addition to the already existing `sm://secret_id` format. Users should move away from `sm://` and use `sm@` instead. Usage of `sm://` will raise a warning about this being removed in the future. This has been tested using `spring-framework:6.2.2-SNAPSHOT`.

The introduction of this syntax was suggested in a discussion of a regression caused by spring-framework:6.2.1 - see https://github.com/spring-projects/spring-framework/issues/34124



































































































































































































































