### PR TITLE
docs: correct readme versions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,8 +14,8 @@ For a deep dive into the project, refer to the Spring Framework on Google Cloud 
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.0.0/reference/html/index.html[Spring Framework on Google Cloud 6.0.0 (Latest)] - https://googleapis.dev/java/spring-cloud-gcp/6.0.0/index.html[Javadocs 6.0.0]
 // {x-version-update-end}
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/5.11.0/reference/html/index.html[Spring Framework on Google Cloud 5.11.0] - https://googleapis.dev/java/spring-cloud-gcp/5.11.0/index.html[Javadocs 5.11.0]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/4.10.15/reference/html/index.html[Spring Framework on Google Cloud 4.10.15] - https://googleapis.dev/java/spring-cloud-gcp/4.10.16/index.html[Javadocs 4.10.16]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.8.15/reference/html/index.html[Spring Framework on Google Cloud 3.8.15] - https://googleapis.dev/java/spring-cloud-gcp/3.8.14/index.html[Javadocs 3.8.15]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/4.10.16/reference/html/index.html[Spring Framework on Google Cloud 4.10.16] - https://googleapis.dev/java/spring-cloud-gcp/4.10.16/index.html[Javadocs 4.10.16]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.8.15/reference/html/index.html[Spring Framework on Google Cloud 3.8.15] - https://googleapis.dev/java/spring-cloud-gcp/3.8.15/index.html[Javadocs 3.8.15]
 
 If you prefer to learn by doing, try taking a look at the https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples[Spring Framework on Google Cloud sample applications] or the https://codelabs.developers.google.com/spring[Spring on Google Cloud codelabs].
 


### PR DESCRIPTION
Corrects documentation and javadoc links in readme.

Stemmed from https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3533#issuecomment-2650441691