### PR TITLE
chore: use cloud java bot token in autoconfig generation job checkout

### DIFF
--- a/.github/workflows/generateAutoConfigs.yaml
+++ b/.github/workflows/generateAutoConfigs.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           java-version: 17
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
       - run: bazelisk version
       - uses: actions/setup-go@v3
       - name: Install buildozer


### PR DESCRIPTION
The job https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/13709162243 failed with 

```
remote: Permission to GoogleCloudPlatform/spring-cloud-gcp.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/GoogleCloudPlatform/spring-cloud-gcp/': The requested URL returned error: 403
```

This is because the GH actions bot does not have repo access. We here configure the action to use Cloud Java Bot instead.