### PR TITLE
ci: grant permission to doc jobs

### DIFF
--- a/.github/workflows/updateDocs.yaml
+++ b/.github/workflows/updateDocs.yaml
@@ -19,6 +19,9 @@ on:
 jobs:
   updateDocs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - name: Get current date
       id: date


### PR DESCRIPTION
Similar to https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3677.

This should resolve the failure:

```
+ git push origin gh-pages
remote: Permission to GoogleCloudPlatform/spring-cloud-gcp.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/GoogleCloudPlatform/spring-cloud-gcp/': The requested URL returned error: 403
```

b/406213068
