### PR TITLE
fix: secretmanager to be an optional dep in autoconfig module

### DIFF
--- a/spring-cloud-gcp-autoconfigure/pom.xml
+++ b/spring-cloud-gcp-autoconfigure/pom.xml
@@ -275,10 +275,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>spring-cloud-gcp-secretmanager</artifactId>
-            <!-- A few starters need this dependency to validate secrets -->
-            <!-- using SecretManagerSyntaxUtils. Making it optional produces runtime failures -->
-            <!-- of the kind ClassNotFoundError. -->
-            <optional>false</optional>
+            <optional>true</optional>
         </dependency>
 
         <!-- KMS -->

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -57,7 +57,7 @@ public class SecretManagerConfigDataLocationResolver implements
    * Checks if the property can be resolved by the Secret Manager resolver.
    * For the check, we rely on the presence of the SecretManagerSyntaxUtils class, which is an
    * optional dependency.
-   * Since optional dependencies can not be present at runtime, we explicitly check for its
+   * Since optional dependencies may not be present at runtime, we explicitly check for its
    * existence before resolving the property.
    * If it's not present, it means this config resolver (which operates at early stages of Spring
    * initialization) is not meant to be used.

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -59,8 +59,7 @@ public class SecretManagerConfigDataLocationResolver implements
    * optional dependency.
    * Since optional dependencies may not be present at runtime, we explicitly check for its
    * existence before resolving the property.
-   * If it's not present, it means this config resolver (which operates at early stages of Spring
-   * initialization) is not meant to be used.
+   * If it's not present, it means this config resolver is not meant to be used.
    * @return true if it contains the expected `sm@` or `sm://` prefix, false otherwise.
    */
   @Override

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerConfigDataLocationResolver.java
@@ -60,6 +60,7 @@ public class SecretManagerConfigDataLocationResolver implements
    * Since optional dependencies may not be present at runtime, we explicitly check for its
    * existence before resolving the property.
    * If it's not present, it means this config resolver is not meant to be used.
+   *
    * @return true if it contains the expected `sm@` or `sm://` prefix, false otherwise.
    */
   @Override
@@ -75,9 +76,10 @@ public class SecretManagerConfigDataLocationResolver implements
   }
 
   /**
+   * Checks if the specified class is present in this runtime.
    *
-   * @param clazzFullName
-   * @return Whether the specified class is present in this runtime.
+   * @param clazzFullName the full name of the class for the existence check
+   * @return true if present
    */
   private boolean isClassPresent(String clazzFullName) {
     try {


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3560 ☕ 

It marks the secretmanager dependency as optional. The config loader in the Secret Manager autoconfig was assuming the existence of the now optional Secret Manager integration.
We now check for the class to be present before resolving the properties
