### PR TITLE
fix: #3694: Producer destination: ensure topic exists or create one only if auto create resource is true

### DIFF
--- a/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/main/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisioner.java
@@ -58,7 +58,10 @@ public class PubSubChannelProvisioner
   @Override
   public ProducerDestination provisionProducerDestination(
       String topic, ExtendedProducerProperties<PubSubProducerProperties> properties) {
-    ensureTopicExists(topic, properties.getExtension().isAutoCreateResources());
+    boolean autoCreate = properties.getExtension().isAutoCreateResources();
+    if (autoCreate) {
+      ensureTopicExists(topic, autoCreate);
+    }
 
     return new PubSubProducerDestination(topic);
   }

--- a/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
+++ b/spring-cloud-gcp-pubsub-stream-binder/src/test/java/com/google/cloud/spring/stream/binder/pubsub/provisioning/PubSubChannelProvisionerTests.java
@@ -390,17 +390,4 @@ class PubSubChannelProvisionerTests {
 
     assertThat(destination.getName()).isEqualTo("topic_A");
   }
-
-  @Test
-  void testProvisionProducerDestination_dontCreateTopic() {
-    when(this.pubSubProducerProperties.isAutoCreateResources()).thenReturn(false);
-    when(this.pubSubAdminMock.getTopic(any())).thenReturn(null);
-
-    assertThatExceptionOfType(ProvisioningException.class)
-        .isThrownBy(
-            () ->
-                this.pubSubChannelProvisioner.provisionProducerDestination(
-                    "not_yet_created", extendedProducerProperties))
-        .withMessageContaining("Non-existing");
-  }
 }


### PR DESCRIPTION
 fix: #3694   Producer destination: ensure topic exists or create one only if auto create resource is true
