### PR TITLE
chore: add JDK 17 to Native Tests pool

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -26,6 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         graalvm_for_jdk_version:
+          - 17
           - 21
           - 23
         it:

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -35,7 +35,7 @@
 
 	<properties>
 		<gcp-libraries-bom.version>26.57.0</gcp-libraries-bom.version>
-		<cloud-sql-socket-factory.version>1.23.1</cloud-sql-socket-factory.version>
+		<cloud-sql-socket-factory.version>1.25.0</cloud-sql-socket-factory.version>
 		<r2dbc-postgres-driver.version>1.0.7.RELEASE</r2dbc-postgres-driver.version>
 		<cloud-spanner-r2dbc.version>1.3.0</cloud-spanner-r2dbc.version>
 		<alloydb-jdbc-connector.version>1.2.0</alloydb-jdbc-connector.version>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -4,13 +4,14 @@
 # Please refer to the Spring Cloud GCP Secret Manager reference documentation for the full protocol syntax.
 
 # You can also specify a secret from another project.
-# example.property=${sm://MY_PROJECT/MY_SECRET_ID/MY_VERSION}
+# example.property=${sm@MY_PROJECT/MY_SECRET_ID/MY_VERSION}
 
 # Using SpEL, you can reference an environment variable and fallback to a secret if it is missing.
-# example.secret=${MY_ENV_VARIABLE:${sm://application-secret/latest}}
+# example.secret=${MY_ENV_VARIABLE:${sm@application-secret/latest}}
 
 management.endpoints.web.exposure.include=refresh
-# enable external resource from GCP Secret Manager.
+
+# Enable external resource from GCP Secret Manager.
 # Here we enable the config loader for GCP Secret Manager
 # The sm:// syntax has been Deprecated and may be removed in a future version of
 # Spring Cloud GCP. Please use the sm@ syntax instead.

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/aot/SecretManagerRuntimeHints.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/aot/SecretManagerRuntimeHints.java
@@ -1,0 +1,22 @@
+package com.google.cloud.spring.secretmanager.aot;
+
+import com.google.cloud.spring.secretmanager.SecretManagerSyntaxUtils;
+import java.util.Arrays;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+
+public class SecretManagerRuntimeHints implements RuntimeHintsRegistrar {
+  @Override
+  public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+    hints
+        .reflection()
+        .registerTypes(
+            Arrays.asList(TypeReference.of(SecretManagerSyntaxUtils.class)),
+            hint ->
+                hint.withMembers(
+                    MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                    MemberCategory.INVOKE_PUBLIC_METHODS));
+  }
+}

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/aot/SecretManagerRuntimeHints.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/aot/SecretManagerRuntimeHints.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spring.secretmanager.aot;
 
 import com.google.cloud.spring.secretmanager.SecretManagerSyntaxUtils;

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/aot/SecretManagerRuntimeHints.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/aot/SecretManagerRuntimeHints.java
@@ -23,6 +23,10 @@ import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
 
+/**
+ * Runtime Hints for Secret Manager. For now, this is only necessary to enable image generation with
+ * GraalVM for JDK 17. GraalVM for JDK 21 and 23 do not need this hint.
+ */
 public class SecretManagerRuntimeHints implements RuntimeHintsRegistrar {
   @Override
   public void registerHints(RuntimeHints hints, ClassLoader classLoader) {

--- a/spring-cloud-gcp-secretmanager/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-cloud-gcp-secretmanager/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=\
+	com.google.cloud.spring.secretmanager.aot.SecretManagerRuntimeHints

--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/aot/SecretManagerRuntimeHintsTest.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/aot/SecretManagerRuntimeHintsTest.java
@@ -1,0 +1,20 @@
+package com.google.cloud.spring.secretmanager.aot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.aot.hint.predicate.RuntimeHintsPredicates.reflection;
+
+import com.google.cloud.spring.secretmanager.SecretManagerSyntaxUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.RuntimeHints;
+
+public class SecretManagerRuntimeHintsTest {
+  @Test
+  void shouldRegisterHints() {
+    RuntimeHints hints = new RuntimeHints();
+    new SecretManagerRuntimeHints().registerHints(hints, getClass().getClassLoader());
+
+    assertThat(hints)
+        .matches(reflection().onType(SecretManagerSyntaxUtils.class));
+  }
+}
+

--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/aot/SecretManagerRuntimeHintsTest.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/aot/SecretManagerRuntimeHintsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spring.secretmanager.aot;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
[Context doc](https://docs.google.com/document/d/1bOeGtVFLsq5ts71If5pFXCvHIeNpbtBRvF6XQfavLZs/edit?tab=t.0#heading=h.gxq6ycxusimq)

Includes runtime hint for secret manager as per https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3706#discussion_r2050999672

#### Update to Cloud SQL socket
Apr 15, 2025 the Cloud SQL folks solved the concern for Graal 17 support in [jdbc-socket-factory#2140](https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/issues/2140#event-17212837470) by removing the flag. They released [1.24.2](https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/releases/tag/v1.24.2) with this change.
