### PR TITLE
test: assert default value in secret manager sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/java/com/example/SecretManagerWebController.java
@@ -55,7 +55,7 @@ public class SecretManagerWebController {
   // in property files.
   // When using the new syntax, it is not necessary to escape the colon character by nesting
   // placeholders as done with the legacy syntax (${${sm://secret}:DEFAULT}).
-  @Value("${sm@application-fake:DEFAULT}")
+  @Value("${${env_var_for_secret}:DEFAULT}")
   private String defaultSecret;
 
   // Application secrets can be accessed using @Value syntax.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/main/resources/application.properties
@@ -8,6 +8,7 @@
 
 # Using SpEL, you can reference an environment variable and fallback to a secret if it is missing.
 # example.secret=${MY_ENV_VARIABLE:${sm://application-secret/latest}}
+env_var_for_secret=sm@application-fake
 
 management.endpoints.web.exposure.include=refresh
 # enable external resource from GCP Secret Manager.

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleLoadSecretsIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleLoadSecretsIntegrationTests.java
@@ -44,7 +44,7 @@ class SecretManagerSampleLoadSecretsIntegrationTests {
   @Autowired private TestRestTemplate testRestTemplate;
 
   private static final String SECRET_CONTENT = "Hello world.";
-  private static final String DEFAULT_CONTENT = "DEFAULT.";
+  private static final String DEFAULT_CONTENT = "DEFAULT";
 
   @Test
   void testApplicationStartupSecretLoadsCorrectly() {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleLoadSecretsIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-secretmanager-sample/src/test/java/com/example/SecretManagerSampleLoadSecretsIntegrationTests.java
@@ -44,11 +44,15 @@ class SecretManagerSampleLoadSecretsIntegrationTests {
   @Autowired private TestRestTemplate testRestTemplate;
 
   private static final String SECRET_CONTENT = "Hello world.";
+  private static final String DEFAULT_CONTENT = "DEFAULT.";
 
   @Test
   void testApplicationStartupSecretLoadsCorrectly() {
     ResponseEntity<String> response = this.testRestTemplate.getForEntity("/", String.class);
     assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+
+    assertThat(response.getBody())
+        .contains("<b>Default Application secret if not found:</b> <i>" + DEFAULT_CONTENT + "</i><br/>");
     assertThat(response.getBody())
         .contains("<b>Application secret from @Value:</b> <i>" + SECRET_CONTENT + "</i>");
     assertThat(response.getBody())


### PR DESCRIPTION
Confirmation of indicated behavior in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3440#issuecomment-2809250844

> If the secret doesn't exist, are we saying that null will be returned and default_value should be used? Because that's not what I'm seeing in 6.x, the application fails to start with Failed to bind properties under {etc etc etc}.