### PR TITLE
feat: add method createBlobFrom(InputStream) to GoogleStorageResource

### DIFF
--- a/spring-cloud-gcp-storage/src/main/java/com/google/cloud/spring/storage/GoogleStorageResource.java
+++ b/spring-cloud-gcp-storage/src/main/java/com/google/cloud/spring/storage/GoogleStorageResource.java
@@ -206,6 +206,21 @@ public class GoogleStorageResource implements WritableResource {
   }
 
   /**
+   * Creates the blob that this {@link GoogleStorageResource} represents in Google Cloud Storage and
+   * fills it with provided stream of data.
+   *
+   * @param inputStream data read from the InputStream will be used as the initial content of the
+   *     bucket object
+   * @return the created blob object
+   * @throws IOException on I/O error
+   * @throws StorageException if any errors during blob creation arise, such as if the blob already
+   *     exists
+   */
+  public Blob createBlobFrom(InputStream inputStream) throws IOException {
+    return this.storage.createFrom(BlobInfo.newBuilder(getBlobId()).build(), inputStream);
+  }
+
+  /**
    * Creates the bucket that this resource references in Google Cloud Storage.
    *
    * @return the {@link Bucket} object for the bucket

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/it/GoogleStorageIntegrationTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/it/GoogleStorageIntegrationTests.java
@@ -27,6 +27,7 @@ import com.google.cloud.spring.storage.GoogleStorageProtocolResolver;
 import com.google.cloud.spring.storage.GoogleStorageResource;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -93,6 +94,28 @@ class GoogleStorageIntegrationTests {
     try (InputStream is = this.resource.getInputStream()) {
       assertThat(StreamUtils.copyToString(is, Charset.defaultCharset())).isEqualTo(message);
     }
+  }
+
+  @Test
+  void createFromStreamTest() throws IOException {
+
+    String message = "test message";
+    InputStream inputStream = new ByteArrayInputStream(message.getBytes());
+
+    thisResource().createBlobFrom(inputStream);
+
+    assertThat(this.resource)
+        .returns(true, Resource::exists)
+        .extracting(
+            res -> {
+              try {
+                return res.getInputStream();
+              } catch (IOException e) {
+                throw new AssertionError(e);
+              }
+            })
+        .asString()
+        .isEqualTo(message);
   }
 
   @Test


### PR DESCRIPTION
fixes #3392

Contrary to the suggestion in the issue, I have chosen to name the method `createBlobFrom` instead of `createFrom`. This method is actually part of the `GoogleStorageResource` class, not the `Blob` one. Given that it creates a `Blob`, I found the proposed name to be misleading.