### PR TITLE
fix: update libraries-bom to 26.60.0 and add support for Interval and UUID

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -19,6 +19,7 @@ package com.google.cloud.spring.data.spanner.core.convert;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation.WriteBuilder;
 import com.google.cloud.spanner.Struct;
@@ -38,6 +39,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -65,7 +67,8 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
                   ByteArray.class,
                   Timestamp.class,
                   com.google.cloud.Date.class,
-                  BigDecimal.class)));
+                  BigDecimal.class,
+                  UUID.class)));
 
   /** A map of types to functions that binds them to `ValueBinder` objects. */
   public static final Map<Class<?>, BiFunction<ValueBinder, ?, ?>>
@@ -86,6 +89,8 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
     map.put(Date.class, ValueBinder::toDateArray);
     map.put(ByteArray.class, ValueBinder::toBytesArray);
     map.put(String.class, ValueBinder::toStringArray);
+    map.put(Interval.class, ValueBinder::toIntervalArray);
+    map.put(UUID.class, ValueBinder::toUuidArray);
 
     return Collections.unmodifiableMap(map);
   }
@@ -110,7 +115,8 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
     map.put(boolean[].class, (BiFunction<ValueBinder, boolean[], ?>) ValueBinder::toBoolArray);
     map.put(long[].class, (BiFunction<ValueBinder, long[], ?>) ValueBinder::toInt64Array);
     map.put(Struct.class, (BiFunction<ValueBinder, Struct, ?>) ValueBinder::to);
-
+    map.put(Interval.class, (BiFunction<ValueBinder, Interval, ?>) ValueBinder::to);
+    map.put(UUID.class, (BiFunction<ValueBinder, UUID, ?>) ValueBinder::to);
     singleItemTypeValueBinderMethodMap = Collections.unmodifiableMap(map);
   }
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/SpannerTypeMapper.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/SpannerTypeMapper.java
@@ -18,6 +18,7 @@ package com.google.cloud.spring.data.spanner.core.convert;
 
 import com.google.cloud.ByteArray;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.Code;
@@ -26,6 +27,7 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * A utility class to map between common Java types and types to use with Spanner.
@@ -52,6 +54,8 @@ public final class SpannerTypeMapper {
           .put(Type.Code.STRING, String.class)
           .put(Type.Code.STRUCT, Struct.class)
           .put(Type.Code.TIMESTAMP, Timestamp.class)
+          .put(Type.Code.INTERVAL, Interval.class)
+              .put(Type.Code.UUID, UUID.class)
           .build();
 
   private static final Map<Type.Code, Class> SPANNER_ARRAY_COLUMN_CODES_TO_JAVA_TYPE_MAPPING =
@@ -66,6 +70,8 @@ public final class SpannerTypeMapper {
           .put(Type.Code.STRING, String[].class)
           .put(Type.Code.STRUCT, Struct[].class)
           .put(Type.Code.TIMESTAMP, Timestamp[].class)
+          .put(Type.Code.INTERVAL, Interval[].class)
+              .put(Code.UUID, UUID[].class)
           .build();
 
   static {

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
@@ -20,6 +20,7 @@ import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AbstractStructReader;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.Code;
@@ -32,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.BiFunction;
 
 /**
@@ -55,6 +57,8 @@ public class StructAccessor {
           .put(ByteArray.class, AbstractStructReader::getBytesList)
           .put(BigDecimal.class, AbstractStructReader::getBigDecimalList)
           .put(Struct.class, AbstractStructReader::getStructList)
+              .put(Interval.class, AbstractStructReader::getIntervalList)
+              .put(UUID.class, AbstractStructReader::getUuidList)
           .build();
 
   static final Map<Class, BiFunction<Struct, String, ?>> singleItemReadMethodMapping =
@@ -75,6 +79,8 @@ public class StructAccessor {
           .put(float[].class, AbstractStructReader::getFloatArray)
           .put(long[].class, AbstractStructReader::getLongArray)
           .put(boolean[].class, AbstractStructReader::getBooleanArray)
+              .put(Interval.class, AbstractStructReader::getInterval)
+              .put(UUID.class, AbstractStructReader::getUuid)
           // Note that Struct.class appears in this map. While we support
           // converting structs into POJO fields of POJOs, the value in this map is for
           // the case where the field within the POJO is Struct.
@@ -99,6 +105,8 @@ public class StructAccessor {
           .put(float[].class, AbstractStructReader::getFloatArray)
           .put(long[].class, AbstractStructReader::getLongArray)
           .put(boolean[].class, AbstractStructReader::getBooleanArray)
+              .put(Interval.class, AbstractStructReader::getInterval)
+              .put(UUID.class, AbstractStructReader::getUuid)
           // Note that Struct.class appears in this map. While we support
           // converting structs into POJO fields of POJOs, the value in this map
           // is for

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Value;
@@ -39,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -194,6 +196,8 @@ class ConverterAwareMappingSpannerEntityProcessorTests {
             Timestamp.ofTimeSecondsAndNanos(111, 0),
             Timestamp.ofTimeSecondsAndNanos(222, 0),
             Timestamp.ofTimeSecondsAndNanos(333, 0));
+    List<Interval> intervals = Collections.singletonList(Interval.ofSeconds(1L));
+    List<UUID> uuids = Collections.singletonList(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
 
     Struct struct1 =
         Struct.newBuilder()
@@ -253,6 +257,14 @@ class ConverterAwareMappingSpannerEntityProcessorTests {
             .to(Value.numeric(BigDecimal.TEN))
             .set("bigDecimals")
             .to(Value.numericArray(Arrays.asList(BigDecimal.ONE, BigDecimal.ZERO)))
+            .set("intervalField")
+            .to(Interval.ofSeconds(100L))
+            .set("intervalList")
+            .to(Value.intervalArray(intervals))
+            .set("uuidField")
+            .to(Value.uuid(UUID.fromString("a1b2c3d4-e5f6-7890-1234-567890abcdef")))
+            .set("uuidList")
+            .to(Value.uuidArray(uuids))
             .build();
 
     Struct struct2 =
@@ -315,6 +327,14 @@ class ConverterAwareMappingSpannerEntityProcessorTests {
             .to(
                 Value.numericArray(
                     Arrays.asList(new BigDecimal("-0.999"), new BigDecimal("10.9001"))))
+            .set("intervalField")
+            .to(Value.interval(Interval.ofSeconds(200L)))
+            .set("intervalList")
+            .to(Value.intervalArray(intervals))
+            .set("uuidField")
+            .to(Value.uuid(UUID.fromString("123e4567-e89b-12d3-a456-426614174000")))
+            .set("uuidList")
+            .to(Value.uuidArray(uuids))
             .build();
 
     MockResults mockResults = new MockResults();
@@ -354,6 +374,11 @@ class ConverterAwareMappingSpannerEntityProcessorTests {
     assertThat(t1.floatField).isEqualTo(3.33F, DELTA_FLOAT);
     assertThat(t1.floatArray).hasSize(3);
     assertThat(t1.bigDecimals).containsExactly(BigDecimal.ONE, BigDecimal.ZERO);
+    assertThat(t1.intervalField).isEqualTo(Interval.ofSeconds(100L));
+    assertThat(t1.intervalList).containsExactly(Interval.ofSeconds(1L));
+    assertThat(t1.uuidField).isEqualTo(UUID.fromString("a1b2c3d4-e5f6-7890-1234-567890abcdef"));
+    assertThat(t1.uuidList).containsExactly(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+
 
     assertThat(t2)
         .hasFieldOrPropertyWithValue("id", "key12")
@@ -381,6 +406,10 @@ class ConverterAwareMappingSpannerEntityProcessorTests {
     assertThat(t2.stringList).containsExactly("string");
     assertThat(t2.bigDecimalField).isEqualTo(new BigDecimal("0.0001"));
     assertThat(t2.bigDecimals).containsExactly(new BigDecimal("-0.999"), new BigDecimal("10.9001"));
+    assertThat(t2.intervalField).isEqualTo(Interval.ofSeconds(200L));
+    assertThat(t2.intervalList).containsExactly(Interval.ofSeconds(1L));
+    assertThat(t2.uuidField).isEqualTo(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    assertThat(t2.uuidList).containsExactly(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
   }
 
   @Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
@@ -35,6 +35,7 @@ import static org.springframework.util.ReflectionUtils.setField;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Mutation.WriteBuilder;
@@ -61,6 +62,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -116,6 +118,12 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     t.timestampList.add(t.timestampField);
     t.bytesList = new ArrayList<>();
     t.bytesList.add(t.bytes);
+    t.intervalField = Interval.ofSeconds(100L);
+    t.intervalList = new ArrayList<>();
+    t.intervalList.add(t.intervalField);
+    t.uuidField = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+    t.uuidList = new ArrayList<>();
+    t.uuidList.add(t.uuidField);
 
     // this property will be ignored in write mapping because it is a child relationship. no
     // exception will result even though it is an unsupported type for writing.
@@ -260,6 +268,22 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     when(bigDecimalsBinder.toNumericArray(any())).thenReturn(null);
     when(writeBuilder.set("bigDecimals")).thenReturn(bigDecimalsBinder);
 
+    ValueBinder<WriteBuilder> intervalFieldBinder = mock(ValueBinder.class);
+    when(intervalFieldBinder.to((Interval) any())).thenReturn(null);
+    when(writeBuilder.set("intervalField")).thenReturn(intervalFieldBinder);
+
+    ValueBinder<WriteBuilder> intervalListFieldBinder = mock(ValueBinder.class);
+    when(intervalListFieldBinder.toIntervalArray(any())).thenReturn(null);
+    when(writeBuilder.set("intervalList")).thenReturn(intervalListFieldBinder);
+
+    ValueBinder<WriteBuilder> uuidFieldBinder = mock(ValueBinder.class);
+    when(uuidFieldBinder.to((UUID) any())).thenReturn(null);
+    when(writeBuilder.set("uuidField")).thenReturn(uuidFieldBinder);
+
+    ValueBinder<WriteBuilder> uuidListFieldBinder = mock(ValueBinder.class);
+    when(uuidListFieldBinder.toUuidArray(any())).thenReturn(null);
+    when(writeBuilder.set("uuidList")).thenReturn(uuidListFieldBinder);
+
     this.spannerEntityWriter.write(t, writeBuilder::set);
 
     verify(idBinder, times(1)).to(t.id);
@@ -293,6 +317,10 @@ class ConverterAwareMappingSpannerEntityWriterTests {
 
     verify(bigDecimalFieldBinder, times(1)).to(t.bigDecimalField);
     verify(bigDecimalsBinder, times(1)).toNumericArray(t.bigDecimals);
+    verify(intervalFieldBinder, times(1)).to(t.intervalField);
+    verify(intervalListFieldBinder, times(1)).toIntervalArray(t.intervalList);
+    verify(uuidFieldBinder, times(1)).to(t.uuidField);
+    verify(uuidListFieldBinder, times(1)).toUuidArray(t.uuidList);
   }
 
   @Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
@@ -19,6 +19,7 @@ package com.google.cloud.spring.data.spanner.core.convert;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spring.data.spanner.core.mapping.Column;
 import com.google.cloud.spring.data.spanner.core.mapping.Embedded;
@@ -29,6 +30,7 @@ import com.google.spanner.v1.TypeCode;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 /** Test entities for Spanner tests that hit many features and situations. */
 class TestEntities {
@@ -109,6 +111,14 @@ class TestEntities {
     BigDecimal bigDecimalField;
 
     List<BigDecimal> bigDecimals;
+
+    Interval intervalField;
+
+    List<Interval> intervalList;
+
+    UUID uuidField;
+
+    List<UUID> uuidList;
   }
 
   /** A test entity that acts as a child of another entity. */

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -34,7 +34,7 @@
 	</distributionManagement>
 
 	<properties>
-		<gcp-libraries-bom.version>26.57.0</gcp-libraries-bom.version>
+		<gcp-libraries-bom.version>26.60.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.25.0</cloud-sql-socket-factory.version>
 		<r2dbc-postgres-driver.version>1.0.7.RELEASE</r2dbc-postgres-driver.version>
 		<cloud-spanner-r2dbc.version>1.3.0</cloud-spanner-r2dbc.version>


### PR DESCRIPTION
For https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3756#issuecomment-2874348012. Emulating https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/2662.

The Interval datatype was added in the Spanner client library in https://github.com/googleapis/java-spanner/pull/3714 (v6.90.0)
Additionally, the java.util.UUID support was added in https://github.com/googleapis/java-spanner/pull/3839 and https://github.com/googleapis/java-spanner/pull/3572

This PR addresses the following failures: 
```
[ERROR] Failures: 
[ERROR]   SpannerWriteMethodCoverageTests.allKnownMappingTypesTest:75 
Expecting actual:
  {java.lang.Boolean=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$424/0x00007fbe2c0d3e50@383bfa16, java.lang.Long=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$425/0x00007fbe2c0d4080@4d465b11, long=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$426/0x00007fbe2c0d42b0@53fdffa1, java.lang.Double=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$427/0x00007fbe2c0d44e0@5562c41e, double=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$428/0x00007fbe2c0d4710@32ee6fee, java.lang.Float=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$429/0x00007fbe2c0d4940@4d0f2471, float=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$430/0x00007fbe2c0d4b70@7133da86, java.math.BigDecimal=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$431/0x00007fbe2c0d4da0@3232a28a, com.google.cloud.Timestamp=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$432/0x00007fbe2c0d4fd0@73e22a3d, com.google.cloud.Date=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$433/0x00007fbe2c0d5200@47faa49c, com.google.cloud.ByteArray=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$434/0x00007fbe2c0d5430@28f2a10f, java.lang.String=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$435/0x00007fbe2c0d5660@f736069, double[]=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$436/0x00007fbe2c0d5890@6da21078, float[]=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$437/0x00007fbe2c0d5ac0@7fee8714, boolean[]=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$438/0x00007fbe2c0d5cf0@4229bb3f, long[]=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$439/0x00007fbe2c0d5f20@56cdfb3b, com.google.cloud.spanner.Struct=com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter$$Lambda$440/0x00007fbe2c0d6150@2b91004a}
to contain key:
  com.google.cloud.spanner.Interval
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```
and
```
Error:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.001 s <<< FAILURE! - in com.google.cloud.spring.data.spanner.core.convert.SpannerStructReadMethodCoverageTests
Error:  allKnownMappingTypesTest  Time elapsed: 0 s  <<< FAILURE!
java.lang.AssertionError: 

Expecting actual:
  {java.lang.Boolean=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$591/223696575@315cf170, com.google.cloud.Timestamp=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$599/1217416538@7878bbdb, java.lang.Long=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$592/185674515@25f7cc38, java.lang.String=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$594/61620079@563263a, com.google.cloud.ByteArray=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$602/1505123790@53e28097, java.lang.Float=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$597/1792904767@6e794f53, double=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$596/1741618564@75f4d8a8, float[]=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$604/1586636359@69ba72da, boolean[]=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$606/680466239@2e1ba142, com.google.cloud.Date=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$600/314309716@abc7005, com.google.cloud.spanner.Struct=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$607/170050776@595ec862, java.math.BigDecimal=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$601/345060426@63c84d31, double[]=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$603/327561535@102af1bb, java.lang.Double=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$595/418731780@797f97e3, long[]=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$605/1128032955@56cd5d76, long=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$593/619406819@77cd235b, float=com.google.cloud.spring.data.spanner.core.convert.StructAccessor$$Lambda$598/1487059223@302da330}
to contain key:
  java.util.UUID
	at com.google.cloud.spring.data.spanner.core.convert.SpannerStructReadMethodCoverageTests.allKnownMappingTypesTest(SpannerStructReadMethodCoverageTests.java:58)
```

BEGIN_COMMIT_OVERRIDE
deps: bump com.google.cloud:libraries-bom from 26.57.0 to 26.60.0

feat(spanner): support Interval and UUID types.
END_COMMIT_OVERRIDE