### PR TITLE
fix(3.x): update libraries-bom to 26.60.0 and add support for Interval and UUID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,7 +456,7 @@
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
 								<!-- illegal-access=permit is needed to make GCLIB proxying work, used in Datastore -->
-								<argLine>-Xms512m -Xmx512m --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED</argLine>
+								<argLine>-Xms512m -Xmx512m --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
 								<skip>${skip.surefire.tests}</skip>
 								<excludes>
 									<exclude>${integration-test.pattern}</exclude>
@@ -472,7 +472,7 @@
 								<includes>
 									<include>${integration-test.pattern}</include>
 								</includes>
-								<argLine>-Xms512m -Xmx512m --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED</argLine>
+								<argLine>-Xms512m -Xmx512m --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
 							</configuration>
 						</plugin>
 					</plugins>

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -19,6 +19,7 @@ package com.google.cloud.spring.data.spanner.core.convert;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation.WriteBuilder;
 import com.google.cloud.spanner.Struct;
@@ -38,6 +39,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -65,7 +67,8 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
                   ByteArray.class,
                   Timestamp.class,
                   com.google.cloud.Date.class,
-                  BigDecimal.class)));
+                  BigDecimal.class,
+                  UUID.class)));
 
   /** A map of types to functions that binds them to `ValueBinder` objects. */
   public static final Map<Class<?>, BiFunction<ValueBinder, ?, ?>>
@@ -86,6 +89,8 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
     map.put(Date.class, ValueBinder::toDateArray);
     map.put(ByteArray.class, ValueBinder::toBytesArray);
     map.put(String.class, ValueBinder::toStringArray);
+    map.put(Interval.class, ValueBinder::toIntervalArray);
+    map.put(UUID.class, ValueBinder::toUuidArray);
 
     return Collections.unmodifiableMap(map);
   }
@@ -110,7 +115,8 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
     map.put(boolean[].class, (BiFunction<ValueBinder, boolean[], ?>) ValueBinder::toBoolArray);
     map.put(long[].class, (BiFunction<ValueBinder, long[], ?>) ValueBinder::toInt64Array);
     map.put(Struct.class, (BiFunction<ValueBinder, Struct, ?>) ValueBinder::to);
-
+    map.put(Interval.class, (BiFunction<ValueBinder, Interval, ?>) ValueBinder::to);
+    map.put(UUID.class, (BiFunction<ValueBinder, UUID, ?>) ValueBinder::to);
     singleItemTypeValueBinderMethodMap = Collections.unmodifiableMap(map);
   }
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/SpannerTypeMapper.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/SpannerTypeMapper.java
@@ -18,6 +18,7 @@ package com.google.cloud.spring.data.spanner.core.convert;
 
 import com.google.cloud.ByteArray;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.Code;
@@ -26,6 +27,7 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * A utility class to map between common Java types and types to use with Spanner.
@@ -52,6 +54,8 @@ public final class SpannerTypeMapper {
           .put(Type.Code.STRING, String.class)
           .put(Type.Code.STRUCT, Struct.class)
           .put(Type.Code.TIMESTAMP, Timestamp.class)
+          .put(Type.Code.INTERVAL, Interval.class)
+              .put(Type.Code.UUID, UUID.class)
           .build();
 
   private static final Map<Type.Code, Class> SPANNER_ARRAY_COLUMN_CODES_TO_JAVA_TYPE_MAPPING =
@@ -66,6 +70,8 @@ public final class SpannerTypeMapper {
           .put(Type.Code.STRING, String[].class)
           .put(Type.Code.STRUCT, Struct[].class)
           .put(Type.Code.TIMESTAMP, Timestamp[].class)
+          .put(Type.Code.INTERVAL, Interval[].class)
+              .put(Code.UUID, UUID[].class)
           .build();
 
   static {

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
@@ -20,6 +20,7 @@ import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AbstractStructReader;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.Code;
@@ -32,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.BiFunction;
 
 /**
@@ -55,6 +57,8 @@ public class StructAccessor {
           .put(ByteArray.class, AbstractStructReader::getBytesList)
           .put(BigDecimal.class, AbstractStructReader::getBigDecimalList)
           .put(Struct.class, AbstractStructReader::getStructList)
+              .put(Interval.class, AbstractStructReader::getIntervalList)
+              .put(UUID.class, AbstractStructReader::getUuidList)
           .build();
 
   static final Map<Class, BiFunction<Struct, String, ?>> singleItemReadMethodMapping =
@@ -75,6 +79,8 @@ public class StructAccessor {
           .put(float[].class, AbstractStructReader::getFloatArray)
           .put(long[].class, AbstractStructReader::getLongArray)
           .put(boolean[].class, AbstractStructReader::getBooleanArray)
+              .put(Interval.class, AbstractStructReader::getInterval)
+              .put(UUID.class, AbstractStructReader::getUuid)
           // Note that Struct.class appears in this map. While we support
           // converting structs into POJO fields of POJOs, the value in this map is for
           // the case where the field within the POJO is Struct.
@@ -99,6 +105,8 @@ public class StructAccessor {
           .put(float[].class, AbstractStructReader::getFloatArray)
           .put(long[].class, AbstractStructReader::getLongArray)
           .put(boolean[].class, AbstractStructReader::getBooleanArray)
+              .put(Interval.class, AbstractStructReader::getInterval)
+              .put(UUID.class, AbstractStructReader::getUuid)
           // Note that Struct.class appears in this map. While we support
           // converting structs into POJO fields of POJOs, the value in this map
           // is for

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityProcessorTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Value;
@@ -39,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -194,6 +196,8 @@ class ConverterAwareMappingSpannerEntityProcessorTests {
             Timestamp.ofTimeSecondsAndNanos(111, 0),
             Timestamp.ofTimeSecondsAndNanos(222, 0),
             Timestamp.ofTimeSecondsAndNanos(333, 0));
+    List<Interval> intervals = Collections.singletonList(Interval.ofSeconds(1L));
+    List<UUID> uuids = Collections.singletonList(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
 
     Struct struct1 =
         Struct.newBuilder()
@@ -253,6 +257,14 @@ class ConverterAwareMappingSpannerEntityProcessorTests {
             .to(Value.numeric(BigDecimal.TEN))
             .set("bigDecimals")
             .to(Value.numericArray(Arrays.asList(BigDecimal.ONE, BigDecimal.ZERO)))
+            .set("intervalField")
+            .to(Interval.ofSeconds(100L))
+            .set("intervalList")
+            .to(Value.intervalArray(intervals))
+            .set("uuidField")
+            .to(Value.uuid(UUID.fromString("a1b2c3d4-e5f6-7890-1234-567890abcdef")))
+            .set("uuidList")
+            .to(Value.uuidArray(uuids))
             .build();
 
     Struct struct2 =
@@ -315,6 +327,14 @@ class ConverterAwareMappingSpannerEntityProcessorTests {
             .to(
                 Value.numericArray(
                     Arrays.asList(new BigDecimal("-0.999"), new BigDecimal("10.9001"))))
+            .set("intervalField")
+            .to(Value.interval(Interval.ofSeconds(200L)))
+            .set("intervalList")
+            .to(Value.intervalArray(intervals))
+            .set("uuidField")
+            .to(Value.uuid(UUID.fromString("123e4567-e89b-12d3-a456-426614174000")))
+            .set("uuidList")
+            .to(Value.uuidArray(uuids))
             .build();
 
     MockResults mockResults = new MockResults();
@@ -354,6 +374,11 @@ class ConverterAwareMappingSpannerEntityProcessorTests {
     assertThat(t1.floatField).isEqualTo(3.33F, DELTA_FLOAT);
     assertThat(t1.floatArray).hasSize(3);
     assertThat(t1.bigDecimals).containsExactly(BigDecimal.ONE, BigDecimal.ZERO);
+    assertThat(t1.intervalField).isEqualTo(Interval.ofSeconds(100L));
+    assertThat(t1.intervalList).containsExactly(Interval.ofSeconds(1L));
+    assertThat(t1.uuidField).isEqualTo(UUID.fromString("a1b2c3d4-e5f6-7890-1234-567890abcdef"));
+    assertThat(t1.uuidList).containsExactly(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+
 
     assertThat(t2)
         .hasFieldOrPropertyWithValue("id", "key12")
@@ -381,6 +406,10 @@ class ConverterAwareMappingSpannerEntityProcessorTests {
     assertThat(t2.stringList).containsExactly("string");
     assertThat(t2.bigDecimalField).isEqualTo(new BigDecimal("0.0001"));
     assertThat(t2.bigDecimals).containsExactly(new BigDecimal("-0.999"), new BigDecimal("10.9001"));
+    assertThat(t2.intervalField).isEqualTo(Interval.ofSeconds(200L));
+    assertThat(t2.intervalList).containsExactly(Interval.ofSeconds(1L));
+    assertThat(t2.uuidField).isEqualTo(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    assertThat(t2.uuidList).containsExactly(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"));
   }
 
   @Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
@@ -35,6 +35,7 @@ import static org.springframework.util.ReflectionUtils.setField;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Mutation.WriteBuilder;
@@ -61,6 +62,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -117,6 +119,12 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     t.timestampList.add(t.timestampField);
     t.bytesList = new ArrayList<>();
     t.bytesList.add(t.bytes);
+    t.intervalField = Interval.ofSeconds(100L);
+    t.intervalList = new ArrayList<>();
+    t.intervalList.add(t.intervalField);
+    t.uuidField = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+    t.uuidList = new ArrayList<>();
+    t.uuidList.add(t.uuidField);
 
     // this property will be ignored in write mapping because it is a child relationship. no
     // exception will result even though it is an unsupported type for writing.
@@ -261,6 +269,22 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     when(bigDecimalsBinder.toNumericArray(any())).thenReturn(null);
     when(writeBuilder.set("bigDecimals")).thenReturn(bigDecimalsBinder);
 
+    ValueBinder<WriteBuilder> intervalFieldBinder = mock(ValueBinder.class);
+    when(intervalFieldBinder.to((Interval) any())).thenReturn(null);
+    when(writeBuilder.set("intervalField")).thenReturn(intervalFieldBinder);
+
+    ValueBinder<WriteBuilder> intervalListFieldBinder = mock(ValueBinder.class);
+    when(intervalListFieldBinder.toIntervalArray(any())).thenReturn(null);
+    when(writeBuilder.set("intervalList")).thenReturn(intervalListFieldBinder);
+
+    ValueBinder<WriteBuilder> uuidFieldBinder = mock(ValueBinder.class);
+    when(uuidFieldBinder.to((UUID) any())).thenReturn(null);
+    when(writeBuilder.set("uuidField")).thenReturn(uuidFieldBinder);
+
+    ValueBinder<WriteBuilder> uuidListFieldBinder = mock(ValueBinder.class);
+    when(uuidListFieldBinder.toUuidArray(any())).thenReturn(null);
+    when(writeBuilder.set("uuidList")).thenReturn(uuidListFieldBinder);
+
     this.spannerEntityWriter.write(t, writeBuilder::set);
 
     verify(idBinder, times(1)).to(t.id);
@@ -294,6 +318,10 @@ class ConverterAwareMappingSpannerEntityWriterTests {
 
     verify(bigDecimalFieldBinder, times(1)).to(t.bigDecimalField);
     verify(bigDecimalsBinder, times(1)).toNumericArray(t.bigDecimals);
+    verify(intervalFieldBinder, times(1)).to(t.intervalField);
+    verify(intervalListFieldBinder, times(1)).toIntervalArray(t.intervalList);
+    verify(uuidFieldBinder, times(1)).to(t.uuidField);
+    verify(uuidListFieldBinder, times(1)).toUuidArray(t.uuidList);
   }
 
   @Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
@@ -19,6 +19,7 @@ package com.google.cloud.spring.data.spanner.core.convert;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Interval;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spring.data.spanner.core.mapping.Column;
 import com.google.cloud.spring.data.spanner.core.mapping.Embedded;
@@ -29,6 +30,7 @@ import com.google.spanner.v1.TypeCode;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 /** Test entities for Spanner tests that hit many features and situations. */
 class TestEntities {
@@ -109,6 +111,14 @@ class TestEntities {
     BigDecimal bigDecimalField;
 
     List<BigDecimal> bigDecimals;
+
+    Interval intervalField;
+
+    List<Interval> intervalList;
+
+    UUID uuidField;
+
+    List<UUID> uuidList;
   }
 
   /** A test entity that acts as a child of another entity. */

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -29,7 +29,7 @@
 	</distributionManagement>
 
 	<properties>
-		<gcp-libraries-bom.version>26.57.0</gcp-libraries-bom.version>
+		<gcp-libraries-bom.version>26.60.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.23.1</cloud-sql-socket-factory.version>
 		<r2dbc-mysql-driver.version>0.9.7</r2dbc-mysql-driver.version>
 		<r2dbc-postgres-driver.version>0.8.13.RELEASE</r2dbc-postgres-driver.version>


### PR DESCRIPTION
Backport of https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3769

BEGIN_COMMIT_OVERRIDE
deps: bump com.google.cloud:libraries-bom from 26.57.0 to 26.60.0

feat(spanner): support Interval and UUID types.
END_COMMIT_OVERRIDE