### PR TITLE
chore: update showcase tests for generator-java-bom 2.57.0

### DIFF
--- a/spring-cloud-generator/showcase/showcase-spring-starter/src/main/java/com/google/showcase/v1beta1/spring/EchoSpringAutoConfiguration.java
+++ b/spring-cloud-generator/showcase/showcase-spring-starter/src/main/java/com/google/showcase/v1beta1/spring/EchoSpringAutoConfiguration.java
@@ -167,6 +167,13 @@ public class EchoSpringAutoConfiguration {
           .echoErrorDetailsSettings()
           .setRetrySettings(echoErrorDetailsRetrySettings);
 
+      RetrySettings failEchoWithDetailsRetrySettings =
+          RetryUtil.updateRetrySettings(
+              clientSettingsBuilder.failEchoWithDetailsSettings().getRetrySettings(), serviceRetry);
+      clientSettingsBuilder
+          .failEchoWithDetailsSettings()
+          .setRetrySettings(failEchoWithDetailsRetrySettings);
+
       RetrySettings pagedExpandRetrySettings =
           RetryUtil.updateRetrySettings(
               clientSettingsBuilder.pagedExpandSettings().getRetrySettings(), serviceRetry);
@@ -245,6 +252,20 @@ public class EchoSpringAutoConfiguration {
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace(
             "Configured method-level retry settings for echoErrorDetails from properties.");
+      }
+    }
+    Retry failEchoWithDetailsRetry = clientProperties.getFailEchoWithDetailsRetry();
+    if (failEchoWithDetailsRetry != null) {
+      RetrySettings failEchoWithDetailsRetrySettings =
+          RetryUtil.updateRetrySettings(
+              clientSettingsBuilder.failEchoWithDetailsSettings().getRetrySettings(),
+              failEchoWithDetailsRetry);
+      clientSettingsBuilder
+          .failEchoWithDetailsSettings()
+          .setRetrySettings(failEchoWithDetailsRetrySettings);
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace(
+            "Configured method-level retry settings for failEchoWithDetails from properties.");
       }
     }
     Retry pagedExpandRetry = clientProperties.getPagedExpandRetry();

--- a/spring-cloud-generator/showcase/showcase-spring-starter/src/main/java/com/google/showcase/v1beta1/spring/EchoSpringProperties.java
+++ b/spring-cloud-generator/showcase/showcase-spring-starter/src/main/java/com/google/showcase/v1beta1/spring/EchoSpringProperties.java
@@ -51,6 +51,11 @@ public class EchoSpringProperties implements CredentialsSupplier {
    */
   @NestedConfigurationProperty private Retry echoErrorDetailsRetry;
   /**
+   * Allow override of retry settings at method-level for failEchoWithDetails. If defined, this
+   * takes precedence over service-level retry configurations for that RPC method.
+   */
+  @NestedConfigurationProperty private Retry failEchoWithDetailsRetry;
+  /**
    * Allow override of retry settings at method-level for pagedExpand. If defined, this takes
    * precedence over service-level retry configurations for that RPC method.
    */
@@ -147,6 +152,14 @@ public class EchoSpringProperties implements CredentialsSupplier {
 
   public void setEchoErrorDetailsRetry(Retry echoErrorDetailsRetry) {
     this.echoErrorDetailsRetry = echoErrorDetailsRetry;
+  }
+
+  public Retry getFailEchoWithDetailsRetry() {
+    return this.failEchoWithDetailsRetry;
+  }
+
+  public void setFailEchoWithDetailsRetry(Retry failEchoWithDetailsRetry) {
+    this.failEchoWithDetailsRetry = failEchoWithDetailsRetry;
   }
 
   public Retry getPagedExpandRetry() {

--- a/spring-cloud-generator/showcase/showcase-spring-starter/src/test/java/com/google/showcase/v1beta1/spring/EchoAutoConfigurationTests.java
+++ b/spring-cloud-generator/showcase/showcase-spring-starter/src/test/java/com/google/showcase/v1beta1/spring/EchoAutoConfigurationTests.java
@@ -189,8 +189,7 @@ class EchoAutoConfigurationTests {
   @Test
   void testCustomTransportChannelProviderUsedWhenProvided() throws IOException {
     InstantiatingGrpcChannelProvider channelProvider =
-        InstantiatingGrpcChannelProvider.newBuilder()
-            .build();
+        InstantiatingGrpcChannelProvider.newBuilder().build();
     contextRunner
         .withBean(
             TRANSPORT_CHANNEL_PROVIDER_QUALIFIER_NAME,


### PR DESCRIPTION
The generator was updated in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3757. This PR is to address the following failures we've been seeing in the release PR: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3697#issuecomment-2881639794