### PR TITLE
chore: add jdk 24 to test matrixes

### DIFF
--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17, 19, 21]
+        java: [17, 19, 21, 24]
     steps:
     - name: Get current date
       id: date

--- a/pom.xml
+++ b/pom.xml
@@ -659,8 +659,7 @@
 							<artifactId>maven-compiler-plugin</artifactId>
 							<version>${maven-compiler-plugin.version}</version>
 							<configuration>
-								<source>${maven.compiler.source}</source>
-								<target>${maven.compiler.target}</target>
+								<release>${maven.compiler.source}</release>
 								<encoding>UTF-8</encoding>
 								<fork>true</fork>
 								<compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -697,6 +697,7 @@
 				</pluginManagement>
 			</build>
 		</profile>
+
 		<!-- Handles deploying snapshots and releases. -->
 		<profile>
 			<id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -649,7 +649,7 @@
 		<profile>
 			<id>errorprone_java_17_and_up</id>
 			<activation>
-				<jdk>[17,]</jdk>
+				<jdk>[17,24)</jdk>
 			</activation>
 			<build>
 				<pluginManagement>
@@ -659,7 +659,8 @@
 							<artifactId>maven-compiler-plugin</artifactId>
 							<version>${maven-compiler-plugin.version}</version>
 							<configuration>
-								<release>${maven.compiler.source}</release>
+								<source>${maven.compiler.source}</source>
+								<target>${maven.compiler.target}</target>
 								<encoding>UTF-8</encoding>
 								<fork>true</fork>
 								<compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -697,52 +697,6 @@
 				</pluginManagement>
 			</build>
 		</profile>
-<!--
-		<profile>
-			<id>java_24_and_up</id>
-			<activation>
-				<jdk>[24,]</jdk>
-			</activation>
-			<build>
-				<pluginManagement>
-					<plugins>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-compiler-plugin</artifactId>
-							<version>${maven-compiler-plugin.version}</version>
-							<configuration>
-								<release>${maven.compiler.source}</release>
-								<encoding>UTF-8</encoding>
-								<fork>true</fork>
-								<compilerArgs>
-									<arg>-XDcompilePolicy=simple</arg>
-
-									<arg>-parameters</arg>
-									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-									<arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-									<arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-								</compilerArgs>
-								<annotationProcessorPaths>
-									<path>
-										<groupId>org.springframework.boot</groupId>
-										<artifactId>spring-boot-configuration-processor</artifactId>
-										<version>${spring-boot-dependencies.version}</version>
-									</path>
-								</annotationProcessorPaths>
-							</configuration>
-						</plugin>
-					</plugins>
-				</pluginManagement>
-			</build>
-		</profile>
--->
 		<!-- Handles deploying snapshots and releases. -->
 		<profile>
 			<id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -659,11 +659,11 @@
 							<artifactId>maven-compiler-plugin</artifactId>
 							<version>${maven-compiler-plugin.version}</version>
 							<configuration>
-								<source>${maven.compiler.source}</source>
-								<target>${maven.compiler.target}</target>
+								<release>${maven.compiler.source}</release>
 								<encoding>UTF-8</encoding>
 								<fork>true</fork>
 								<compilerArgs>
+									<arg>--should-stop=ifError=FLOW</arg>
 									<arg>-XDcompilePolicy=simple</arg>
 									<arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF</arg>
 									<!-- See: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/92 -->

--- a/pom.xml
+++ b/pom.xml
@@ -698,6 +698,52 @@
 			</build>
 		</profile>
 
+		<profile>
+			<id>java_24_and_up</id>
+			<activation>
+				<jdk>[24,]</jdk>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-compiler-plugin</artifactId>
+							<version>${maven-compiler-plugin.version}</version>
+							<configuration>
+								<release>${maven.compiler.source}</release>
+								<encoding>UTF-8</encoding>
+								<fork>true</fork>
+								<compilerArgs>
+									<arg>-XDcompilePolicy=simple</arg>
+									<arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF</arg>
+									<!-- See: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/92 -->
+									<arg>-parameters</arg>
+									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+									<arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+									<arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+								</compilerArgs>
+								<annotationProcessorPaths>
+									<path>
+										<groupId>org.springframework.boot</groupId>
+										<artifactId>spring-boot-configuration-processor</artifactId>
+										<version>${spring-boot-dependencies.version}</version>
+									</path>
+								</annotationProcessorPaths>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+
 		<!-- Handles deploying snapshots and releases. -->
 		<profile>
 			<id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -716,7 +716,6 @@
 								<fork>true</fork>
 								<compilerArgs>
 									<arg>-XDcompilePolicy=simple</arg>
-									<arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF</arg>
 									<!-- See: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/92 -->
 									<arg>-parameters</arg>
 									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<checkstyle-rules.version>9.3</checkstyle-rules.version>
 		<asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
 		<native-maven-plugin.version>0.10.5</native-maven-plugin.version>
-		<errorprone.version>2.34.0</errorprone.version>
+		<errorprone.version>2.38.0</errorprone.version>
 
 		<!-- All checks except for javadoc enforced by default -->
 		<skip.failsafe.tests>${skipTests}</skip.failsafe.tests>
@@ -649,7 +649,7 @@
 		<profile>
 			<id>errorprone_java_17_and_up</id>
 			<activation>
-				<jdk>[17,24)</jdk>
+				<jdk>[17,]</jdk>
 			</activation>
 			<build>
 				<pluginManagement>
@@ -697,7 +697,7 @@
 				</pluginManagement>
 			</build>
 		</profile>
-
+<!--
 		<profile>
 			<id>java_24_and_up</id>
 			<activation>
@@ -716,7 +716,7 @@
 								<fork>true</fork>
 								<compilerArgs>
 									<arg>-XDcompilePolicy=simple</arg>
-									<!-- See: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/92 -->
+
 									<arg>-parameters</arg>
 									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
 									<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
@@ -742,7 +742,7 @@
 				</pluginManagement>
 			</build>
 		</profile>
-
+-->
 		<!-- Handles deploying snapshots and releases. -->
 		<profile>
 			<id>release</id>


### PR DESCRIPTION
this is in order to support graalvm upgrade

This required an upgrade in errorprone to support the support JDK 24