### PR TITLE
chore: upgrade protobuf version to v3.25.8

### DIFF
--- a/spring-cloud-generator/pom.xml
+++ b/spring-cloud-generator/pom.xml
@@ -18,7 +18,7 @@
         <gapic-generator-java-bom.version>2.58.0</gapic-generator-java-bom.version>
         <!-- [gapic-test]: protobuf.version for compiling protos used in unit testing
              this should be consistent with version in gapic-generator-java-bom -->
-        <protobuf.version>3.25.3</protobuf.version>
+        <protobuf.version>3.25.8</protobuf.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Update in sync with sdk-platform-java

merge when  gapic-generator-java-bom gets upgraded.