### PR TITLE
ci: wrap nexus-staging-maven-plugin with a profile

### DIFF
--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -44,6 +44,7 @@ export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.
   -Dgpg.passphrase=${GPG_PASSPHRASE} \
   -Dgpg.homedir=${GPG_HOMEDIR} \
   -DperformRelease=true \
+  -Prelease-sonatype
 
 # promote release
 if [[ -n "${AUTORELEASE_PR}" ]]
@@ -51,7 +52,8 @@ then
     ./mvnw nexus-staging:release \
     --batch-mode \
     --settings ${MAVEN_SETTINGS_FILE} \
-    -DperformRelease=true
+    -DperformRelease=true \
+    -Prelease-sonatype
 fi
 
 popd

--- a/pom.xml
+++ b/pom.xml
@@ -757,6 +757,12 @@
 							<groupId>org.sonatype.plugins</groupId>
 							<artifactId>nexus-staging-maven-plugin</artifactId>
 							<version>${nexus-staging-plugin.version}</version>
+							<extensions>true</extensions>
+							<configuration>
+								<serverId>ossrh</serverId>
+								<nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+								<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+							</configuration>
 						</plugin>
 					</plugins>
 				</pluginManagement>
@@ -773,16 +779,6 @@
 								</goals>
 							</execution>
 						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<extensions>true</extensions>
-						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
-							<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -868,6 +864,41 @@
 					<url>${compatibilityCheckRepository}</url>
 				</repository>
 			</repositories>
+		</profile>
+		<profile>
+			<!-- By default, we release artifacts to Sonatype, which requires
+			  nexus-staging-maven-plugin. Going forward, we'll use pure
+			  maven-deploy-plugin, and we need to turn this extension off. -->
+			<id>release-sonatype</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+			  this release-gcp-artifact-registry profile:
+			  mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+			    -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+			-->
+			<id>release-gcp-artifact-registry</id>
+			<properties>
+				<artifact-registry-url>artifactregistry://undefined-artifact-registry-url-value</artifact-registry-url>
+			</properties>
+			<distributionManagement>
+				<repository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</repository>
+				<snapshotRepository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</snapshotRepository>
+			</distributionManagement>
 		</profile>
 	</profiles>
 

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -337,6 +337,16 @@
 							</execution>
 						</executions>
 					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<!-- By default, we release artifacts to Sonatype, which requires
+			    nexus-staging-maven-plugin. Going forward, we'll use pure
+			    maven-deploy-plugin, and we need to turn this extension off. -->
+			<id>release-sonatype</id>
+			<build>
+				<plugins>
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
@@ -350,6 +360,27 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+			  this release-gcp-artifact-registry profile:
+			  mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+			  -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+			-->
+			<id>release-gcp-artifact-registry</id>
+			<properties>
+				<artifact-registry-url>artifactregistry://undefined-artifact-registry-url-value</artifact-registry-url>
+			</properties>
+			<distributionManagement>
+				<repository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</repository>
+				<snapshotRepository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</snapshotRepository>
+			</distributionManagement>
 		</profile>
 		<profile>
 			<id>linkage-check</id>


### PR DESCRIPTION
As the preparation for Central Portal API publication, we need to wrap nexus-staging-maven-plugin with a profile.

The release scriptm, which uses existing OSSRH infra, is updated to activate the release-sonatype profile.

The profile name matches java-shared-config.
https://github.com/googleapis/java-shared-config/blob/main/native-image-shared-config/pom.xml#L112

I'll have to make similar changes to other maintained branches.

b/422164249

