### PR TITLE
ci: wrap nexus-staging-maven-plugin with a profile (3.x)

### DIFF
--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -40,7 +40,8 @@ create_settings_xml_file $MAVEN_SETTINGS_FILE
   -Dgpg.passphrase=${GPG_PASSPHRASE} \
   -Dgpg.homedir=${GPG_HOMEDIR} \
   -Drelease=true \
-  --activate-profiles skip-unreleased-modules
+  --activate-profiles skip-unreleased-modules \
+  -Prelease-sonatype
 
 # promote release
 if [[ -n "${AUTORELEASE_PR}" ]]
@@ -49,7 +50,8 @@ then
     --batch-mode \
     --settings ${MAVEN_SETTINGS_FILE} \
     -Drelease=true \
-    --activate-profiles skip-unreleased-modules
+    --activate-profiles skip-unreleased-modules \
+    -Prelease-sonatype
 fi
 
 popd

--- a/pom.xml
+++ b/pom.xml
@@ -621,6 +621,12 @@
 							<groupId>org.sonatype.plugins</groupId>
 							<artifactId>nexus-staging-maven-plugin</artifactId>
 							<version>${nexus-staging-plugin.version}</version>
+							<extensions>true</extensions>
+							<configuration>
+								<serverId>ossrh</serverId>
+								<nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+								<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+							</configuration>
 						</plugin>
 					</plugins>
 				</pluginManagement>
@@ -637,16 +643,6 @@
 								</goals>
 							</execution>
 						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<extensions>true</extensions>
-						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
-							<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -745,6 +741,41 @@
 					<url>${compatibilityCheckRepository}</url>
 				</repository>
 			</repositories>
+		</profile>
+		<profile>
+			<!-- By default, we release artifacts to Sonatype, which requires
+			  nexus-staging-maven-plugin. Going forward, we'll use pure
+			  maven-deploy-plugin, and we need to turn this extension off. -->
+			<id>release-sonatype</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+			  this release-gcp-artifact-registry profile:
+			  mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+			    -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+			-->
+			<id>release-gcp-artifact-registry</id>
+			<properties>
+				<artifact-registry-url>artifactregistry://undefined-artifact-registry-url-value</artifact-registry-url>
+			</properties>
+			<distributionManagement>
+				<repository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</repository>
+				<snapshotRepository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</snapshotRepository>
+			</distributionManagement>
 		</profile>
 	</profiles>
 


### PR DESCRIPTION
As the preparation for Central Portal API publication, we need to wrap nexus-staging-maven-plugin with a profile.

The following command succeeded:

```
~/spring-cloud-gcp $ mvn clean deploy -V \
    -DaltDeploymentRepository=local::default::file:${local_staging_dir} \
    -DskipTests=true \
    -P=-release-sonatype \
    -P=-release-staging-repository \
    -P=-clirr-compatibility-check \
    -P=-checkstyle-tests \
    -P=-animal-sniffer
```

The profile name matches java-shared-config.
https://github.com/googleapis/java-shared-config/blob/main/native-image-shared-config/pom.xml#L112

b/422164249

This is applied to 3.x branch. The change at the main branch is https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3834.
