### PR TITLE
ci: wrap nexus-staging-maven-plugin the dependencies module

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -339,6 +339,16 @@
 							</execution>
 						</executions>
 					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<!-- By default, we release artifacts to Sonatype, which requires
+			    nexus-staging-maven-plugin. Going forward, we'll use pure
+			    maven-deploy-plugin, and we need to turn this extension off. -->
+			<id>release-sonatype</id>
+			<build>
+				<plugins>
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
@@ -352,6 +362,27 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+			  this release-gcp-artifact-registry profile:
+			  mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+			  -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+			-->
+			<id>release-gcp-artifact-registry</id>
+			<properties>
+				<artifact-registry-url>artifactregistry://undefined-artifact-registry-url-value</artifact-registry-url>
+			</properties>
+			<distributionManagement>
+				<repository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</repository>
+				<snapshotRepository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</snapshotRepository>
+			</distributionManagement>
 		</profile>
 		<profile>
 			<id>linkage-check</id>


### PR DESCRIPTION
The latest run failed with `[ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy (injected-nexus-deploy) on project spring-cloud-gcp-dependencies: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy failed: Server credentials with ID "ossrh" not found!` This is a typical error when nexus-staging-maven-plugin is not wrapped by a profile.


`suztomo@suztomo2:~/spring-cloud-gcp$ mvn clean deploy -V     -DaltDeploymentRepository=local::default::file:${local_staging_dir}     -DskipTests=true     -P=-release-sonatype     -P=-release-staging-repository     -P=-clirr-compatibility-check     -P=-checkstyle-tests     -Dgpg.executable=gpg   -Dgpg.homedir="${GPG_HOMEDIR}"` succeeded.

