### PR TITLE
ci: wrap nexus-staging-maven-plugin (4.x)

### DIFF
--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -114,7 +114,7 @@ jobs:
           ./mvnw \
             --batch-mode \
             --no-transfer-progress \
-            -Drelease=true \
+            -DperformRelease=true \
             -DskipTests \
             -Dgpg.skip \
             -Dcheckstyle.skip \

--- a/.kokoro/publish_javadoc.sh
+++ b/.kokoro/publish_javadoc.sh
@@ -16,7 +16,7 @@ PROJECT_VERSION=$(grep "^spring-cloud-gcp:" "./versions.txt" | cut -d: -f3)
 python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 
 # Build the javadocs
-mvn clean javadoc:aggregate -Drelease=true
+mvn clean javadoc:aggregate -DperformRelease=true
 
 # Move into generated docs directory
 pushd target/reports/apidocs/

--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -43,8 +43,9 @@ export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.
   -Dgpg.executable=gpg \
   -Dgpg.passphrase=${GPG_PASSPHRASE} \
   -Dgpg.homedir=${GPG_HOMEDIR} \
-  -Drelease=true \
-  --activate-profiles skip-unreleased-modules
+  -DperformRelease=true \
+  --activate-profiles skip-unreleased-modules \
+  -Prelease-sonatype
 
 # promote release
 if [[ -n "${AUTORELEASE_PR}" ]]
@@ -52,8 +53,9 @@ then
     mvn nexus-staging:release \
     --batch-mode \
     --settings ${MAVEN_SETTINGS_FILE} \
-    -Drelease=true \
-    --activate-profiles skip-unreleased-modules
+    -DperformRelease=true \
+    --activate-profiles skip-unreleased-modules \
+    -Prelease-sonatype
 fi
 
 popd

--- a/pom.xml
+++ b/pom.xml
@@ -438,7 +438,7 @@
 			<id>default</id>
 			<activation>
 				<property>
-					<name>!release</name>
+					<name>!performRelease</name>
 				</property>
 			</activation>
 			<modules>
@@ -661,7 +661,7 @@
 			<id>release</id>
 			<activation>
 				<property>
-					<name>release</name>
+					<name>performRelease</name>
 				</property>
 			</activation>
 			<modules>
@@ -734,16 +734,6 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<extensions>true</extensions>
-						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
-							<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-						</configuration>
-					</plugin>
-					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<executions>
@@ -772,19 +762,6 @@
 								com.google.cloud.firestore
 							</excludePackageNames>
 						</configuration>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-source-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>attach-sources</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-								<phase>package</phase>
-							</execution>
-						</executions>
 					</plugin>
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
@@ -819,6 +796,48 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<!-- By default, we release artifacts to Sonatype, which requires
+			    nexus-staging-maven-plugin. Going forward, we'll use pure
+			    maven-deploy-plugin, and we need to turn this extension off. -->
+			<id>release-sonatype</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<version>1.7.0</version>
+						<extensions>true</extensions>
+						<configuration>
+							<serverId>ossrh</serverId>
+							<nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+							<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+			  this release-gcp-artifact-registry profile:
+			  mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+			  -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+			-->
+			<id>release-gcp-artifact-registry</id>
+			<properties>
+				<artifact-registry-url>artifactregistry://undefined-artifact-registry-url-value</artifact-registry-url>
+			</properties>
+			<distributionManagement>
+				<repository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</repository>
+				<snapshotRepository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</snapshotRepository>
+			</distributionManagement>
 		</profile>
 		<profile>
 			<id>compatibility-check</id>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -307,7 +307,7 @@
 			<id>release</id>
 			<activation>
 				<property>
-					<name>release</name>
+					<name>performRelease</name>
 				</property>
 			</activation>
 			<build>
@@ -326,6 +326,16 @@
 							</execution>
 						</executions>
 					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<!-- By default, we release artifacts to Sonatype, which requires
+			    nexus-staging-maven-plugin. Going forward, we'll use pure
+			    maven-deploy-plugin, and we need to turn this extension off. -->
+			<id>release-sonatype</id>
+			<build>
+				<plugins>
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
@@ -339,6 +349,27 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+			  this release-gcp-artifact-registry profile:
+			  mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+			  -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+			-->
+			<id>release-gcp-artifact-registry</id>
+			<properties>
+				<artifact-registry-url>artifactregistry://undefined-artifact-registry-url-value</artifact-registry-url>
+			</properties>
+			<distributionManagement>
+				<repository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</repository>
+				<snapshotRepository>
+					<id>gcp-artifact-registry-repository</id>
+					<url>${artifact-registry-url}</url>
+				</snapshotRepository>
+			</distributionManagement>
 		</profile>
 		<profile>
 			<id>linkage-check</id>


### PR DESCRIPTION
- Wrap nexus-staging-maven-plugin in the release-sonatype profile.
- Use "performRelease" Maven property to match the main branch and the new release script.
- maven-source-plugin is not needed here any more (reference: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/commit/3441f06f24e83e3def7a480f0773ff6ebce6a493)
