### PR TITLE
chore(test): try to fix pubsub-emulator version

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -73,7 +73,7 @@ jobs:
         if: ${{ matrix.it == 'pubsub-emulator' }}
         run: |
           gcloud components install pubsub-emulator beta && \
-            gcloud components update
+            gcloud components update --version 525.0.0
       - name: Mvn install # Need this when the directory/pom structure changes
         id: install
         run: |


### PR DESCRIPTION
testing 

This reverts pubsub-emulator version to 0.8.19
![image](https://github.com/user-attachments/assets/8297c31d-6ffa-4963-bc7a-207a7d5f47e8)


test succeeded: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/actions/runs/15643045090/job/44074735117?pr=3879