### PR TITLE
deps: upgrade spring-boot-starter-parent and spring-boot-dependencies.version to 3.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<project.parent.version>${project.version}</project.parent.version>
 		<!-- Dependency versions -->
 		<spring-cloud-dependencies.version>2024.0.0</spring-cloud-dependencies.version>
-		<spring-boot-dependencies.version>3.4.6</spring-boot-dependencies.version>
+		<spring-boot-dependencies.version>3.4.7</spring-boot-dependencies.version>
 		<spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
 		<zipkin-gcp.version>2.3.0</zipkin-gcp.version>
 		<java-cfenv.version>2.5.0</java-cfenv.version>

--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.6</version>
+		<version>3.4.7</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
b/416442436

context: previously spring-boot-dependencies.version was upgraded to v3.4.6 in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3825, but `spring-boot-starter-parent` used by samples were missed. In attempt to sync both to 3.4.6, encountered a known regression introduced by v3.4.6 and fixed in v3.4.7. Now upgrading both to v3.4.7