### PR TITLE
fix: make UserAgentHeaderProvider Serializable

### DIFF
--- a/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/UserAgentHeaderProvider.java
+++ b/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/UserAgentHeaderProvider.java
@@ -27,6 +27,8 @@ import java.util.Map;
  */
 public class UserAgentHeaderProvider implements HeaderProvider, Serializable {
 
+  private static final long serialVersionUID = 4928605135114708652L;
+
   private String userAgent;
 
   private final Map<String, String> headers;

--- a/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/UserAgentHeaderProvider.java
+++ b/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/UserAgentHeaderProvider.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spring.core;
 
 import com.google.api.gax.rpc.HeaderProvider;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
@@ -24,7 +25,7 @@ import java.util.Map;
  * Provides the user-agent header to signal to the Google Cloud Client Libraries that requests
  * originate from a Spring Integration.
  */
-public class UserAgentHeaderProvider implements HeaderProvider {
+public class UserAgentHeaderProvider implements HeaderProvider, Serializable {
 
   private String userAgent;
 

--- a/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/it/GoogleStorageIntegrationTests.java
+++ b/spring-cloud-gcp-storage/src/test/java/com/google/cloud/spring/storage/it/GoogleStorageIntegrationTests.java
@@ -46,6 +46,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.aot.DisabledInAotMode;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.StreamUtils;
 
@@ -129,6 +130,7 @@ class GoogleStorageIntegrationTests {
   }
 
   @Test
+  @DisabledInAotMode
   void testRestorableStateSerialization() throws IOException {
 
     String message = "test message";


### PR DESCRIPTION
This PR is created based on #3676.

[StorageOptions](https://github.com/googleapis/java-storage/blob/main/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java#L41) is Serializable. It extends [ServiceOptions](https://github.com/googleapis/sdk-platform-java/blob/0be1e9670079bcf6a9246d0284e59001c24242ea/java-core/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java#L83) in google-cloud-core. So this UserAgentHeaderProvider that is set to StorageOptions [here](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/a2efc4af6b39d82df0f636f2dd8b03fa91bff0a4/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfiguration.java#L86) in autoconfig needs to be Serializable.

serialVersionUID is calculated with
```
serialver -classpath path/to/google-cloud-core-2.58.0.jar:/path/to/gax-2.68.0.jar com.google.cloud.spring.core.UserAgentHeaderProvider
```
b/428237849
Fixes #3665
Thank you @ajbenjam for contributing!