### PR TITLE
ci: setup for 6.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,7 +45,7 @@ updates:
     # Spring Cloud dependencies
     # spring-cloud-dependencies-parent should be eventually removed per #1294
     - dependency-name: "org.springframework.cloud:spring-cloud-*"
-      versions: ["2022.x", "2023.x", "2024.x"]
+      versions: ["2022.x", "2023.x", "2024.x", "2025.x"]
     # Spring Shell dependencies
     - dependency-name: "org.springframework.shell:spring-shell-starter"
       versions: ["3.x"]
@@ -76,7 +76,7 @@ updates:
       versions: [">=3.2.0"]
     # Spring Cloud dependencies
     - dependency-name: "org.springframework.cloud:spring-cloud-*"
-      versions: ["2023.x", "2024.x"]
+      versions: ["2023.x", "2024.x", "2025.x"]
     # Spring Shell dependencies
     - dependency-name: "org.springframework.shell:spring-shell-starter"
       versions: [">=3.2.0"]
@@ -110,8 +110,34 @@ updates:
       versions: [">=3.4.0"]
     # Spring Cloud dependencies
     - dependency-name: "org.springframework.cloud:spring-cloud-*"
-      versions: ["2024.x"]
+      versions: ["2024.x", "2025.x"]
     # Spring Shell dependencies 3.4+ is meant to be used with Spring boot 3.4, which is part of
     # the non-supported (by 5.x branch) Spring Cloud 2024
     - dependency-name: "org.springframework.shell:spring-shell-starter"
       versions: [">=3.4.0"]
+
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+  commit-message:
+    # Prefix all commit messages with "deps: "
+    prefix: "deps"
+  open-pull-requests-limit: 10
+  target-branch: "6.x"
+  labels:
+    - "6.x dependencies"
+  ignore:
+    # Ignore major version updates - these should be made manually
+    - dependency-name: "*"
+      update-types: [ "version-update:semver-major" ]
+    # Ignore formatter dependency versions used in codegen modules, since they are fixed for Java 8 support
+    - dependency-name: "com.coveo:fmt-maven-plugin"
+    - dependency-name: "com.google.googlejavaformat:google-java-format"
+    # Ignore dependencies corresponding to Spring Boot 3.5+, <= Spring Cloud 2025.x:
+    # Spring Boot dependencies
+    - dependency-name: "org.springframework.boot:spring-boot-*"
+      versions: [">=3.5.0"]
+    # Spring Cloud dependencies
+    - dependency-name: "org.springframework.cloud:spring-cloud-*"
+      versions: ["2025.x"]

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -18,3 +18,7 @@ branches:
     handleGHRelease: true
     branch: 5.x
     extraFiles: ["README.adoc"]
+  - releaseType: java-yoshi
+    handleGHRelease: true
+    branch: 6.x
+    extraFiles: ["README.adoc"]

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -41,6 +41,42 @@ branchProtectionRules:
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false
+  - pattern: 6.x
+    isAdminEnforced: true
+    requiredStatusCheckContexts:
+      - 'cla/google'
+      - 'unitTests (17)'
+      - 'unitTests (19)'
+      - 'unitTests (21)'
+      - 'releaseCheck'
+      - 'conventionalcommits.org'
+      - 'Build with Sonar'
+      - 'parallel-NativeTests (alloydb-sample)'
+      - 'parallel-NativeTests (bigquery-sample)'
+      - 'parallel-NativeTests (bigquery)'
+      - 'parallel-NativeTests (core)'
+      - 'parallel-NativeTests (data-firestore)'
+      - 'parallel-NativeTests (data-firestore-sample)'
+      - 'parallel-NativeTests (datastore)'
+      - 'parallel-NativeTests (datastore-basic-sample)'
+      - 'parallel-NativeTests (kms)'
+      - 'parallel-NativeTests (kms-sample)'
+      - 'parallel-NativeTests (logging-sample)'
+      - 'parallel-NativeTests (metrics-sample)'
+      - 'parallel-NativeTests (pubsub-sample)'
+      - 'parallel-NativeTests (pubsub-bus-sample)'
+      - 'parallel-NativeTests (pubsub-integration-sample)'
+      - 'parallel-NativeTests (secretmanager)'
+      - 'parallel-NativeTests (secretmanager-sample)'
+      - 'parallel-NativeTests (spanner)'
+      - 'parallel-NativeTests (sql-mysql-sample)'
+      - 'parallel-NativeTests (sql-postgres-sample)'
+      - 'parallel-NativeTests (starter-firestore-sample)'
+      - 'parallel-NativeTests (storage)'
+      - 'parallel-NativeTests (storage-sample)'
+      - 'parallel-NativeTests (trace-sample)'
+      - 'parallel-NativeTests (vision)'
+      - 'parallel-NativeTests (vision-sample)'
   - pattern: 5.x
     isAdminEnforced: true
     requiredStatusCheckContexts:

--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 6.x
       - 5.x
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
-      - 3.x
-      - 4.x
+      - 6.x
       - 5.x
+      - 4.x
+      - 3.x
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Run Renovate
         uses: renovatebot/forking-renovate@main
         with:
-          baseBranches: main,3.x,4.x,5.x
+          baseBranches: main,6.x,5.x,4.x,3.x
           createPullRequests: true

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
-      - 3.x
-      - 4.x
+      - 6.x
       - 5.x
+      - 4.x
+      - 3.x
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Following steps from https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3436

Plan:
- [ ] `do not merge` until https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/3837 is approved (and don't merge that one just yet)
- [ ] Merge this.
- [ ] Create 5.x branch.
- [ ] Merge breaking change PR to update to Spring Cloud 2025 and Spring Boot 3.5