### PR TITLE
docs: remove beta subcommand for GA library "parameter manager"

### DIFF
--- a/docs/src/main/asciidoc/parameter.adoc
+++ b/docs/src/main/asciidoc/parameter.adoc
@@ -58,9 +58,9 @@ In order to do that, you should have the https://cloud.google.com/sdk/[Google Cl
 ----
 $ gcloud init # if this is your first Google Cloud SDK run.
 
-$ gcloud beta parametermanager parameters create myapp --location=global --parameter-format=JSON
+$ gcloud parametermanager parameters create myapp --location=global --parameter-format=JSON
 
-$ gcloud beta parametermanager parameters versions create prod --parameter=myapp --location=global --payload-data="{\"myapp.username\":\"test-user\",\"myapp.password\":\"test-password\"}"
+$ gcloud parametermanager parameters versions create prod --parameter=myapp --location=global --payload-data="{\"myapp.username\":\"test-user\",\"myapp.password\":\"test-password\"}"
 ----
 
 In the parameter version payload, `myapp.username` and `myapp.password` correspond to properties where `myapp` is the prefix specified in the `@ConfigurationProperties` annotation. For example: `@ConfigurationProperties("myapp")`.
@@ -133,9 +133,9 @@ dependencies {
 4.  Update a property with `gcloud`. For Parameter Manager, need to delete and create the version:
 +
 ....
-$ gcloud beta parametermanager parameters versions delete prod --parameter=myapp --location=global
+$ gcloud parametermanager parameters versions delete prod --parameter=myapp --location=global
 
-$ gcloud beta parametermanager parameters versions create prod --parameter=myapp --location=global --payload-data="{\"username\":\"test-user\",\"password\":\"test-password-refreshed\"}"
+$ gcloud parametermanager parameters versions create prod --parameter=myapp --location=global --payload-data="{\"username\":\"test-user\",\"password\":\"test-password-refreshed\"}"
 ....
 5.  Send a POST request to the refresh endpoint:
 +


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3981

Parameter manager is GA since https://github.com/googleapis/googleapis/commit/592aef543abdb51885ff85570d126f7885cec443


```
$ gcloud parametermanager parameters --help | head -n 5
NAME
    gcloud parametermanager parameters - manage Parameter Manager parameter
        resources
```