### PR TITLE
Include `parameter.adoc` in main documentation structure

### DIFF
--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -65,6 +65,8 @@ include::secretmanager.adoc[]
 
 include::kms.adoc[]
 
+include::parameter.adoc[]
+
 include::config.adoc[]
 
 include::cloudfoundry.adoc[]


### PR DESCRIPTION
Fixes #4061 