### PR TITLE
fix(spanner): check for empty before delete (#4047)

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
@@ -176,6 +176,9 @@ public class SimpleSpannerRepository<T, I> implements SpannerRepository<T, I> {
   @Override
   public void deleteAllById(Iterable<? extends I> ids) {
     Assert.notNull(ids, "IDs must not be null");
+    if (!ids.iterator().hasNext()) {
+      return;
+    }
     KeySet.Builder builder = KeySet.newBuilder();
     for (Object id : ids) {
       builder.addKey(toKey(id));


### PR DESCRIPTION
Backport fix.

spanner IT fails for `deleteAllById_doesNothingOnEmptyIds` test with error from Spanner: `INVALID_ARGUMENT: Failed to initialize transaction due to invalid mutation key.`

**Trigger of this behavior change:**
spanner activated multiplexed sessions by default in [googleapis/java-spanner#3996](https://github.com/googleapis/java-spanner/pull/3996), which triggers this error. When issuing a write() with a Mutation that has an empty KeySet produces an exception in Multiplexed clients (see [pr](https://github.com/googleapis/java-spanner/pull/4023)), but does a no-op in non-multiplexed ones. Unlike Regular session, multiplex session needs a valid mutation to generate a precommit token.

Fixes #4046
