### PR TITLE
deps: bump com.google.cloud:libraries-bom from 26.65.0 to 26.66.0

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -34,7 +34,7 @@
 	</distributionManagement>
 
 	<properties>
-		<gcp-libraries-bom.version>26.65.0</gcp-libraries-bom.version>
+		<gcp-libraries-bom.version>26.66.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.23.1</cloud-sql-socket-factory.version>
 		<r2dbc-postgres-driver.version>1.0.7.RELEASE</r2dbc-postgres-driver.version>
 		<cloud-spanner-r2dbc.version>1.3.0</cloud-spanner-r2dbc.version>


### PR DESCRIPTION
manual version bump