### PR TITLE
feat: Update root reference docs with latest version

### DIFF
--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -189,10 +189,18 @@ function copy_docs_for_provided_version() {
     local FOLDER=${DESTINATION_REPO_FOLDER}/${VERSION}
     mkdir -p "${FOLDER}"
     echo -e "Current tag is [v${VERSION}] Will copy the current docs to the [${FOLDER}] folder"
-    for f in "${ROOT_FOLDER}"/docs/target/generated-docs/*; do
-        file=${f#${ROOT_FOLDER}/docs/target/generated-docs/*}
+    echo -e "Also updating root documentation to point to version [${VERSION}]"
+
+    for f in "${ROOT_FOLDER}"/docs/target/generated-docs/\*; do
+        file=${f#${ROOT_FOLDER}/docs/target/generated-docs/\*}
+
+        # Copy to the version-specific folder
         copy_docs_for_branch "${file}" "${FOLDER}"
+
+        # Copy to the root folder
+        copy_docs_for_branch "${file}" "${DESTINATION_REPO_FOLDER}"
     done
+
     COMMIT_CHANGES="yes"
     CURRENT_BRANCH="v${VERSION}"
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3610

Modifies the ghpages.sh script to update the root documentation
directory (e.g., /reference/html/) in the gh-pages branch *only*
when a versioned release is being processed (using the -v flag).

This is achieved by adding calls to copy_docs_for_branch within the
copy_docs_for_provided_version function to target the root
destination folder, in addition to the version-specific folder.

This ensures the version-less URL always points to the latest
officially released documentation.