### PR TITLE
chore: Update docs to latest available

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,12 +11,12 @@ You can check our project website https://spring.io/projects/spring-cloud-gcp[he
 For a deep dive into the project, refer to the Spring Framework on Google Cloud Reference documentation or Javadocs:
 
 // {x-version-update-start:spring-cloud-gcp:released}
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.3.0/reference/html/index.html[Spring Framework on Google Cloud 7.1.0 (Latest)] - https://googleapis.dev/java/spring-cloud-gcp/7.1.0/index.html[Javadocs 7.1.0]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.2.0/reference/html/index.html[Spring Framework on Google Cloud 7.2.0 (Latest)] - https://googleapis.dev/java/spring-cloud-gcp/7.2.0/index.html[Javadocs 7.2.0]
 // {x-version-update-end}
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.3.1/reference/html/index.html[Spring Framework on Google Cloud 6.3.1] - https://googleapis.dev/java/spring-cloud-gcp/6.3.1/index.html[Javadocs 6.3.1]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/5.13.1/reference/html/index.html[Spring Framework on Google Cloud 5.13.1] - https://googleapis.dev/java/spring-cloud-gcp/5.13.1/index.html[Javadocs 5.13.1]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.3.2/reference/html/index.html[Spring Framework on Google Cloud 6.3.2] - https://googleapis.dev/java/spring-cloud-gcp/6.3.2/index.html[Javadocs 6.3.2]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/5.13.2/reference/html/index.html[Spring Framework on Google Cloud 5.13.2] - https://googleapis.dev/java/spring-cloud-gcp/5.13.1/index.html[Javadocs 5.13.2]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/4.11.3/reference/html/index.html[Spring Framework on Google Cloud 4.11.3] - https://googleapis.dev/java/spring-cloud-gcp/4.11.3/index.html[Javadocs 4.11.3]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.9.7/reference/html/index.html[Spring Framework on Google Cloud 3.9.7] - https://googleapis.dev/java/spring-cloud-gcp/3.9.7/index.html[Javadocs 3.9.7]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.9.7/reference/html/index.html[Spring Framework on Google Cloud 3.9.8] - https://googleapis.dev/java/spring-cloud-gcp/3.9.7/index.html[Javadocs 3.9.8]
 
 
 If you prefer to learn by doing, try taking a look at the https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples[Spring Framework on Google Cloud sample applications] or the https://codelabs.developers.google.com/spring[Spring on Google Cloud codelabs].

--- a/README.adoc
+++ b/README.adoc
@@ -14,9 +14,9 @@ For a deep dive into the project, refer to the Spring Framework on Google Cloud 
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.2.0/reference/html/index.html[Spring Framework on Google Cloud 7.2.0 (Latest)] - https://googleapis.dev/java/spring-cloud-gcp/7.2.0/index.html[Javadocs 7.2.0]
 // {x-version-update-end}
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.3.2/reference/html/index.html[Spring Framework on Google Cloud 6.3.2] - https://googleapis.dev/java/spring-cloud-gcp/6.3.2/index.html[Javadocs 6.3.2]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/5.13.2/reference/html/index.html[Spring Framework on Google Cloud 5.13.2] - https://googleapis.dev/java/spring-cloud-gcp/5.13.1/index.html[Javadocs 5.13.2]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/5.13.2/reference/html/index.html[Spring Framework on Google Cloud 5.13.2] - https://googleapis.dev/java/spring-cloud-gcp/5.13.2/index.html[Javadocs 5.13.2]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/4.11.3/reference/html/index.html[Spring Framework on Google Cloud 4.11.3] - https://googleapis.dev/java/spring-cloud-gcp/4.11.3/index.html[Javadocs 4.11.3]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.9.7/reference/html/index.html[Spring Framework on Google Cloud 3.9.8] - https://googleapis.dev/java/spring-cloud-gcp/3.9.7/index.html[Javadocs 3.9.8]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.9.8/reference/html/index.html[Spring Framework on Google Cloud 3.9.8] - https://googleapis.dev/java/spring-cloud-gcp/3.9.8/index.html[Javadocs 3.9.8]
 
 
 If you prefer to learn by doing, try taking a look at the https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples[Spring Framework on Google Cloud sample applications] or the https://codelabs.developers.google.com/spring[Spring on Google Cloud codelabs].


### PR DESCRIPTION
This is a temporary change to update the README to the latest available documentation as reported in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/4113

After the new latest version's documentation is published, I will update again to the latest version