### PR TITLE
feat: Add support for configuring the Cloud SQL JDBC connection using a DNS name

### DIFF
--- a/docs/src/main/asciidoc/sql.adoc
+++ b/docs/src/main/asciidoc/sql.adoc
@@ -167,8 +167,10 @@ However, it doesn't compromise the security of the communication because the con
 | `spring.cloud.gcp.sql.jdbc.enabled` | Enables or disables Cloud SQL auto-configuration for JDBC | No | `true`
 | `spring.cloud.gcp.sql.r2dbc.enabled` | Enables or disables Cloud SQL auto-configuration for R2DBC | No | `true`
 | `spring.cloud.gcp.sql.database-name` | Name of the database to connect to. | Yes |
-| `spring.cloud.gcp.sql.instance-connection-name` | A string containing a Google Cloud SQL instance's project ID, region and name, each separated by a colon. | Yes |
+| `spring.cloud.gcp.sql.instance-connection-name` | A string containing a Google Cloud SQL instance's project ID, region and name, each separated by a colon. | Yes* |
 For example, `my-project-id:my-region:my-instance-name`.
+| `spring.cloud.gcp.sql.dns-name` | A string containing the DNS for the instance. See https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/blob/main/docs/jdbc.md#using-dns-domain-names-to-identify-instances[Using DNS domain names to identify instances] | Yes* |
+For example, `mydb.example.com`.
 | `spring.cloud.gcp.sql.ip-types` | Allows you to specify a comma delimited list of preferred IP types for connecting to a Cloud SQL instance. Left unconfigured Cloud SQL Socket Factory will default it to `PUBLIC,PRIVATE`. See https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory#specifying-ip-types[Cloud SQL Socket Factory - Specifying IP Types] | No | `PUBLIC,PRIVATE`
 | `spring.cloud.gcp.sql.credentials.location` | File system path to the Google OAuth2 credentials private key file.
 Used to authenticate and authorize new connections to a Google Cloud SQL instance. | No
@@ -185,6 +187,12 @@ Used to authenticate and authorize new connections to a Google Cloud SQL instanc
 | `spring.cloud.gcp.sql.adminServicePath` | An alternate path to the SQL Admin API endpoint. | No | (empty)
 | `spring.cloud.gcp.sql.adminQuotaProject` | A project ID for quota and billing. | No | (empty)
 |===
+
+*Valid configurations set exactly one of these properties:
+
+- `spring.cloud.gcp.sql.dns-name`
+- `spring.cloud.gcp.sql.instance-connection-name`.
+
 
 === Troubleshooting tips
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/DatabaseType.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/DatabaseType.java
@@ -21,18 +21,16 @@ public enum DatabaseType {
   /** MySQL constants. */
   MYSQL(
       "com.mysql.cj.jdbc.Driver",
-      "jdbc:mysql://google/%s?"
-          + "socketFactory=com.google.cloud.sql.mysql.SocketFactory"
-          + "&cloudSqlInstance=%s",
+      "jdbc:mysql://%s/%s?"
+          + "socketFactory=com.google.cloud.sql.mysql.SocketFactory",
       "r2dbc:gcp:mysql://%s/%s",
       "root"),
 
   /** Postgresql constants. */
   POSTGRESQL(
       "org.postgresql.Driver",
-      "jdbc:postgresql://google/%s?"
-          + "socketFactory=com.google.cloud.sql.postgres.SocketFactory"
-          + "&cloudSqlInstance=%s",
+      "jdbc:postgresql://%s/%s?"
+          + "socketFactory=com.google.cloud.sql.postgres.SocketFactory",
       "r2dbc:gcp:postgres://%s/%s",
       "postgres");
 

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/GcpCloudSqlProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/sql/GcpCloudSqlProperties.java
@@ -28,6 +28,9 @@ public class GcpCloudSqlProperties {
   /** Cloud SQL instance connection name. [GCP_PROJECT_ID]:[INSTANCE_REGION]:[INSTANCE_NAME]. */
   private String instanceConnectionName;
 
+  /** The DNS name for the instance, for example mydb.example.com. */
+  private String dnsName;
+
   /** A comma delimited list of preferred IP types for connecting to the Cloud SQL instance. */
   private String ipTypes;
 
@@ -89,6 +92,14 @@ public class GcpCloudSqlProperties {
 
   public void setInstanceConnectionName(String instanceConnectionName) {
     this.instanceConnectionName = instanceConnectionName;
+  }
+
+  public String getDnsName() {
+    return dnsName;
+  }
+
+  public void setDnsName(String dnsName) {
+    this.dnsName = dnsName;
   }
 
   public String getIpTypes() {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/sql/CloudSqlEnvironmentPostProcessorTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/sql/CloudSqlEnvironmentPostProcessorTests.java
@@ -100,6 +100,24 @@ class CloudSqlEnvironmentPostProcessorTests {
             });
   }
 
+    @Test
+    void testCloudSqlDataSourceWithDnsName() {
+        this.contextRunner
+                .withPropertyValues(
+                        "spring.cloud.gcp.sql.dns-name=myinstance.example.com",
+                        "spring.datasource.password=")
+                .run(
+                        context -> {
+                            HikariDataSource dataSource = (HikariDataSource) context.getBean(DataSource.class);
+                            assertThat(dataSource.getDriverClassName()).matches("com.mysql.cj.jdbc.Driver");
+                            assertThat(dataSource.getJdbcUrl())
+                                    .isEqualTo(
+                                            "jdbc:mysql://myinstance.example.com/test-database?"
+                                                    + "socketFactory=com.google.cloud.sql.mysql.SocketFactory");
+                            assertThat(dataSource.getUsername()).matches("root");
+                            assertThat(dataSource.getPassword()).isNull();
+                        });
+    }
   @Test
   void testCloudSqlDataSourceWithIgnoredProvidedUrl() {
     this.contextRunner


### PR DESCRIPTION
This updates the Spring GCP Cloud SQL configuration so that you can use an instance DNS name instead of an instance connection name. 

See [Using domain names to identify instances](https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/blob/main/docs/jdbc.md#using-dns-domain-names-to-identify-instances) in the Cloud SQL Java Connection documentation.
