### PR TITLE
chore: Provide generic Javadocs link on the Spring README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,14 +10,16 @@ You can check our project website https://spring.io/projects/spring-cloud-gcp[he
 
 For a deep dive into the project, refer to the Spring Framework on Google Cloud Reference documentation or Javadocs:
 
+Google Cloud Reference Documentation:
 // {x-version-update-start:spring-cloud-gcp:released}
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.3.0/reference/html/index.html[Spring Framework on Google Cloud 7.3.0 (Latest)] - https://googleapis.dev/java/spring-cloud-gcp/7.3.0/index.html[Javadocs 7.3.0]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.3.0/reference/html/index.html[Spring Framework on Google Cloud 7.3.0 (Latest)]
 // {x-version-update-end}
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.3.3/reference/html/index.html[Spring Framework on Google Cloud 6.3.3] - https://googleapis.dev/java/spring-cloud-gcp/6.3.3/index.html[Javadocs 6.3.3]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/5.13.3/reference/html/index.html[Spring Framework on Google Cloud 5.13.3] - https://googleapis.dev/java/spring-cloud-gcp/5.13.3/index.html[Javadocs 5.13.3]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/4.11.3/reference/html/index.html[Spring Framework on Google Cloud 4.11.3] - https://googleapis.dev/java/spring-cloud-gcp/4.11.3/index.html[Javadocs 4.11.3]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.9.9/reference/html/index.html[Spring Framework on Google Cloud 3.9.9] - https://googleapis.dev/java/spring-cloud-gcp/3.9.9/index.html[Javadocs 3.9.9]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.3.3/reference/html/index.html[Spring Framework on Google Cloud 6.3.3]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/5.13.3/reference/html/index.html[Spring Framework on Google Cloud 5.13.3]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/4.11.3/reference/html/index.html[Spring Framework on Google Cloud 4.11.3]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.9.9/reference/html/index.html[Spring Framework on Google Cloud 3.9.9]
 
+Javadocs: https://googleapis.dev/java/spring-cloud-gcp/latest/index.html
 
 If you prefer to learn by doing, try taking a look at the https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples[Spring Framework on Google Cloud sample applications] or the https://codelabs.developers.google.com/spring[Spring on Google Cloud codelabs].
 


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/4113

The Javadocs page takes a bit to generate and prevents us from updating the latest versions on the README once we kick off the Spring release. Provide a generic link to the javadocs page that points to the latest version by default. Users can select the version they want to use in the drop down in the bottom right corner.