### PR TITLE
feat: add script to update versions in README.adoc

### DIFF
--- a/docs/update_latest_versions_in_readme.sh
+++ b/docs/update_latest_versions_in_readme.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script updates the version numbers in README.adoc to the latest
+# released versions from Maven Central.
+
+set -e
+
+# Fetch the list of versions from Maven Central
+versions=$(curl -s https://repo.maven.apache.org/maven2/com/google/cloud/spring-cloud-gcp/maven-metadata.xml | grep '<version>' | sed -e 's/.*<version>//' -e 's/<\/version>.*//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V)
+
+# Find the latest version for each major version
+latest_v6=$(echo "$versions" | grep '^6\.' | tail -n 1)
+latest_v5=$(echo "$versions" | grep '^5\.' | tail -n 1)
+latest_v4=$(echo "$versions" | grep '^4\.' | tail -n 1)
+latest_v3=$(echo "$versions" | grep '^3\.' | tail -n 1)
+
+# Update the README.adoc file
+sed -i "/Spring Framework on Google Cloud 6\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v6}/g" README.adoc
+sed -i "/Spring Framework on Google Cloud 5\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v5}/g" README.adoc
+sed -i "/Spring Framework on Google Cloud 4\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v4}/g" README.adoc
+sed -i "/Spring Framework on Google Cloud 3\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v3}/g" README.adoc
+
+echo "README.adoc updated with the latest versions:"
+echo "version-6: $latest_v6"
+echo "version-5: $latest_v5"
+echo "version-4: $latest_v4"
+echo "version-3: $latest_v3"


### PR DESCRIPTION
**Description**

  This PR introduces a new script to automate the process of updating the version numbers in the README.adoc file.

**Problem**

  The README.adoc file contains links to the documentation for different versions of the project. These version numbers are hardcoded and need to be updated manually for each new release. This is a tedious and error-prone process.

**Solution**

  This PR adds a new shell script named `update_latest_versions_in_readme.sh` in the `docs/` folder. This script:

   1. Fetches the latest version numbers for each major release line (6.x, 5.x, 4.x, 3.x) from the maven-metadata.xml file in the Maven Central repository.
   2. Uses sed to directly update the hardcoded version numbers in the README.adoc file.

**How to use the script**

  To update the versions in the README.adoc file, simply run the following command from the root of the project:

   1 `./docs/update_latest_versions_in_readme.sh`

  This will ensure that the README.adoc file always points to the latest released versions of the documentation.
