### PR TITLE
chore: Fix list rendering in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,7 @@ You can check our project website https://spring.io/projects/spring-cloud-gcp[he
 For a deep dive into the project, refer to the Spring Framework on Google Cloud Reference documentation or Javadocs:
 
 Google Cloud Reference Documentation:
+
 // {x-version-update-start:spring-cloud-gcp:released}
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.3.2/reference/html/index.html[Spring Framework on Google Cloud 7.3.0 (Latest)]
 // {x-version-update-end}


### PR DESCRIPTION
The current 'Google Cloud Reference Documentation' list on https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/main/README.adoc is not rendered as a list, but all entries are on a single line.

Asciidoc requires an empty line before a bullet list.