### PR TITLE
fix(#4184): Make data-spanner unit tests deterministic by implementing SQL column sorting in SpannerStatementQueryExecutor

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryExecutor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryExecutor.java
@@ -34,6 +34,7 @@ import com.google.cloud.spring.data.spanner.core.mapping.Where;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -494,7 +495,10 @@ public final class SpannerStatementQueryExecutor {
       SpannerPersistentEntity<?> spannerPersistentEntity,
       SpannerMappingContext mappingContext,
       boolean fetchInterleaved) {
-    final String sql = String.join(", ", spannerPersistentEntity.columns());
+    // To assure the columns are deterministic, sort them here.
+    ArrayList<String> sortedColumns = new ArrayList<>(spannerPersistentEntity.columns());
+    Collections.sort(sortedColumns);
+    final String sql = String.join(", ", sortedColumns);
     return fetchInterleaved
         ? sql + getChildrenSubquery(spannerPersistentEntity, mappingContext)
         : sql;

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
@@ -539,7 +539,7 @@ class SpannerTemplateTests {
     spyTemplate.read(ParentEntity.class, keys);
     Statement statement =
         Statement.newBuilder(
-                "SELECT other, id, custom_col, id_2, ARRAY (SELECT AS STRUCT deleted, id3, id, id_2"
+                "SELECT custom_col, id, id_2, other, ARRAY (SELECT AS STRUCT deleted, id, id3, id_2"
                     + " FROM child_test_table WHERE (child_test_table.id = parent_test_table.id AND"
                     + " child_test_table.id_2 = parent_test_table.id_2) AND (deleted = false)) AS"
                     + " childEntities FROM parent_test_table WHERE (id = @tag0) OR (id_2 = @tag1)")
@@ -558,7 +558,7 @@ class SpannerTemplateTests {
     spyTemplate.readAll(ParentEntity.class);
     Statement statement =
         Statement.newBuilder(
-                "SELECT other, id, custom_col, id_2, ARRAY (SELECT AS STRUCT deleted, id3, id, id_2"
+                "SELECT custom_col, id, id_2, other, ARRAY (SELECT AS STRUCT deleted, id, id3, id_2"
                     + " FROM child_test_table WHERE (child_test_table.id = parent_test_table.id AND"
                     + " child_test_table.id_2 = parent_test_table.id_2) AND (deleted = false)) AS"
                     + " childEntities FROM parent_test_table")

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
@@ -196,7 +196,7 @@ class SpannerQueryLookupStrategyTests {
             this.spannerMappingContext);
     assertThat(statement.getSql())
         .isEqualTo(
-            "SELECT deleted, id3, id, id_2 FROM child_test_table WHERE ((id = @tag0 AND id_2 ="
+            "SELECT deleted, id, id3, id_2 FROM child_test_table WHERE ((id = @tag0 AND id_2 ="
                 + " @tag1)) AND (deleted = false)");
     assertThat(statement.getParameters()).hasSize(2);
     assertThat(statement.getParameters().get("tag0").getString()).isEqualTo("key");
@@ -218,7 +218,7 @@ class SpannerQueryLookupStrategyTests {
 
     assertThat(columnsStringForSelect)
         .isEqualTo(
-            "other, deleted, id, custom_col, id_2, ARRAY (SELECT AS STRUCT deleted, id3, id, id_2"
+            "custom_col, deleted, id, id_2, other, ARRAY (SELECT AS STRUCT deleted, id, id3, id_2"
                 + " FROM child_test_table WHERE (child_test_table.id = custom_test_table.id AND"
                 + " child_test_table.id_2 = custom_test_table.id_2) AND (deleted = false)) AS"
                 + " childEntities");
@@ -245,7 +245,7 @@ class SpannerQueryLookupStrategyTests {
 
     assertThat(childrenRowsQuery.getSql())
         .isEqualTo(
-            "SELECT other, deleted, id, custom_col, id_2, ARRAY (SELECT AS STRUCT deleted, id3, id,"
+            "SELECT custom_col, deleted, id, id_2, other, ARRAY (SELECT AS STRUCT deleted, id, id3,"
                 + " id_2 FROM child_test_table WHERE (child_test_table.id = custom_test_table.id"
                 + " AND child_test_table.id_2 = custom_test_table.id_2) AND (deleted = false)) AS"
                 + " childEntities FROM custom_test_table WHERE ((id = @tag0 AND id_2 = @tag1) OR"

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
@@ -119,7 +119,7 @@ class SpannerStatementQueryTests {
               Statement statement = invocation.getArgument(1);
 
               String expectedQuery =
-                  "SELECT DISTINCT shares, trader_id, ticker, price, action, id, value FROM trades"
+                  "SELECT DISTINCT action, id, price, shares, ticker, trader_id, value FROM trades"
                       + " WHERE ( LOWER(action)=LOWER(@tag0) AND ticker=@tag1 ) OR ("
                       + " trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND id IS NOT NULL AND"
                       + " trader_id=NULL AND trader_id LIKE @tag7 AND price=TRUE AND price=FALSE"
@@ -230,7 +230,7 @@ class SpannerStatementQueryTests {
               Statement statement = invocation.getArgument(1);
 
               String expectedSql =
-                  "SELECT EXISTS(SELECT DISTINCT shares, trader_id, ticker, price, action, id,"
+                  "SELECT EXISTS(SELECT DISTINCT action, id, price, shares, ticker, trader_id,"
                       + " value FROM trades WHERE ( LOWER(action)=LOWER(@tag0) AND ticker=@tag1 )"
                       + " OR ( trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND id IS NOT NULL AND"
                       + " trader_id=NULL AND trader_id LIKE @tag7 AND price=TRUE AND price=FALSE"
@@ -267,7 +267,7 @@ class SpannerStatementQueryTests {
     Object[] params = new Object[] {8.88, PageRequest.of(1, 10, Sort.by("traderId"))};
     Method method = QueryHolder.class.getMethod("repositoryMethod5", Double.class, Pageable.class);
     String expectedSql =
-        "SELECT shares, trader_id, ticker, price, action, id, value "
+        "SELECT action, id, price, shares, ticker, trader_id, value "
             + "FROM trades WHERE ( price<@tag0 ) "
             + "ORDER BY trader_id ASC LIMIT 10 OFFSET 10";
 
@@ -282,7 +282,7 @@ class SpannerStatementQueryTests {
         };
     Method method = QueryHolder.class.getMethod("repositoryMethod6", Double.class, Sort.class);
     String expectedSql =
-        "SELECT shares, trader_id, ticker, price, action, id, value "
+        "SELECT action, id, price, shares, ticker, trader_id, value "
             + "FROM trades WHERE ( price<@tag0 ) "
             + "ORDER BY trader_id DESC , price ASC , action DESC";
 
@@ -329,7 +329,7 @@ class SpannerStatementQueryTests {
 
     when(this.queryMethod.getQueryMethod()).thenReturn(method);
     String expectedSql =
-        "SELECT shares, trader_id, ticker, price, action, id, value "
+        "SELECT action, id, price, shares, ticker, trader_id, value "
             + "FROM trades "
             + "WHERE ( action=@tag0 AND ticker=@tag1 ) "
             + "ORDER BY trader_id ASC LIMIT 10 OFFSET 10";

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQueryTests.java
@@ -175,8 +175,8 @@ class SqlSpannerQueryTests {
             + ":com.google.cloud.spring.data.spanner.repository.query.SqlSpannerQueryTests$Trade:";
     // @formatter:off
     String entityResolvedSql =
-        "SELECT *, ARRAY (SELECT AS STRUCT disabled, id, childId, value, ARRAY (SELECT AS STRUCT"
-            + " canceled, documentId, id, childId, content FROM documents WHERE (documents.id ="
+        "SELECT *, ARRAY (SELECT AS STRUCT childId, disabled, id, value, ARRAY (SELECT AS STRUCT"
+            + " canceled, childId, content, documentId, id FROM documents WHERE (documents.id ="
             + " children.id AND documents.childId = children.childId) AND (canceled = false)) AS"
             + " documents FROM children WHERE (children.id = trades.id) AND (disabled = false)) AS"
             + " children FROM (SELECT DISTINCT * FROM trades) trades";
@@ -229,7 +229,7 @@ class SqlSpannerQueryTests {
             + " WHERE id = @id AND trader_id = @trader_id";
     // @formatter:off
     String entityResolvedSql =
-        "SELECT *, ARRAY (SELECT AS STRUCT canceled, documentId, id, childId, content FROM"
+        "SELECT *, ARRAY (SELECT AS STRUCT canceled, childId, content, documentId, id FROM"
             + " documents WHERE (documents.id = children.id AND documents.childId ="
             + " children.childId) AND (canceled = false)) AS documents FROM (SELECT * FROM children"
             + " WHERE id = @id AND trader_id = @trader_id) children WHERE disabled = false ORDER BY"
@@ -294,7 +294,7 @@ class SqlSpannerQueryTests {
             + " WHERE id = @id AND trader_id = @trader_id";
     // @formatter:off
     String entityResolvedSql =
-        "SELECT *, ARRAY (SELECT AS STRUCT canceled, documentId, id, childId, content FROM"
+        "SELECT *, ARRAY (SELECT AS STRUCT canceled, childId, content, documentId, id FROM"
             + " documents WHERE (documents.id = children.id AND documents.childId ="
             + " children.childId) AND (canceled = false)) AS documents FROM (SELECT * FROM children"
             + " WHERE id = @id AND trader_id = @trader_id) children WHERE disabled = false ORDER BY"
@@ -358,7 +358,7 @@ class SqlSpannerQueryTests {
             + " WHERE id = @id AND trader_id = @trader_id";
     // @formatter:off
     String entityResolvedSql =
-        "SELECT *, ARRAY (SELECT AS STRUCT canceled, documentId, id, childId, content FROM"
+        "SELECT *, ARRAY (SELECT AS STRUCT canceled, childId, content, documentId, id FROM"
             + " documents WHERE (documents.id = children.id AND documents.childId ="
             + " children.childId) AND (canceled = false)) AS documents FROM (SELECT * FROM children"
             + " WHERE id = @id AND trader_id = @trader_id) children WHERE disabled = false ORDER BY"
@@ -431,8 +431,8 @@ class SqlSpannerQueryTests {
 
     // @formatter:off
     String entityResolvedSql =
-        "SELECT *, ARRAY (SELECT AS STRUCT disabled, id, childId, value, ARRAY (SELECT AS STRUCT"
-            + " canceled, documentId, id, childId, content FROM documents WHERE (documents.id ="
+        "SELECT *, ARRAY (SELECT AS STRUCT childId, disabled, id, value, ARRAY (SELECT AS STRUCT"
+            + " canceled, childId, content, documentId, id FROM documents WHERE (documents.id ="
             + " children.id AND documents.childId = children.childId) AND (canceled = false)) AS"
             + " documents FROM children WHERE (children.id = trades.id) AND (disabled = false)) AS"
             + " children FROM (SELECT DISTINCT * FROM trades@{index=fakeindex} WHERE"


### PR DESCRIPTION
Hello, I implement a fix here for issue #4184 . The details of the issue can be found in that description, but to summarize briefly, the unit tests in the spring-cloud-gcp-data-spanner module that verify SQL statements may fail occasionally since the generated SQL strings may have different column orderings on different runs due to how they are stored. Though the tests may be stable now, it's not guaranteed to remain this way if the underlying environment changes for whatever reason, so it might be beneficial to address this. 

**Fix:**

The fix I implemented is the one I propose in the issue as well, which simply sorts the columns in the `getColumnStringsForSelect()` method of `SpannerStatementQueryExecutor`. Then, I changed the column ordering of the expected SQL strings in the 15 unit tests that are affected by this to alphabetical order. 

I ran all tests using `./mvnw clean test` and observed a passing result. I'm assuming that column name ordering in the SQL statements is not important, due to how they are stored in the unordered HashSet in the existing implementation; apologies if I've misunderstood or missed something. If it is necessary to preserve a certain order (ie the ones present currently in expected strings of the unit tests), or if there is a better way to address this issue, please let me know. Thank you!