### PR TITLE
Fix Flaky Test `ConverterAwareMappingSpannerEntityReaderTests#readNotFoundColumnTest`

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
@@ -223,7 +223,7 @@ class ConverterAwareMappingSpannerEntityReaderTests {
 
     assertThatThrownBy(() -> this.spannerEntityReader.read(TestEntity.class, struct))
         .isInstanceOf(SpannerDataException.class)
-        .hasMessage("Unable to read column from Cloud Spanner results: id4");
+        .hasMessageContaining("Unable to read column from Cloud Spanner results:");
   }
 
   @Test


### PR DESCRIPTION
## Issue
Test `ConverterAwareMappingSpannerEntityReaderTests#readNotFoundColumnTest` is flaky. See #4211 

## Fix
This fix checks only the stable part of the error message instead of the full string. It keeps verifying that the expected exception is thrown while removing flakiness from variable details like column names or formatting.