### PR TITLE
Fix Flaky Test `SpannerPersistentPropertyImplTests#testNullColumnName`

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentPropertyImplTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/mapping/SpannerPersistentPropertyImplTests.java
@@ -48,13 +48,12 @@ class SpannerPersistentPropertyImplTests {
     context.setFieldNamingStrategy(namingStrat);
 
     assertThatThrownBy(() -> context.getPersistentEntity(TestEntity.class))
-            .hasMessageContaining("Invalid (null or empty) field name returned for "
-                    + "property @com.google.cloud.spring.data.spanner.core.mapping.PrimaryKey")
-            .hasMessageContaining("keyOrder=1")
-            .hasMessageContaining("value=1")
-            .hasMessageContaining("java.lang.String com.google.cloud.spring.data.spanner.core.mapping."
-                    + "SpannerPersistentPropertyImplTests$TestEntity.id by class "
-                    + "org.springframework.data.mapping.model.FieldNamingStrategy$MockitoMock$");
+            .hasMessageContaining("Invalid (null or empty) field name returned for ")
+            .hasMessageContaining("com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentPropertyImplTests$TestEntity")
+                .satisfies(t -> {
+                  String msg = t.getMessage();
+                  assertThat(msg).matches("(?s).*SpannerPersistentPropertyImplTests\\$TestEntity\\.(id|doubleList|other)\\b.*");
+                });
   }
 
 


### PR DESCRIPTION
## Issue
Test `SpannerPersistentPropertyImplTests#testNullColumnName` is flaky. See #4213  

## Fix
This fix drops brittle message checks (including dynamic Mockito class names) and instead asserts stable parts of the error plus a regex that accepts any of the expected property names. It still verifies that an exception is thrown for a null field name on TestEntity and that the message references the entity/property, but no longer fails due to environment-dependent wording.