### PR TITLE
docs: Update readme to point to the latest versions of spring

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,10 +14,10 @@ Google Cloud Reference Documentation:
 // {x-version-update-start:spring-cloud-gcp:released}
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.4.1/reference/html/index.html[Spring Framework on Google Cloud 7.3.0 (Latest)]
 // {x-version-update-end}
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.4.0/reference/html/index.html[Spring Framework on Google Cloud 6.4.0]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/5.13.5/reference/html/index.html[Spring Framework on Google Cloud 5.13.5]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.5.1/reference/html/index.html[Spring Framework on Google Cloud 6.5.1]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/5.13.7/reference/html/index.html[Spring Framework on Google Cloud 5.13.7]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/4.11.3/reference/html/index.html[Spring Framework on Google Cloud 4.11.3]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.9.11/reference/html/index.html[Spring Framework on Google Cloud 3.9.11]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.9.13/reference/html/index.html[Spring Framework on Google Cloud 3.9.13]
 
 Javadocs: https://googleapis.dev/java/spring-cloud-gcp/latest/index.html
 

--- a/docs/update_latest_versions_in_readme.sh
+++ b/docs/update_latest_versions_in_readme.sh
@@ -15,10 +15,10 @@ latest_v4=$(echo "$versions" | grep '^4\.' | tail -n 1)
 latest_v3=$(echo "$versions" | grep '^3\.' | tail -n 1)
 
 # Update the README.adoc file
-sed -i "/Spring Framework on Google Cloud 6\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v6}/g" README.adoc
-sed -i "/Spring Framework on Google Cloud 5\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v5}/g" README.adoc
-sed -i "/Spring Framework on Google Cloud 4\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v4}/g" README.adoc
-sed -i "/Spring Framework on Google Cloud 3\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v3}/g" README.adoc
+sed -i.bak "/Spring Framework on Google Cloud 6\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v6}/g" README.adoc
+sed -i.bak "/Spring Framework on Google Cloud 5\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v5}/g" README.adoc
+sed -i.bak "/Spring Framework on Google Cloud 4\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v4}/g" README.adoc
+sed -i.bak "/Spring Framework on Google Cloud 3\./s/[0-9]*\.[0-9]*\.[0-9]*/${latest_v3}/g" README.adoc
 
 echo "README.adoc updated with the latest versions:"
 echo "version-6: $latest_v6"


### PR DESCRIPTION
`sed -i.bak` is to resolve the issue of sed running on mac vs linux. Local error on my mac: `sed: 1: "README.adoc": invalid command code R`