### PR TITLE
fix(#4235): Make SpannerSchemaUtilsTests deterministic by implementing SQL column sorting in SpannerSchemaUtils

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtils.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtils.java
@@ -27,6 +27,7 @@ import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentEntity;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentProperty;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.OptionalLong;
@@ -238,15 +239,24 @@ public class SpannerSchemaUtils {
 
   private <T> void addColumnDdlStrings(
       SpannerPersistentEntity<T> spannerPersistentEntity, StringJoiner stringJoiner) {
+    ArrayList<String> allColumnStrings = new ArrayList<>();
+    collectColumnDdlStrings(spannerPersistentEntity, allColumnStrings);
+    Collections.sort(allColumnStrings);
+    for (String columnString : allColumnStrings) {
+      stringJoiner.add(columnString);
+    }
+  }
+
+  private <T> void collectColumnDdlStrings(
+      SpannerPersistentEntity<T> spannerPersistentEntity, List<String> collector) {
     spannerPersistentEntity.doWithColumnBackedProperties(
         spannerPersistentProperty -> {
           if (spannerPersistentProperty.isEmbedded()) {
-            addColumnDdlStrings(
+            collectColumnDdlStrings(
                 this.mappingContext.getPersistentEntityOrFail(spannerPersistentProperty.getType()),
-                stringJoiner);
+                collector);
           } else {
-            stringJoiner.add(
-                getColumnDdlString(spannerPersistentProperty, this.spannerEntityProcessor));
+            collector.add(getColumnDdlString(spannerPersistentProperty, this.spannerEntityProcessor));
           }
         });
   }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
@@ -68,14 +68,14 @@ class SpannerSchemaUtilsTests {
   @Test
   void getCreateDdlTest() {
     String ddlResult =
-        "CREATE TABLE custom_test_table ( id STRING(MAX) , id3 INT64 , id_2 STRING(MAX) , "
-            + "bytes2 BYTES(MAX) , custom_col FLOAT64 NOT NULL , other STRING(333) , "
-            + "primitiveDoubleField FLOAT64 , bigDoubleField FLOAT64 , primitiveFloatField FLOAT32 , "
-            + "bigFloatField FLOAT32 , bigLongField INT64 , primitiveIntField INT64 , "
-            + "bigIntField INT64 , bytes BYTES(MAX) , bytesList ARRAY<BYTES(111)> , "
-            + "integerList ARRAY<INT64> , doubles ARRAY<FLOAT64> , floats ARRAY<FLOAT32> , "
-            + "commitTimestamp TIMESTAMP OPTIONS (allow_commit_timestamp=true) , "
-            + "bigDecimalField NUMERIC , bigDecimals ARRAY<NUMERIC> , jsonCol JSON ) "
+        "CREATE TABLE custom_test_table ( bigDecimalField NUMERIC , bigDecimals ARRAY<NUMERIC> , "
+            + "bigDoubleField FLOAT64 , bigFloatField FLOAT32 , bigIntField INT64 , "
+            + "bigLongField INT64 , bytes BYTES(MAX) , bytes2 BYTES(MAX) , "
+            + "bytesList ARRAY<BYTES(111)> , commitTimestamp TIMESTAMP OPTIONS (allow_commit_timestamp=true) , "
+            + "custom_col FLOAT64 NOT NULL , doubles ARRAY<FLOAT64> , floats ARRAY<FLOAT32> , "
+            + "id STRING(MAX) , id3 INT64 , id_2 STRING(MAX) , "
+            + "integerList ARRAY<INT64> , jsonCol JSON , other STRING(333) , "
+            + "primitiveDoubleField FLOAT64 , primitiveFloatField FLOAT32 , primitiveIntField INT64 ) "
             + "PRIMARY KEY ( id , id_2 , id3 )";
 
     assertThat(this.spannerSchemaUtils.getCreateTableDdlString(TestEntity.class))
@@ -223,15 +223,15 @@ class SpannerSchemaUtilsTests {
         this.spannerSchemaUtils.getCreateTableDdlStringsForInterleavedHierarchy(ParentEntity.class);
     assertThat(createStrings)
         .containsExactly(
-            "CREATE TABLE parent_test_table ( id STRING(MAX) "
-                + ", id_2 STRING(MAX) , bytes2 BYTES(MAX) , "
-                + "custom_col STRING(MAX) , other STRING(MAX) ) PRIMARY KEY ( id , id_2 )",
-            "CREATE TABLE child_test_table ( id STRING(MAX) "
-                + ", id_2 STRING(MAX) , bytes2 BYTES(MAX) , "
-                + "id3 STRING(MAX) ) PRIMARY KEY ( id , id_2 , id3 ), INTERLEAVE IN PARENT "
+            "CREATE TABLE parent_test_table ( bytes2 BYTES(MAX) "
+                + ", custom_col STRING(MAX) , id STRING(MAX) , "
+                + "id_2 STRING(MAX) , other STRING(MAX) ) PRIMARY KEY ( id , id_2 )",
+            "CREATE TABLE child_test_table ( bytes2 BYTES(MAX) "
+                + ", id STRING(MAX) , id3 STRING(MAX) , "
+                + "id_2 STRING(MAX) ) PRIMARY KEY ( id , id_2 , id3 ), INTERLEAVE IN PARENT "
                 + "parent_test_table ON DELETE CASCADE",
-            "CREATE TABLE grand_child_test_table ( id STRING(MAX) , id_2 STRING(MAX) , "
-                + "id3 STRING(MAX) , id4 STRING(MAX) ) PRIMARY KEY ( id , id_2 , id3 , id4 ), "
+            "CREATE TABLE grand_child_test_table ( id STRING(MAX) , id3 STRING(MAX) , "
+                + "id4 STRING(MAX) , id_2 STRING(MAX) ) PRIMARY KEY ( id , id_2 , id3 , id4 ), "
                 + "INTERLEAVE IN PARENT child_test_table ON DELETE CASCADE");
   }
 


### PR DESCRIPTION
Hello, I implement a fix here for issue #4235 . The details of the issue can be found in that description, but to summarize briefly, the unit tests in `SpannerSchemaUtilsTests` that verify SQL statements may fail occasionally since the generated SQL strings may have different column orderings on different runs due to how they are obtained. Though the tests may be stable now, it's not guaranteed to remain this way if the underlying environment changes for whatever reason, so it might be beneficial to address this. 

**Fix:**

The fix I implemented is the one I propose in the issue as well, which sorts the columns in the `addColumnDdlStrings()` method of `SpannerSchemaUtils`. I created a new method `collectColumnDdlStrings()` as a helper that preserves the original recursive column collection logic. Lastly, I changed the column ordering of the expected SQL strings in the 2 unit tests that are affected by this to alphabetical order. 

I ran all tests using `./mvnw clean test` and observed a passing result. I'm assuming that column name ordering in the SQL statements is not important; apologies if I've misunderstood or missed something. If it is necessary to preserve a certain order (ie the ones present currently in expected strings of the unit tests), or if there is a better way to address this issue, please let me know. Thank you!