### PR TITLE
docs: update README documentation links to 7.4.2 #2697

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ For a deep dive into the project, refer to the Spring Framework on Google Cloud 
 Google Cloud Reference Documentation:
 
 // {x-version-update-start:spring-cloud-gcp:released}
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.4.2/reference/html/index.html[Spring Framework on Google Cloud 7.3.0 (Latest)]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.4.2/reference/html/index.html[Spring Framework on Google Cloud 7.4.2 (Latest)]
 // {x-version-update-end}
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.5.2/reference/html/index.html[Spring Framework on Google Cloud 6.5.2]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/5.13.8/reference/html/index.html[Spring Framework on Google Cloud 5.13.8]
@@ -130,7 +130,7 @@ This will allow you to not specify versions for any of the Maven dependencies an
 </dependencyManagement>
 ----
 
-// {x-version-update-end} 
+// {x-version-update-end}
 
 == Snapshots Repository
 


### PR DESCRIPTION
updated the documentation links and the BOM version in the README.adoc file to point to the latest stable version (7.4.2)