### PR TITLE
feat: sanitize secrets loaded from Secret Manager #4122

### DIFF
--- a/spring-cloud-gcp-secretmanager/pom.xml
+++ b/spring-cloud-gcp-secretmanager/pom.xml
@@ -20,12 +20,15 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-context</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>spring-cloud-gcp-core</artifactId>
     </dependency>
-
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-secretmanager</artifactId>

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerSanitizingFunction.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerSanitizingFunction.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.secretmanager;
+
+import org.springframework.boot.actuate.endpoint.SanitizableData;
+import org.springframework.boot.actuate.endpoint.SanitizingFunction;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * Sanitize data with secrets from GCP Secret Manager.
+ *
+ * @since 5.10.0
+ */
+public class SecretManagerSanitizingFunction implements SanitizingFunction {
+
+    @Override
+    public SanitizableData apply(SanitizableData data) {
+        PropertySource<?> propertySource = data.getPropertySource();
+
+        if (propertySource == null || data.getValue() == null) {
+            return data;
+        }
+
+        // On récupère la valeur "non-résolue" (ex: ${sm://mon-secret})
+        Object unresolvedValue = propertySource.getProperty(data.getKey());
+
+        if (unresolvedValue instanceof String stringValue) {
+            for (String secretManagerPrefix : SecretManagerSyntaxUtils.PREFIXES) {
+                if (stringValue.contains("${" + secretManagerPrefix)) {
+                    // Si la valeur contient un préfixe Secret Manager, on retourne l'expression
+                    // au lieu du secret réel pour le masquer.
+                    return data.withValue(stringValue);
+                }
+            }
+        }
+
+        return data;
+    }
+}

--- a/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/SecretManagerSanitizingFunctionTests.java
+++ b/spring-cloud-gcp-secretmanager/src/test/java/com/google/cloud/spring/secretmanager/SecretManagerSanitizingFunctionTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.secretmanager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.endpoint.SanitizableData;
+import org.springframework.core.env.PropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link SecretManagerSanitizingFunction}.
+ */
+class SecretManagerSanitizingFunctionTests {
+
+    private final SecretManagerSanitizingFunction sanitizingFunction = new SecretManagerSanitizingFunction();
+
+    @Test
+    void testApply_sanitizesSecretManagerProperty() {
+        String key = "my.secret";
+        String unresolvedValue = "${sm://my-password}";
+        String resolvedValue = "super-secret-123";
+
+        PropertySource<?> mockSource = mock(PropertySource.class);
+        when(mockSource.getProperty(key)).thenReturn(unresolvedValue);
+
+        SanitizableData data = new SanitizableData(mockSource, key, resolvedValue);
+        SanitizableData result = sanitizingFunction.apply(data);
+
+        // Vérifie que la valeur affichée est l'expression ${sm://...} et non le secret réel
+        assertThat(result.getValue()).isEqualTo(unresolvedValue);
+    }
+
+    @Test
+    void testApply_doesNotSanitizeRegularProperty() {
+        String key = "normal.prop";
+        String value = "normal-value";
+
+        PropertySource<?> mockSource = mock(PropertySource.class);
+        when(mockSource.getProperty(key)).thenReturn(value);
+
+        SanitizableData data = new SanitizableData(mockSource, key, value);
+        SanitizableData result = sanitizingFunction.apply(data);
+
+        // Vérifie qu'on ne touche pas aux propriétés classiques
+        assertThat(result.getValue()).isEqualTo(value);
+    }
+}

--- a/spring-cloud-gcp-security-iap/.idea/compiler.xml
+++ b/spring-cloud-gcp-security-iap/.idea/compiler.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel>
+      <module name="spring-cloud-gcp-security-iap" target="17" />
+    </bytecodeTargetLevel>
+  </component>
+</project>

--- a/spring-cloud-gcp-security-iap/.idea/misc.xml
+++ b/spring-cloud-gcp-security-iap/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+</project>

--- a/spring-cloud-gcp-security-iap/.idea/workspace.xml
+++ b/spring-cloud-gcp-security-iap/.idea/workspace.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="a9542beb-00c8-4d16-bd6e-a61df7d6a6f7" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$/.." />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 5
+}</component>
+  <component name="ProjectId" id="37lXRb2PeCKMaxkEs7Ni4L7x2Z6" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;cleanup/unused-imports&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;run.code.analysis.last.selected.profile&quot;: &quot;pProject Default&quot;
+  }
+}</component>
+  <component name="RunManager">
+    <configuration default="true" type="JetRunConfigurationType">
+      <module name="spring-cloud-gcp-security-iap" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration default="true" type="KotlinStandaloneScriptRunConfigurationType">
+      <module name="spring-cloud-gcp-security-iap" />
+      <option name="filePath" />
+      <method v="2" />
+    </configuration>
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-jdk-30f59d01ecdd-26cb7f24e5b0-intellij.indexing.shared.core-IU-253.29346.138" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="a9542beb-00c8-4d16-bd6e-a61df7d6a6f7" name="Changes" comment="" />
+      <created>1767478625908</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1767478625908</updated>
+    </task>
+    <servers />
+  </component>
+</project>


### PR DESCRIPTION
### Description
This PR addresses issue #4122 by adding a `SanitizingFunction` for GCP Secret Manager. It prevents secrets (using the `sm://` syntax) from being exposed in plain text via Spring Boot Actuator endpoints like `/actuator/env`.

### Changes
- Created `SecretManagerSanitizingFunction` to detect and mask Secret Manager properties.
- Updated `GcpSecretManagerAutoConfiguration` to register the sanitizer bean when Actuator is present.
- Added `spring-boot-starter-actuator` as an optional dependency in `pom.xml`.
- Added unit tests in `SecretManagerSanitizingFunctionTests` to verify both sanitization and non-interference with regular properties.

### Impact
This improves security for all users of the Secret Manager starter by ensuring sensitive credentials aren't accidentally leaked through management endpoints.