### PR TITLE
fix: #534 added support for @CreatedDate in Datastore

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/DatastoreAuditingEventListener.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/support/DatastoreAuditingEventListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,11 @@
 
 package com.google.cloud.spring.data.datastore.repository.support;
 
+import com.google.cloud.spring.data.datastore.core.mapping.DatastoreMappingContext;
 import com.google.cloud.spring.data.datastore.core.mapping.event.BeforeSaveEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.data.auditing.AuditingHandler;
+import org.springframework.data.mapping.PersistentEntity;
 
 /**
  * Auditing event listener that listens for {@code BeforeSaveEvent}.
@@ -29,17 +31,35 @@ public class DatastoreAuditingEventListener implements ApplicationListener<Befor
 
   private final AuditingHandler handler;
 
+  private final DatastoreMappingContext mappingContext;
+
   /**
    * Constructor.
    *
    * @param datastoreAuditingHandler the auditing handler to set auditing properties.
+   * @param mappingContext the mapping context to check entity states.
    */
-  public DatastoreAuditingEventListener(AuditingHandler datastoreAuditingHandler) {
+  public DatastoreAuditingEventListener(
+      AuditingHandler datastoreAuditingHandler, DatastoreMappingContext mappingContext) {
     this.handler = datastoreAuditingHandler;
+    this.mappingContext = mappingContext;
   }
 
   @Override
   public void onApplicationEvent(BeforeSaveEvent event) {
-    event.getTargetEntities().forEach(this.handler::markModified);
+    Iterable<?> entities = event.getTargetEntities();
+
+    if (entities != null) {
+      entities.forEach(entity -> {
+        PersistentEntity<?, ?> persistentEntity =
+            this.mappingContext.getPersistentEntity(entity.getClass());
+
+        if (persistentEntity != null && persistentEntity.isNew(entity)) {
+          this.handler.markCreated(entity);
+        } else {
+          this.handler.markModified(entity);
+        }
+      });
+    }
   }
 }


### PR DESCRIPTION
This PR resolves issue #534 where @CreatedDate was not being correctly populated in Datastore entities.

The root cause was that the DatastoreAuditingEventListener was only calling markModified on the auditing handler, which indiscriminately updates modification dates but often misses the initial creation signal for new entities.

Changes
Modified DatastoreAuditingEventListener to include DatastoreMappingContext via constructor injection.

Updated onApplicationEvent logic to use persistentEntity.isNew(entity) to distinguish between "insert" and "update" operations.

The listener now calls handler.markCreated(entity) for new entities (filling both @CreatedDate and @LastModifiedDate) and handler.markModified(entity) for existing ones.

Fixed Java Generics warnings by using Iterable<?> for entity iteration.

Impact
Users can now use the standard Spring Data @CreatedDate annotation on their Datastore entity fields to automatically track when a record was first persisted.

Validation performed
Compiled the module successfully using mvn clean compile -pl spring-cloud-gcp-data-datastore.

Verified that the logic correctly identifies new entities using the provided MappingContext.