### PR TITLE
fix: resolve nondeterministic Spanner tests by improving SQL assertions

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
@@ -67,19 +67,34 @@ class SpannerSchemaUtilsTests {
 
   @Test
   void getCreateDdlTest() {
-    String ddlResult =
-        "CREATE TABLE custom_test_table ( id STRING(MAX) , id3 INT64 , id_2 STRING(MAX) , "
-            + "bytes2 BYTES(MAX) , custom_col FLOAT64 NOT NULL , other STRING(333) , "
-            + "primitiveDoubleField FLOAT64 , bigDoubleField FLOAT64 , primitiveFloatField FLOAT32 , "
-            + "bigFloatField FLOAT32 , bigLongField INT64 , primitiveIntField INT64 , "
-            + "bigIntField INT64 , bytes BYTES(MAX) , bytesList ARRAY<BYTES(111)> , "
-            + "integerList ARRAY<INT64> , doubles ARRAY<FLOAT64> , floats ARRAY<FLOAT32> , "
-            + "commitTimestamp TIMESTAMP OPTIONS (allow_commit_timestamp=true) , "
-            + "bigDecimalField NUMERIC , bigDecimals ARRAY<NUMERIC> , jsonCol JSON ) "
-            + "PRIMARY KEY ( id , id_2 , id3 )";
+    String ddl = this.spannerSchemaUtils.getCreateTableDdlString(TestEntity.class);
 
-    assertThat(this.spannerSchemaUtils.getCreateTableDdlString(TestEntity.class))
-        .isEqualTo(ddlResult);
+    assertThat(ddl).startsWith("CREATE TABLE custom_test_table (");
+    assertThat(ddl).contains(") PRIMARY KEY ( id , id_2 , id3 )");
+
+    // All columns from TestEntity
+    assertThat(ddl).contains("id STRING(MAX)");
+    assertThat(ddl).contains("id3 INT64");
+    assertThat(ddl).contains("id_2 STRING(MAX)");
+    assertThat(ddl).contains("bytes2 BYTES(MAX)");
+    assertThat(ddl).contains("custom_col FLOAT64 NOT NULL");
+    assertThat(ddl).contains("other STRING(333)");
+    assertThat(ddl).contains("primitiveDoubleField FLOAT64");
+    assertThat(ddl).contains("bigDoubleField FLOAT64");
+    assertThat(ddl).contains("primitiveFloatField FLOAT32");
+    assertThat(ddl).contains("bigFloatField FLOAT32");
+    assertThat(ddl).contains("bigLongField INT64");
+    assertThat(ddl).contains("primitiveIntField INT64");
+    assertThat(ddl).contains("bigIntField INT64");
+    assertThat(ddl).contains("bytes BYTES(MAX)");
+    assertThat(ddl).contains("bytesList ARRAY<BYTES(111)>");
+    assertThat(ddl).contains("integerList ARRAY<INT64>");
+    assertThat(ddl).contains("doubles ARRAY<FLOAT64>");
+    assertThat(ddl).contains("floats ARRAY<FLOAT32>");
+    assertThat(ddl).contains("commitTimestamp TIMESTAMP OPTIONS (allow_commit_timestamp=true)");
+    assertThat(ddl).contains("bigDecimalField NUMERIC");
+    assertThat(ddl).contains("bigDecimals ARRAY<NUMERIC>");
+    assertThat(ddl).contains("jsonCol JSON");
   }
 
   @Test


### PR DESCRIPTION
This PR fixes the flaky behavior in SpannerSchemaUtilsTests.java. The getCreateDdlTest was failing intermittently because it relied on a strict string comparison of the generated SQL CREATE TABLE statement.

The Problem: Java's reflection API does not guarantee the order in which fields are retrieved from a class. Consequently, the columns in the generated DDL string would occasionally swap positions, causing the test to fail despite the SQL being functionally correct.

The Solution: I replaced the strict isEqualTo(String) assertion with a set of robust assertions using AssertJ:

Verified the CREATE TABLE header and table name using startsWith.

Verified the PRIMARY KEY clause using contains.

Verified the presence of every individual column and its specific type/options using individual contains assertions.

Why this approach?

CI Stability: It eliminates "false negative" build failures caused by environment-specific field ordering.

Accuracy: It focuses on the technical contract (schema completeness) rather than cosmetic details (column order), which Spanner does not require to be in a specific sequence for table creation.

Low Impact: It avoids adding unnecessary sorting logic to the production code (SpannerSchemaUtils.java), keeping the framework's core logic lean.
See
also [CONTRIBUTING.md](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/main/CONTRIBUTING.md)
.