### PR TITLE
refactor(gcp-datastore): improve code readability

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/aot/DatastoreCoreRuntimeHints.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/aot/DatastoreCoreRuntimeHints.java
@@ -16,11 +16,13 @@
 
 package com.google.cloud.spring.data.datastore.aot;
 
-import java.util.Arrays;
+import java.util.HashMap;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
+
+import static java.util.List.of;
 
 public class DatastoreCoreRuntimeHints implements RuntimeHintsRegistrar {
 
@@ -29,8 +31,7 @@ public class DatastoreCoreRuntimeHints implements RuntimeHintsRegistrar {
     hints
         .reflection()
         .registerTypes(
-            Arrays.asList(
-                TypeReference.of(java.util.HashMap.class)),
+                of(TypeReference.of(HashMap.class)),
             hint ->
                 hint.withMembers(
                     MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/aot/DatastoreQueryRuntimeHints.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/aot/DatastoreQueryRuntimeHints.java
@@ -17,11 +17,13 @@
 package com.google.cloud.spring.data.datastore.aot;
 
 import com.google.cloud.spring.data.datastore.repository.query.DatastorePageable;
-import java.util.Arrays;
+
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
+
+import static java.util.List.of;
 
 public class DatastoreQueryRuntimeHints implements RuntimeHintsRegistrar {
 
@@ -29,9 +31,7 @@ public class DatastoreQueryRuntimeHints implements RuntimeHintsRegistrar {
   public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
     hints
         .reflection()
-        .registerTypes(
-            Arrays.asList(
-                TypeReference.of(DatastorePageable.class)),
+        .registerTypes(of(TypeReference.of(DatastorePageable.class)),
             hint ->
                 hint.withMembers(
                     MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/aot/DatastoreRepositoryRuntimeHints.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/aot/DatastoreRepositoryRuntimeHints.java
@@ -18,11 +18,15 @@ package com.google.cloud.spring.data.datastore.aot;
 
 import com.google.cloud.spring.data.datastore.repository.query.DatastorePageable;
 import com.google.cloud.spring.data.datastore.repository.support.SimpleDatastoreRepository;
-import java.util.Arrays;
+
+import java.util.List;
+
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
+
+import static org.springframework.aot.hint.TypeReference.of;
 
 public class DatastoreRepositoryRuntimeHints implements RuntimeHintsRegistrar {
 
@@ -31,9 +35,7 @@ public class DatastoreRepositoryRuntimeHints implements RuntimeHintsRegistrar {
     hints
         .reflection()
         .registerTypes(
-            Arrays.asList(
-                TypeReference.of(DatastorePageable.class),
-                TypeReference.of(SimpleDatastoreRepository.class)),
+            List.of(of(DatastorePageable.class), of(SimpleDatastoreRepository.class)),
             hint ->
                 hint.withMembers(
                     MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/DatastoreCustomConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/DatastoreCustomConversions.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.Jsr310Converters;
-import org.springframework.lang.NonNull;
 
 /**
  * Value object to capture custom conversion. {@link DatastoreCustomConversions}
@@ -39,44 +38,35 @@ public class DatastoreCustomConversions extends CustomConversions {
   private static final List<Converter<?, ?>> STORE_CONVERTERS;
 
   static {
-    ArrayList<Converter<?, ?>> converters = new ArrayList<>();
-    converters.addAll(Jsr310Converters.getConvertersToRegister());
-    converters.add(
-        new Converter<BaseKey, Long>() {
-          @Override
-          public Long convert(@NonNull BaseKey baseKey) {
-            Long id = null;
-            // embedded entities have IncompleteKey, and have no inner value
-            if (baseKey instanceof Key key) {
-              id = key.getId();
-              if (id == null) {
-                throw new DatastoreDataException(
-                    "The given key doesn't have a numeric ID but a conversion"
-                        + " to Long was attempted: "
-                        + key);
+      ArrayList<Converter<?, ?>> converters = new ArrayList<>(Jsr310Converters.getConvertersToRegister());
+    converters.add((Converter<BaseKey, Long>) baseKey -> {
+              Long id = null;
+              // embedded entities have IncompleteKey, and have no inner value
+              if (baseKey instanceof Key key) {
+                id = key.getId();
+                if (id == null) {
+                  throw new DatastoreDataException(
+                      "The given key doesn't have a numeric ID but a conversion"
+                          + " to Long was attempted: "
+                          + key);
+                }
               }
-            }
-            return id;
-          }
-        });
-    converters.add(
-        new Converter<BaseKey, String>() {
-          @Override
-          public String convert(@NonNull BaseKey baseKey) {
-            String name = null;
-            // embedded entities have IncompleteKey, and have no inner value
-            if (baseKey instanceof Key key) {
-              name = key.getName();
-              if (name == null) {
-                throw new DatastoreDataException(
-                    "The given key doesn't have a String name value but "
-                        + "a conversion to String was attempted: "
-                        + key);
+              return id;
+            });
+    converters.add((Converter<BaseKey, String>) baseKey -> {
+              String name = null;
+              // embedded entities have IncompleteKey, and have no inner value
+              if (baseKey instanceof Key key) {
+                name = key.getName();
+                if (name == null) {
+                  throw new DatastoreDataException(
+                      "The given key doesn't have a String name value but "
+                          + "a conversion to String was attempted: "
+                          + key);
+                }
               }
-            }
-            return name;
-          }
-        });
+              return name;
+            });
     STORE_CONVERTERS = Collections.unmodifiableList(converters);
 
     STORE_CONVERSIONS = StoreConversions.of(DatastoreNativeTypes.HOLDER, STORE_CONVERTERS);

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverter.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverter.java
@@ -120,10 +120,7 @@ public class DefaultDatastoreEntityConverter implements DatastoreEntityConverter
   @Override
   public <T, R> Map<T, R> readAsMap(
       Class<T> keyType, TypeInformation<R> componentType, BaseEntity entity) {
-    if (entity == null) {
-      return null;
-    }
-    return readAsMap(entity, TypeInformation.of(HashMap.class));
+    return entity != null ? readAsMap(entity, TypeInformation.of(HashMap.class)) : null;
   }
 
   public <T> DatastorePersistentEntity<T> getDiscriminationPersistentEntity(

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/EntityPropertyValueProvider.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/EntityPropertyValueProvider.java
@@ -24,6 +24,8 @@ import org.springframework.core.convert.ConversionException;
 import org.springframework.data.mapping.model.PropertyValueProvider;
 import org.springframework.data.util.TypeInformation;
 
+import static java.util.Optional.of;
+
 /**
  * A {@link PropertyValueProvider} for Datastore entities.
  *
@@ -36,10 +38,7 @@ public class EntityPropertyValueProvider
   private final ReadWriteConversions conversion;
 
   public EntityPropertyValueProvider(BaseEntity entity, ReadWriteConversions readWriteConversions) {
-    if (entity == null) {
-      throw new DatastoreDataException("A non-null entity is required");
-    }
-    this.entity = entity;
+    this.entity = of(entity).orElseThrow(()->new DatastoreDataException("A non-null entity is required"));
     this.conversion = readWriteConversions;
   }
 

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/ReadWriteConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/ReadWriteConversions.java
@@ -70,13 +70,7 @@ public interface ReadWriteConversions {
    */
   Value convertOnWriteSingle(Object obj);
 
-  /**
-   * Get the Cloud Datastore-compatible native Java type that can be used to store the given type.
-   *
-   * @param inputType the given type to test.
-   * @return the Cloud Datastore-compatible native Java type, if it exists.
-   */
-  Optional<Class<?>> getDatastoreCompatibleType(Class inputType);
+  Optional<Class<?>> getDatastoreCompatibleType(Class<?> inputType);
 
   /**
    * Registers {@link DatastoreEntityConverter} to be used for embedded entities.

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/convert/TwoStepsConversions.java
@@ -235,12 +235,7 @@ public class TwoStepsConversions implements ReadWriteConversions {
         && this.internalConversionService.canConvert(sourceType, targetType)) {
       result = this.internalConversionService.convert(val, targetType);
     }
-
-    if (result != null) {
-      return (T) result;
-    } else {
-      throw new DatastoreDataException("Unable to convert " + val.getClass() + " to " + targetType);
-    }
+    return Optional.ofNullable((T)result).orElseThrow(()->new DatastoreDataException("Unable to convert " + val.getClass() + " to " + targetType));
   }
 
   @Override
@@ -395,7 +390,7 @@ public class TwoStepsConversions implements ReadWriteConversions {
   }
 
   @Override
-  public Optional<Class<?>> getDatastoreCompatibleType(Class inputType) {
+  public Optional<Class<?>> getDatastoreCompatibleType(Class<?> inputType) {
     if (DatastoreNativeTypes.DATASTORE_NATIVE_TYPES.contains(inputType)) {
       return Optional.of(inputType);
     }

--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/AbstractDatastoreQuery.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/repository/query/AbstractDatastoreQuery.java
@@ -20,7 +20,7 @@ import com.google.cloud.spring.data.datastore.core.DatastoreOperations;
 import com.google.cloud.spring.data.datastore.core.mapping.DatastoreMappingContext;
 import java.lang.reflect.Array;
 import java.util.List;
-import java.util.stream.Collectors;
+
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.RepositoryQuery;
 
@@ -64,7 +64,7 @@ public abstract class AbstractDatastoreQuery<T> implements RepositoryQuery {
    * @return an array of a compatible type.
    */
   protected Object[] convertCollectionParamToCompatibleArray(List<?> param) {
-    List converted =
+    List<Object> converted =
         param.stream()
             .map(
                 x ->
@@ -72,8 +72,7 @@ public abstract class AbstractDatastoreQuery<T> implements RepositoryQuery {
                         .getDatastoreEntityConverter()
                         .getConversions()
                         .convertOnWriteSingle(x)
-                        .get())
-            .collect(Collectors.toList());
+                        .get()).toList();
     return converted.toArray(
         (Object[])
             Array.newInstance(


### PR DESCRIPTION
1. Replaced `Collectors.toList()` usage with `List.of()` where applicable.
2. Applied static imports to reduce verbosity.
3. Simplified conditional logic using `Optional`.