### PR TITLE
fix: remove main from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,5 @@
 version: 2
 updates:
-# rules for the main branch
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-  commit-message:
-    # Prefix all commit messages with "deps: "
-    prefix: "deps"
-  open-pull-requests-limit: 10
-  labels:
-    - "dependencies"
-  ignore:
-    # Ignore major version updates - these should be made manually
-    - dependency-name: "*"
-      update-types: [ "version-update:semver-major" ]
-    # Ignore formatter dependency versions used in codegen modules, since they are fixed for Java 8 support
-    - dependency-name: "com.coveo:fmt-maven-plugin"
-    - dependency-name: "com.google.googlejavaformat:google-java-format"
-
 # rules for the `3.x` branch
 - package-ecosystem: maven
   directory: "/"


### PR DESCRIPTION
Also allow libraries-bom only for dependabot for non-main branches.

main branch is handled by renovate-bot.
e.g.
* https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/4320
* https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/4296

Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/3808