### PR TITLE
fix: update maven flags for ensuring tests and samples skip formatter and checkstyle plugins for Spring Boot 4.0 / Spring 7 migration

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - 6.x
       - 5.x
+      - 8.0-migration
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
@@ -96,6 +97,7 @@ jobs:
         id: intTest
         env:
           DB_PASSWORD: ${{ secrets.SPRING_CLOUD_GCP_CI_NATIVE_DB_ROOT_PASSWORD }}
+          EXTRA_MAVEN_FLAGS: ${{ (github.ref_name == '8.0-migration' || github.base_ref == '8.0-migration') && '-DskipUnitTests -Dcheckstyle.skip -Dfmt.skip' || '' }}
         run: MODULE_UNDER_TEST="${{ matrix.it }}" ./.github/workflows/scripts/native-image-tests.sh
       - name: Aggregate Report
         run: |

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -7,6 +7,7 @@ on:
       - 6.x
       - 5.x
       - 3.x
+      - 8.0-migration
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
@@ -103,6 +104,7 @@ jobs:
             --define "spring.datasource.password=${DB_PASSWORD}" \
             --define "spring.r2dbc.password=${DB_PASSWORD}" \
             --define it.${{ matrix.it }}=true \
+            ${{ (github.ref_name == '8.0-migration' || github.base_ref == '8.0-migration') && '-DskipUnitTests -Dcheckstyle.skip -Dfmt.skip' || '' }} \
             verify
       - name: Aggregate Report
         run: |

--- a/.github/workflows/scripts/native-image-tests.sh
+++ b/.github/workflows/scripts/native-image-tests.sh
@@ -56,13 +56,15 @@ run_sample_tests () {
       -Pnative -Pnative-sample-config \
       --define skipTests \
       --define org.slf4j.simpleLogger.showDateTime=true \
-      --define org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS
+      --define org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS \
+      ${EXTRA_MAVEN_FLAGS}
     mvn test \
       -Pnative-sample-config -PnativeTest \
       --define notAllModules=true \
       --define maven.javadoc.skip=true \
       --define org.slf4j.simpleLogger.showDateTime=true \
-      --define org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS
+      --define org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS \
+      ${EXTRA_MAVEN_FLAGS}
     popd
     filtered_project_names="$(echo "${filtered_modules[@]}" | sed 's/ /,/g')"
     mvn clean test \
@@ -71,7 +73,8 @@ run_sample_tests () {
       --define maven.javadoc.skip=true \
       -pl="${filtered_project_names}" \
       --define org.slf4j.simpleLogger.showDateTime=true \
-      --define org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS
+      --define org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS \
+      ${EXTRA_MAVEN_FLAGS}
 
   else
     project_names="$(echo "${module_samples[@]}" | sed 's/ /,/g')"
@@ -85,7 +88,8 @@ run_sample_tests () {
       -pl="${project_names}" \
       --define org.slf4j.simpleLogger.showDateTime=true \
       --define org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS \
-      --define spring-boot.run.arguments="--spring.cloud.refresh.enabled=false"
+      --define spring-boot.run.arguments="--spring.cloud.refresh.enabled=false" \
+      ${EXTRA_MAVEN_FLAGS}
   fi
   popd
 }
@@ -103,7 +107,8 @@ run_module_tests() {
     -Pspring-native,!default \
     -pl="${project_names}" \
     --define org.slf4j.simpleLogger.showDateTime=true \
-    --define org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS
+    --define org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS \
+    ${EXTRA_MAVEN_FLAGS}
 }
 
 


### PR DESCRIPTION
This PR focuses on ensuring tests and samples skip formatter and checkstyle plugins.

  CI Pipeline Enhancements
   * Migration Branching: Enabled the 8.0-migration branch for both integrationTests and NativeTests workflows.
   * Build Optimization: Introduced EXTRA_MAVEN_FLAGS to automatically skip unit tests, checkstyle, and formatting when running integration/native tests on the migration branch, significantly reducing CI runtime.