### PR TITLE
feat: Secret Manager SanitizingFunction  #4122

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerAutoConfiguration.java
@@ -26,6 +26,7 @@ import com.google.cloud.spring.secretmanager.SecretManagerServiceClientFactory;
 import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
 import java.io.IOException;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.endpoint.SanitizingFunction;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -96,6 +97,13 @@ public class GcpSecretManagerAutoConfiguration {
       return new SecretManagerTemplate(client, this.gcpProjectIdProvider)
           .setAllowDefaultSecretValue(this.properties.isAllowDefaultSecret());
     }
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  @ConditionalOnClass(SanitizingFunction.class)
+  public SecretManagerSanitizingFunction secretManagerSanitizingFunction() {
+    return new SecretManagerSanitizingFunction();
   }
 
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerSanitizingFunction.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerSanitizingFunction.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.secretmanager;
+
+import com.google.cloud.spring.secretmanager.SecretManagerSyntaxUtils;
+import org.springframework.boot.actuate.endpoint.SanitizableData;
+import org.springframework.boot.actuate.endpoint.SanitizingFunction;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * A {@link SanitizingFunction} that prevents GCP Secret Manager secrets from being exposed
+ * in plain text via Spring Boot Actuator endpoints (e.g. {@code /actuator/env}).
+ *
+ * <p>When a property's unresolved value contains a Secret Manager reference such as
+ * {@code ${sm@my-secret}} or {@code ${sm://my-secret}}, this function replaces the resolved
+ * secret value with the unresolved expression, so that the actual secret is never surfaced
+ * regardless of the value of {@code management.endpoint.env.show-values}.
+ *
+ * @since 6.4.0
+ */
+public class SecretManagerSanitizingFunction implements SanitizingFunction {
+
+  @Override
+  public SanitizableData apply(SanitizableData data) {
+    PropertySource<?> propertySource = data.getPropertySource();
+
+    if (propertySource == null || data.getValue() == null) {
+      return data;
+    }
+
+    Object unresolvedValue = propertySource.getProperty(data.getKey());
+
+    if (unresolvedValue instanceof String stringValue) {
+      for (String prefix : SecretManagerSyntaxUtils.PREFIXES) {
+        if (stringValue.contains("${" + prefix)) {
+          // Replace the resolved secret with the unresolved SM expression so the
+          // real secret is never surfaced in actuator output.
+          return data.withValue(stringValue);
+        }
+      }
+    }
+
+    return data;
+  }
+}

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerAutoConfigurationUnitTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/GcpSecretManagerAutoConfigurationUnitTests.java
@@ -23,6 +23,7 @@ import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import com.google.cloud.spring.autoconfigure.TestUtils;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
 import com.google.cloud.spring.autoconfigure.parametermanager.GcpParameterManagerAutoConfiguration;
+import com.google.cloud.spring.autoconfigure.secretmanager.SecretManagerSanitizingFunction;
 import com.google.cloud.spring.parametermanager.ParameterManagerClientFactory;
 import com.google.cloud.spring.secretmanager.SecretManagerServiceClientFactory;
 import com.google.cloud.spring.secretmanager.SecretManagerTemplate;
@@ -97,6 +98,12 @@ class GcpSecretManagerAutoConfigurationUnitTests {
     contextRunner.run(
         ctx -> assertThat(ctx.getBean(SecretManagerTemplate.class))
             .isNotNull());
+  }
+
+  @Test
+  void testSanitizingFunctionBeanRegistered() {
+    contextRunner.run(
+        ctx -> assertThat(ctx).hasSingleBean(SecretManagerSanitizingFunction.class));
   }
 
   static class TestConfig {

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerSanitizingFunctionTest.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerSanitizingFunctionTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.secretmanager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.endpoint.SanitizableData;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * Unit tests for {@link SecretManagerSanitizingFunction}.
+ */
+class SecretManagerSanitizingFunctionTest {
+
+  private final SecretManagerSanitizingFunction sanitizingFunction =
+      new SecretManagerSanitizingFunction();
+
+  @Test
+  void sanitizesSmAtPrefixProperty() {
+    String key = "my.secret";
+    String unresolvedValue = "${sm@my-password}";
+    String resolvedValue = "super-secret-123";
+
+    PropertySource<?> mockSource = mock(PropertySource.class);
+    when(mockSource.getProperty(key)).thenReturn(unresolvedValue);
+
+    SanitizableData data = new SanitizableData(mockSource, key, resolvedValue);
+    SanitizableData result = sanitizingFunction.apply(data);
+
+    assertThat(result.getValue()).isEqualTo(unresolvedValue);
+  }
+
+  @Test
+  void sanitizesSmSlashPrefixProperty() {
+    String key = "my.secret";
+    String unresolvedValue = "${sm://my-password}";
+    String resolvedValue = "super-secret-123";
+
+    PropertySource<?> mockSource = mock(PropertySource.class);
+    when(mockSource.getProperty(key)).thenReturn(unresolvedValue);
+
+    SanitizableData data = new SanitizableData(mockSource, key, resolvedValue);
+    SanitizableData result = sanitizingFunction.apply(data);
+
+    assertThat(result.getValue()).isEqualTo(unresolvedValue);
+  }
+
+  @Test
+  void sanitizesCompositeValueContainingSmReference() {
+    String key = "my.database.url";
+    String unresolvedValue = "https://user:${sm@my-pass}@host/db";
+    String resolvedValue = "https://user:secret123@host/db";
+
+    PropertySource<?> mockSource = mock(PropertySource.class);
+    when(mockSource.getProperty(key)).thenReturn(unresolvedValue);
+
+    SanitizableData data = new SanitizableData(mockSource, key, resolvedValue);
+    SanitizableData result = sanitizingFunction.apply(data);
+
+    // The resolved URL (with embedded secret) should be replaced by the unresolved expression.
+    assertThat(result.getValue()).isEqualTo(unresolvedValue);
+  }
+
+  @Test
+  void doesNotSanitizeRegularProperty() {
+    String key = "normal.prop";
+    String value = "normal-value";
+
+    PropertySource<?> mockSource = mock(PropertySource.class);
+    when(mockSource.getProperty(key)).thenReturn(value);
+
+    SanitizableData data = new SanitizableData(mockSource, key, value);
+    SanitizableData result = sanitizingFunction.apply(data);
+
+    assertThat(result.getValue()).isEqualTo(value);
+  }
+
+  @Test
+  void returnsDataUnchangedWhenPropertySourceIsNull() {
+    SanitizableData data = new SanitizableData(null, "my.key", "some-value");
+    SanitizableData result = sanitizingFunction.apply(data);
+
+    assertThat(result.getValue()).isEqualTo("some-value");
+  }
+
+  @Test
+  void returnsDataUnchangedWhenValueIsNull() {
+    PropertySource<?> mockSource = mock(PropertySource.class);
+    when(mockSource.getProperty("my.key")).thenReturn("${sm@some-secret}");
+
+    SanitizableData data = new SanitizableData(mockSource, "my.key", null);
+    SanitizableData result = sanitizingFunction.apply(data);
+
+    assertThat(result.getValue()).isNull();
+  }
+
+  @Test
+  void returnsDataUnchangedWhenUnresolvedValueIsNull() {
+    PropertySource<?> mockSource = mock(PropertySource.class);
+    when(mockSource.getProperty("my.key")).thenReturn(null);
+
+    SanitizableData data = new SanitizableData(mockSource, "my.key", "resolved-value");
+    SanitizableData result = sanitizingFunction.apply(data);
+
+    // No SM prefix detected — pass through unchanged.
+    assertThat(result.getValue()).isEqualTo("resolved-value");
+  }
+}


### PR DESCRIPTION
Description

This PR is a fix for https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/4122: secrets loaded from GCP Secret Manager were exposed in plain text via /actuator/env when management.endpoint.env.show-values was set to always or when-authorized.

Changes

- Implements SanitizingFunction. When a property's unresolved value (from the PropertySource) contains a ${sm@...} or ${sm://...} reference, the resolved secret is replaced with the unresolved expression so the real secret is never surfaced.
- Added a new @bean to auto-register the sanitizing function, guarded by @ConditionalOnClass(SanitizingFunction.class) so it only activates when spring-boot-actuator is on the classpath
- Added testSanitizingFunctionBeanRegistered to verify the bean is present in the application context.