### PR TITLE
chore: add 7.x branch to CI and release configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,21 @@ updates:
     # Prefix all commit messages with "deps: "
     prefix: "deps"
   open-pull-requests-limit: 30
+  target-branch: "7.x"
+  labels:
+    - "7.x dependencies"
+  allow:
+    # ONLY allow the libraries-bom update
+    - dependency-name: "com.google.cloud:libraries-bom"
+
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+  commit-message:
+    # Prefix all commit messages with "deps: "
+    prefix: "deps"
+  open-pull-requests-limit: 30
   target-branch: "6.x"
   labels:
     - "6.x dependencies"

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -16,5 +16,9 @@ branches:
     extraFiles: ["README.adoc"]
   - releaseType: java-yoshi
     handleGHRelease: true
+    branch: 7.x
+    extraFiles: ["README.adoc"]
+  - releaseType: java-yoshi
+    handleGHRelease: true
     branch: 6.x
     extraFiles: ["README.adoc"]

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -41,6 +41,42 @@ branchProtectionRules:
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false
+  - pattern: 7.x
+    isAdminEnforced: true
+    requiredStatusCheckContexts:
+      - 'cla/google'
+      - 'unitTests (17)'
+      - 'unitTests (19)'
+      - 'unitTests (21)'
+      - 'releaseCheck'
+      - 'conventionalcommits.org'
+      - 'Build with Sonar'
+      - 'parallel-NativeTests (alloydb-sample)'
+      - 'parallel-NativeTests (bigquery-sample)'
+      - 'parallel-NativeTests (bigquery)'
+      - 'parallel-NativeTests (core)'
+      - 'parallel-NativeTests (data-firestore)'
+      - 'parallel-NativeTests (data-firestore-sample)'
+      - 'parallel-NativeTests (datastore)'
+      - 'parallel-NativeTests (datastore-basic-sample)'
+      - 'parallel-NativeTests (kms)'
+      - 'parallel-NativeTests (kms-sample)'
+      - 'parallel-NativeTests (logging-sample)'
+      - 'parallel-NativeTests (metrics-sample)'
+      - 'parallel-NativeTests (pubsub-sample)'
+      - 'parallel-NativeTests (pubsub-bus-sample)'
+      - 'parallel-NativeTests (pubsub-integration-sample)'
+      - 'parallel-NativeTests (secretmanager)'
+      - 'parallel-NativeTests (secretmanager-sample)'
+      - 'parallel-NativeTests (spanner)'
+      - 'parallel-NativeTests (sql-mysql-sample)'
+      - 'parallel-NativeTests (sql-postgres-sample)'
+      - 'parallel-NativeTests (starter-firestore-sample)'
+      - 'parallel-NativeTests (storage)'
+      - 'parallel-NativeTests (storage-sample)'
+      - 'parallel-NativeTests (trace-sample)'
+      - 'parallel-NativeTests (vision)'
+      - 'parallel-NativeTests (vision-sample)'
   - pattern: 6.x
     isAdminEnforced: true
     requiredStatusCheckContexts:

--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 7.x
       - 6.x
       - 5.x
   pull_request:

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 7.x
       - 6.x
       - 5.x
       - 3.x

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Run Renovate
         uses: renovatebot/forking-renovate@main
         with:
-          baseBranches: main,6.x,5.x,3.x
+          baseBranches: main,7.x,6.x,5.x,3.x
           createPullRequests: true

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 7.x
       - 6.x
       - 5.x
       - 4.x

--- a/util/release.go
+++ b/util/release.go
@@ -38,7 +38,7 @@
 //
 // The flags are:
 //     -branches string
-//         Comma-separated list of branches to release (default "main,3.x,5.x,6.x")
+//         Comma-separated list of branches to release (default "main,7.x,6.x,5.x,3.x")
 //     -email string
 //         Email address to send success/failure notifications to. This utilizes
 //         the internal `sendgmr` tool and requires active LOAS/gcert credentials.
@@ -76,7 +76,7 @@ var interactiveOpt bool
 // main is the entry point of the script. It parses flags, sets up the parallel release process
 // for the specified branches, and handles the sequential README update for the main branch.
 func main() {
-	branchesOpt := flag.String("branches", "main,3.x,5.x,6.x", "Comma-separated list of branches to release")
+	branchesOpt := flag.String("branches", "main,7.x,6.x,5.x,3.x", "Comma-separated list of branches to release")
 	flag.StringVar(&emailOpt, "email", "", "Email address to send notifications to (requires LOAS/gcert)")
 	flag.StringVar(&bootMaxOpt, "boot-max", "", "Newly supported Spring Boot max version for compatibilityRange (e.g. 4.1.0-M1)")
 	flag.BoolVar(&interactiveOpt, "interactive", false, "Ask for confirmation before proceeding to each step")
@@ -223,7 +223,7 @@ func runReleaseForMain() {
 
 }
 
-// runReleaseForBranch contains the standard release pipeline for 3.x, 5.x, 6.x
+// runReleaseForBranch contains the standard release pipeline for 3.x, 5.x, 6.x, 7.x
 func runReleaseForBranch(branch string) {
 	prefix := fmt.Sprintf("[%s]", branch)
 	step := 1


### PR DESCRIPTION
- Update workflow triggers for unit, integration, and native tests to include 7.x
- Enforce branch protection rules for 7.x via sync-repo-settings.yaml
- Enable dependency updates for 7.x in Dependabot and Renovate configs
- Register 7.x in release-please and custom release scripts