### PR TITLE
fix: Iterate over QueryResults to populate cursor in DatastoreTemplate

### DIFF
--- a/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
+++ b/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java
@@ -358,7 +358,10 @@ public class DatastoreTemplate implements DatastoreOperations, ApplicationEventP
     QueryResults results = getDatastoreReadWriter().run(query);
     DatastoreResultsIterable resultsIterable;
     if (results.getResultClass() == Key.class) {
-      resultsIterable = new DatastoreResultsIterable(results, results.getCursorAfter());
+      QueryResults<Key> resultKeys = (QueryResults<Key>) results;
+      List<Key> keys = new ArrayList<>();
+      resultKeys.forEachRemaining(keys::add);
+      resultsIterable = new DatastoreResultsIterable(keys, results.getCursorAfter());
     } else {
       resultsIterable =
           new DatastoreResultsIterable<>(


### PR DESCRIPTION
Fix for issue [4348](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/4348).

Resolution:
Iterate over key results to allow the use cursor in returned DatastoreResultsIterable.

Issue description:
DatastoreTemplate.java methods queryKeysSlice/queryKeysOrEntities do not iterate over results, and because of that, the cursor is not populated.

The results should be iterated in this [reference](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/87153c1150d0a5e2d981b91941177f6dfd010a51/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java#L359C15-L359C15), as it is already mentioned [here](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/87153c1150d0a5e2d981b91941177f6dfd010a51/spring-cloud-gcp-data-datastore/src/main/java/com/google/cloud/spring/data/datastore/core/DatastoreTemplate.java#L387).

Spring Cloud version 7.4.5