### PR TITLE
fix: NullPointerException in spring-cloud-gcp-data-spanner

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructPropertyValueProvider.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructPropertyValueProvider.java
@@ -138,6 +138,9 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
   }
 
   private <T> T convertOrRead(Class<T> targetType, Object sourceValue) {
+    if (sourceValue == null) {
+      return null;
+    }
     Class<?> sourceClass = sourceValue.getClass();
     return (Struct.class.isAssignableFrom(sourceClass)
             && !this.readConverter.canConvert(sourceClass, targetType))

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
@@ -461,4 +461,32 @@ class ConverterAwareMappingSpannerEntityReaderTests {
 
     assertThat(result.paramsList.get(2)).isNull();
   }
+
+  @Test
+  void readArrayWithNullFieldTest() {
+    Struct row = mock(Struct.class);
+    when(row.getString("id")).thenReturn("1234");
+    when(row.getType())
+        .thenReturn(
+            Type.struct(
+                Arrays.asList(
+                    Type.StructField.of("id", Type.string()),
+                    Type.StructField.of("stringList", Type.array(Type.string())))));
+    when(row.getColumnType("id")).thenReturn(Type.string());
+
+    when(row.getColumnType("stringList")).thenReturn(Type.array(Type.string()));
+    when(row.getStringList("stringList"))
+        .thenReturn(
+            Arrays.asList("string1", null, "string3"));
+
+    TestEntities.TestEntityWithStringList result =
+        this.spannerEntityReader.read(TestEntities.TestEntityWithStringList.class, row);
+
+    assertThat(result.id).isEqualTo("1234");
+
+    assertThat(result.stringList).hasSize(3);
+    assertThat(result.stringList.get(0)).isEqualTo("string1");
+    assertThat(result.stringList.get(1)).isNull();
+    assertThat(result.stringList.get(2)).isEqualTo("string3");
+  }
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
@@ -318,4 +318,10 @@ class TestEntities {
       this.instant = instant;
     }
   }
+
+  static class TestEntityWithStringList {
+    @PrimaryKey String id;
+
+    List<String> stringList;
+  }
 }


### PR DESCRIPTION
Fix a NullPointerException that happens when reading data from an array that contains null elements.

Fixes #4381
