### PR TITLE
fix(storage): preserve port in spring.cloud.gcp.storage.host (#4343)

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfiguration.java
@@ -113,6 +113,6 @@ public class GcpStorageAutoConfiguration { // NOSONAR squid:S1610 must be a clas
               + host
               + ". Please verify that the specified host follows the 'https://${service}.${universeDomain}/' format");
     }
-    return url.getProtocol() + "://" + url.getHost() + "/";
+    return url.getProtocol() + "://" + url.getAuthority() + "/";
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfigurationTests.java
@@ -106,6 +106,17 @@ class GcpStorageAutoConfigurationTests {
   }
 
   @Test
+  void testHostWithPort() {
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.storage.host=http://localhost:54321")
+        .run(
+            context -> {
+              Storage storage = context.getBean("storage", Storage.class);
+              assertThat(storage.getOptions().getHost()).isEqualTo("http://localhost:54321/");
+            });
+  }
+
+  @Test
   void testUniverseDomainAndHostSet() {
     this.contextRunner
         .withPropertyValues(


### PR DESCRIPTION
## Description
Fixes #4343

**Problem:** 
When configuring `spring.cloud.gcp.storage.host` with a custom port (such as for a local emulator or `fake-gcs-server` Testcontainers setup), the port number was being silently removed by `GcpStorageAutoConfiguration`. Specifically, `verifyAndFetchHost()` used `URL.getHost()` which only returns the hostname portion. This resulted in `http://localhost:54321` being incorrectly transformed to `http://localhost/`, causing `Connection refused` errors during integration tests.

**Solution:**
Replaced `url.getHost()` with `url.getAuthority()` in `GcpStorageAutoConfiguration.java`. `url.getAuthority()` properly returns `host:port` when a port is present, and behaves identically to `url.getHost()` when no port is configured, guaranteeing no breaking regressions for existing configurations.

## Contribution Checklist
- [x] **Issue Linked:** This PR addresses an existing issue (#4343) that has been labeled with "Accepting Contributions".
- [x] **Clear Description:** The PR description clearly states the problem and the proposed solution.
- [x] **Unit Tests:** Added a new unit test (`testHostWithPort()`) in `GcpStorageAutoConfigurationTests.java` to explicitly test and prevent regressions of hosts configured with ports. 
- [x] **Tests Passed:** Verified that all existing and new unit tests pass successfully (`./mvnw -pl spring-cloud-gcp-autoconfigure test -Dtest=GcpStorageAutoConfigurationTests`).
- [x] **Code Formatting:** Ensured the code conforms to the Google Java Style Guide (verified via the `validate-google-style` checkstyle plugin check running without errors).
- [x] **CLA Signed:** (I have signed the Contributor License Agreement).
