### PR TITLE
fix(spanner): support querying UUID against STRING columns by using untyped binding

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -253,10 +253,29 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
       Class<?> propertyType,
       ValueBinder valueBinder,
       SpannerCustomConverter spannerCustomConverter) {
+    boolean valueSet = false;
+
+    if (propertyType == UUID.class) {
+      if (propertyValue != null) {
+        com.google.protobuf.Value protoValue = com.google.protobuf.Value.newBuilder()
+            .setStringValue(propertyValue.toString())
+            .build();
+        valueBinder.to(Value.untyped(protoValue));
+      } else {
+        com.google.protobuf.Value nullProtoValue = com.google.protobuf.Value.newBuilder()
+            .setNullValue(com.google.protobuf.NullValue.NULL_VALUE)
+            .build();
+        valueBinder.to(Value.untyped(nullProtoValue));
+      }
+      valueSet = true;
+    }
+
     // directly try to set using the property's original Java type
-    boolean valueSet =
-        attemptSetSingleItemValue(
-            propertyValue, propertyType, valueBinder, propertyType, spannerCustomConverter);
+    if (!valueSet) {
+      valueSet =
+          attemptSetSingleItemValue(
+              propertyValue, propertyType, valueBinder, propertyType, spannerCustomConverter);
+    }
 
     // Finally try and find any conversion that works
     if (!valueSet) {

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
@@ -319,7 +319,10 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     verify(bigDecimalsBinder, times(1)).toNumericArray(t.bigDecimals);
     verify(intervalFieldBinder, times(1)).to(t.intervalField);
     verify(intervalListFieldBinder, times(1)).toIntervalArray(t.intervalList);
-    verify(uuidFieldBinder, times(1)).to(t.uuidField);
+    com.google.protobuf.Value expectedProtoValue = com.google.protobuf.Value.newBuilder()
+        .setStringValue(t.uuidField.toString())
+        .build();
+    verify(uuidFieldBinder, times(1)).to(Value.untyped(expectedProtoValue));
     verify(uuidListFieldBinder, times(1)).toUuidArray(t.uuidList);
   }
 
@@ -329,6 +332,7 @@ class ConverterAwareMappingSpannerEntityWriterTests {
 
     t.dateField = null;
     t.doubleList = null;
+    t.uuidField = null;
 
     WriteBuilder writeBuilder = mock(WriteBuilder.class);
 
@@ -340,12 +344,21 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     when(doubleListFieldBinder.toFloat64Array((Iterable<Double>) any())).thenReturn(null);
     when(writeBuilder.set("doubleList")).thenReturn(doubleListFieldBinder);
 
+    ValueBinder<WriteBuilder> uuidFieldBinder = mock(ValueBinder.class);
+    when(uuidFieldBinder.to((Value) any())).thenReturn(null);
+    when(writeBuilder.set("uuidField")).thenReturn(uuidFieldBinder);
+
     this.spannerEntityWriter.write(
         t,
         writeBuilder::set,
-        Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("dateField", "doubleList"))));
+        Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("dateField", "doubleList", "uuidField"))));
     verify(dateFieldBinder, times(1)).to((Date) isNull());
     verify(doubleListFieldBinder, times(1)).toFloat64Array((Iterable<Double>) isNull());
+    
+    com.google.protobuf.Value nullProtoValue = com.google.protobuf.Value.newBuilder()
+        .setNullValue(com.google.protobuf.NullValue.NULL_VALUE)
+        .build();
+    verify(uuidFieldBinder, times(1)).to(Value.untyped(nullProtoValue));
   }
 
   @Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerUuidIntegrationTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/it/SpannerUuidIntegrationTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.data.spanner.repository.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.spring.data.spanner.test.AbstractSpannerIntegrationTest;
+import com.google.cloud.spring.data.spanner.test.domain.UuidStringUser;
+import com.google.cloud.spring.data.spanner.test.domain.UuidStringUserRepository;
+import com.google.cloud.spring.data.spanner.test.domain.UuidUser;
+import com.google.cloud.spring.data.spanner.test.domain.UuidUserRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@EnabledIfSystemProperty(named = "it.spanner", matches = "true")
+@ExtendWith(SpringExtension.class)
+public class SpannerUuidIntegrationTests extends AbstractSpannerIntegrationTest {
+
+  @Autowired UuidUserRepository uuidUserRepository;
+  @Autowired UuidStringUserRepository uuidStringUserRepository;
+
+  @BeforeEach
+  void setUp() {
+    uuidUserRepository.deleteAll();
+    uuidStringUserRepository.deleteAll();
+  }
+
+  @AfterEach
+  void tearDown() {
+    uuidUserRepository.deleteAll();
+    uuidStringUserRepository.deleteAll();
+  }
+
+  @Test
+  void testUuidUntypedBindingWorks() {
+    UUID uuid = UUID.randomUUID();
+    UuidUser user = new UuidUser(uuid, "Test User Untyped");
+
+    uuidUserRepository.save(user);
+
+    // Verify read using generated query method
+    List<UuidUser> foundUsers = uuidUserRepository.findByUserId(uuid);
+    assertThat(foundUsers).hasSize(1).contains(user);
+
+    // Verify read using custom query with parameter binding
+    List<UuidUser> foundUsersCustom = uuidUserRepository.findByUuidCustom(uuid);
+    assertThat(foundUsersCustom).hasSize(1).contains(user);
+  }
+
+  @Test
+  void testUuidNullBindingWorks() {
+    UUID uuid = UUID.randomUUID();
+    UuidUser user = new UuidUser(uuid, "Test User Null Secondary");
+    user.setSecondaryId(null);
+
+    uuidUserRepository.save(user);
+
+    List<UuidUser> foundUsers = uuidUserRepository.findByUserId(uuid);
+    assertThat(foundUsers).hasSize(1).contains(user);
+    assertThat(foundUsers.get(0).getSecondaryId()).isNull();
+  }
+
+  @Test
+  void testUuidUntypedBindingWorksWithString36Column() {
+    UUID uuid = UUID.randomUUID();
+    UuidStringUser user = new UuidStringUser(uuid, "Test User String36");
+
+    uuidStringUserRepository.save(user);
+
+    // Verify read using generated query method
+    List<UuidStringUser> foundUsers = uuidStringUserRepository.findByUserId(uuid);
+    assertThat(foundUsers).hasSize(1).contains(user);
+
+    // Verify read using custom query with parameter binding
+    List<UuidStringUser> foundUsersCustom = uuidStringUserRepository.findByUuidCustom(uuid);
+    assertThat(foundUsersCustom).hasSize(1).contains(user);
+  }
+}

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
@@ -119,7 +119,7 @@ class SpannerStatementQueryTests {
               Statement statement = invocation.getArgument(1);
 
               String expectedQuery =
-                  "SELECT DISTINCT shares, trader_id, ticker, price, action, id, value FROM trades"
+                  "SELECT DISTINCT shares, trader_id, ticker, price, action, id, value, uuid FROM trades"
                       + " WHERE ( LOWER(action)=LOWER(@tag0) AND ticker=@tag1 ) OR ("
                       + " trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND id IS NOT NULL AND"
                       + " trader_id=NULL AND trader_id LIKE @tag7 AND price=TRUE AND price=FALSE"
@@ -235,7 +235,7 @@ class SpannerStatementQueryTests {
 
               String expectedSql =
                   "SELECT EXISTS(SELECT DISTINCT shares, trader_id, ticker, price, action, id,"
-                      + " value FROM trades WHERE ( LOWER(action)=LOWER(@tag0) AND ticker=@tag1 )"
+                      + " value, uuid FROM trades WHERE ( LOWER(action)=LOWER(@tag0) AND ticker=@tag1 )"
                       + " OR ( trader_id=@tag2 AND price<@tag3 ) OR ( price>=@tag4 AND id IS NOT NULL AND"
                       + " trader_id=NULL AND trader_id LIKE @tag7 AND price=TRUE AND price=FALSE"
                       + " AND price>@tag10 AND price<=@tag11 ) ORDER BY id DESC LIMIT 1)";
@@ -271,7 +271,7 @@ class SpannerStatementQueryTests {
     Object[] params = new Object[] {8.88, PageRequest.of(1, 10, Sort.by("traderId"))};
     Method method = QueryHolder.class.getMethod("repositoryMethod5", Double.class, Pageable.class);
     String expectedSql =
-        "SELECT shares, trader_id, ticker, price, action, id, value "
+        "SELECT shares, trader_id, ticker, price, action, id, value, uuid "
             + "FROM trades WHERE ( price<@tag0 ) "
             + "ORDER BY trader_id ASC LIMIT 10 OFFSET 10";
 
@@ -286,11 +286,46 @@ class SpannerStatementQueryTests {
         };
     Method method = QueryHolder.class.getMethod("repositoryMethod6", Double.class, Sort.class);
     String expectedSql =
-        "SELECT shares, trader_id, ticker, price, action, id, value "
+        "SELECT shares, trader_id, ticker, price, action, id, value, uuid "
             + "FROM trades WHERE ( price<@tag0 ) "
             + "ORDER BY trader_id DESC , price ASC , action DESC";
 
     runPageableOrSortTest(params, method, expectedSql);
+  }
+
+  @Test
+  void uuidUntypedBindingTest() throws NoSuchMethodException {
+    when(this.queryMethod.getName()).thenReturn("findByUuid");
+    this.partTreeSpannerQuery = spy(createQuery());
+
+    java.util.UUID uuid = java.util.UUID.randomUUID();
+    Object[] params = new Object[] {uuid};
+    
+    Method method = QueryHolder.class.getMethod("repositoryMethod8", java.util.UUID.class);
+    doReturn(new DefaultParameters(ParametersSource.of(method)))
+        .when(this.queryMethod)
+        .getParameters();
+
+    when(this.spannerTemplate.query((Class) any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              Statement statement = invocation.getArgument(1);
+              Map<String, Value> paramMap = statement.getParameters();
+
+              com.google.protobuf.Value expectedProtoValue = com.google.protobuf.Value.newBuilder()
+                  .setStringValue(uuid.toString())
+                  .build();
+              assertThat(paramMap.get("tag0")).isEqualTo(Value.untyped(expectedProtoValue));
+              assertThat(paramMap).hasSize(1);
+
+              return null;
+            });
+
+    doReturn(Object.class).when(this.partTreeSpannerQuery).getReturnedSimpleConvertableItemType();
+    doReturn(null).when(this.partTreeSpannerQuery).convertToSimpleReturnType(any(), any());
+
+    this.partTreeSpannerQuery.execute(params);
+    verify(this.spannerTemplate, times(1)).query((Class) any(), any(), any());
   }
 
   private void runPageableOrSortTest(Object[] params, Method method, String expectedSql) {
@@ -337,7 +372,7 @@ class SpannerStatementQueryTests {
 
     when(this.queryMethod.getQueryMethod()).thenReturn(method);
     String expectedSql =
-        "SELECT shares, trader_id, ticker, price, action, id, value "
+        "SELECT shares, trader_id, ticker, price, action, id, value, uuid "
             + "FROM trades "
             + "WHERE ( action=@tag0 AND ticker=@tag1 ) "
             + "ORDER BY trader_id ASC LIMIT 10 OFFSET 10";
@@ -474,6 +509,8 @@ class SpannerStatementQueryTests {
     }
 
     BigDecimal value;
+
+    java.util.UUID uuid;
   }
 
   // The methods in this class are used to emulate repository methods
@@ -531,6 +568,10 @@ class SpannerStatementQueryTests {
     }
 
     public long repositoryMethod7(String tag0, Pageable tag1, String tag2) {
+      return 0;
+    }
+
+    public long repositoryMethod8(java.util.UUID tag0) {
       return 0;
     }
   }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/SpannerTestExecutionListener.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/SpannerTestExecutionListener.java
@@ -23,6 +23,8 @@ import com.google.cloud.spring.data.spanner.core.admin.SpannerDatabaseAdminTempl
 import com.google.cloud.spring.data.spanner.core.admin.SpannerSchemaUtils;
 import com.google.cloud.spring.data.spanner.test.domain.CommitTimestamps;
 import com.google.cloud.spring.data.spanner.test.domain.Trade;
+import com.google.cloud.spring.data.spanner.test.domain.UuidStringUser;
+import com.google.cloud.spring.data.spanner.test.domain.UuidUser;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,6 +61,8 @@ public class SpannerTestExecutionListener implements TestExecutionListener {
     List<String> dropSchemaStatements =
         spannerSchemaUtils.getDropTableDdlStringsForInterleavedHierarchy(Trade.class);
     dropSchemaStatements.add(spannerSchemaUtils.getDropTableDdlString(CommitTimestamps.class));
+    dropSchemaStatements.add(spannerSchemaUtils.getDropTableDdlString(UuidUser.class));
+    dropSchemaStatements.add(spannerSchemaUtils.getDropTableDdlString(UuidStringUser.class));
 
     spannerDatabaseAdminTemplate.executeDdlStrings(dropSchemaStatements, false);
   }
@@ -91,6 +95,8 @@ public class SpannerTestExecutionListener implements TestExecutionListener {
         this.spannerSchemaUtils
             .getCreateTableDdlString(CommitTimestamps.class)
             .replaceAll("TIMESTAMP", "TIMESTAMP OPTIONS (allow_commit_timestamp = true)"));
+    list.add(this.spannerSchemaUtils.getCreateTableDdlString(UuidUser.class));
+    list.add(this.spannerSchemaUtils.getCreateTableDdlString(UuidStringUser.class));
     return list;
   }
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/UuidStringUser.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/UuidStringUser.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.data.spanner.test.domain;
+
+import com.google.cloud.spring.data.spanner.core.mapping.Column;
+import com.google.cloud.spring.data.spanner.core.mapping.PrimaryKey;
+import com.google.cloud.spring.data.spanner.core.mapping.Table;
+import java.util.UUID;
+
+@Table(name = "uuid_string_users")
+public class UuidStringUser {
+
+  @PrimaryKey
+  @Column(name = "user_id", spannerType = com.google.spanner.v1.TypeCode.STRING, spannerTypeMaxLength = 36)
+  private UUID userId;
+
+  private String name;
+
+  public UuidStringUser() {}
+
+  public UuidStringUser(UUID userId, String name) {
+    this.userId = userId;
+    this.name = name;
+  }
+
+  public UUID getUserId() {
+    return this.userId;
+  }
+
+  public void setUserId(UUID userId) {
+    this.userId = userId;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    UuidStringUser that = (UuidStringUser) o;
+
+    if (userId != null ? !userId.equals(that.userId) : that.userId != null) return false;
+    return name != null ? name.equals(that.name) : that.name == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = userId != null ? userId.hashCode() : 0;
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "UuidStringUser{" + "userId=" + userId + ", name='" + name + '\'' + '}';
+  }
+}

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/UuidStringUserRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/UuidStringUserRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.data.spanner.test.domain;
+
+import com.google.cloud.spanner.Key;
+import com.google.cloud.spring.data.spanner.repository.SpannerRepository;
+import com.google.cloud.spring.data.spanner.repository.query.Query;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.repository.query.Param;
+
+public interface UuidStringUserRepository extends SpannerRepository<UuidStringUser, Key> {
+
+  List<UuidStringUser> findByUserId(UUID userId);
+
+  @Query("SELECT * FROM :com.google.cloud.spring.data.spanner.test.domain.UuidStringUser: WHERE user_id = @userId")
+  List<UuidStringUser> findByUuidCustom(@Param("userId") UUID userId);
+}

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/UuidUser.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/UuidUser.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.data.spanner.test.domain;
+
+import com.google.cloud.spring.data.spanner.core.mapping.Column;
+import com.google.cloud.spring.data.spanner.core.mapping.PrimaryKey;
+import com.google.cloud.spring.data.spanner.core.mapping.Table;
+import java.util.UUID;
+
+@Table(name = "uuid_users")
+public class UuidUser {
+
+  @PrimaryKey
+  @Column(name = "user_id")
+  private UUID userId;
+
+  private String name;
+
+  private UUID secondaryId;
+
+  public UuidUser() {}
+
+  public UuidUser(UUID userId, String name) {
+    this.userId = userId;
+    this.name = name;
+  }
+
+  public UUID getUserId() {
+    return this.userId;
+  }
+
+  public void setUserId(UUID userId) {
+    this.userId = userId;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+  public UUID getSecondaryId() {
+    return this.secondaryId;
+  }
+
+  public void setSecondaryId(UUID secondaryId) {
+    this.secondaryId = secondaryId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    UuidUser uuidUser = (UuidUser) o;
+
+    if (userId != null ? !userId.equals(uuidUser.userId) : uuidUser.userId != null) return false;
+    if (name != null ? !name.equals(uuidUser.name) : uuidUser.name != null) return false;
+    return secondaryId != null ? secondaryId.equals(uuidUser.secondaryId) : uuidUser.secondaryId == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = userId != null ? userId.hashCode() : 0;
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + (secondaryId != null ? secondaryId.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "UuidUser{" + "userId=" + userId + ", name='" + name + '\'' + ", secondaryId=" + secondaryId + '}';
+  }
+}

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/UuidUserRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/test/domain/UuidUserRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.data.spanner.test.domain;
+
+import com.google.cloud.spanner.Key;
+import com.google.cloud.spring.data.spanner.repository.SpannerRepository;
+import com.google.cloud.spring.data.spanner.repository.query.Query;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.repository.query.Param;
+
+public interface UuidUserRepository extends SpannerRepository<UuidUser, Key> {
+
+  List<UuidUser> findByUserId(UUID userId);
+
+  @Query("SELECT * FROM :com.google.cloud.spring.data.spanner.test.domain.UuidUser: WHERE user_id = @userId")
+  List<UuidUser> findByUuidCustom(@Param("userId") UUID userId);
+}


### PR DESCRIPTION
Binds java.util.UUID parameters as Untyped so that BE resolves the correct type which solves the issues with legacy schemas using STRING columns.

Fixes: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/4120