### PR TITLE
fix(secretmanager): restore parsing of bytestrings

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports
@@ -1,6 +1,0 @@
-# Migrated from spring.factories to enable native Spring Boot 3+ discovery
-com.google.cloud.spring.autoconfigure.alloydb.AlloyDbEnvironmentPostProcessor
-com.google.cloud.spring.autoconfigure.sql.CloudSqlEnvironmentPostProcessor
-com.google.cloud.spring.autoconfigure.sql.R2dbcCloudSqlEnvironmentPostProcessor
-com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerEnvironmentPostProcessor
-com.google.cloud.spring.autoconfigure.parametermanager.GcpParameterManagerEnvironmentPostProcessor

--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports
@@ -1,0 +1,6 @@
+# Migrated from spring.factories to enable native Spring Boot 3+ discovery
+com.google.cloud.spring.autoconfigure.alloydb.AlloyDbEnvironmentPostProcessor
+com.google.cloud.spring.autoconfigure.sql.CloudSqlEnvironmentPostProcessor
+com.google.cloud.spring.autoconfigure.sql.R2dbcCloudSqlEnvironmentPostProcessor
+com.google.cloud.spring.autoconfigure.secretmanager.GcpSecretManagerEnvironmentPostProcessor
+com.google.cloud.spring.autoconfigure.parametermanager.GcpParameterManagerEnvironmentPostProcessor

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/secretmanager/SecretManagerCompatibilityTests.java
@@ -21,7 +21,15 @@ import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.bootstrap.BootstrapRegistry.InstanceSupplier;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.cloud.spring.core.GcpProjectIdProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 
 /** Unit tests to check compatibility of Secret Manager. */
 class SecretManagerCompatibilityTests {
@@ -124,4 +132,52 @@ class SecretManagerCompatibilityTests {
       assertThat(environment.getProperty(prefix + "fake-secret")).isNull();
     }
   }
+  @ParameterizedTest
+  @MethodSource("prefixes")
+  void testConfigurationPropertiesBinding(String prefix, String projectIdPropertyName) {
+    application
+        .sources(MongoConfig.class)
+        .properties(
+            projectIdPropertyName + PROJECT_NAME,
+            "spring.config.import=" + prefix,
+            "spring.data.mongodb.uri=${" + prefix + "my-secret}")
+        .addBootstrapRegistryInitializer(
+            (registry) ->
+                registry.registerIfAbsent(
+                    SecretManagerServiceClientFactory.class,
+                    InstanceSupplier.of(secretManagerServiceClientFactory)))
+        .addBootstrapRegistryInitializer(
+            (registry) ->
+                registry.registerIfAbsent(
+                    SecretManagerServiceClient.class, InstanceSupplier.of(client)));
+    try (ConfigurableApplicationContext applicationContext = application.run()) {
+      MongoConfig.MongoProperties properties = applicationContext.getBean(MongoConfig.MongoProperties.class);
+      assertThat(properties.getUri()).isInstanceOf(String.class);
+      assertThat(properties.getUri()).isEqualTo("newSecret");
+    }
+  }
+
+  @Configuration
+  @EnableConfigurationProperties(MongoConfig.MongoProperties.class)
+  @Import(GcpSecretManagerAutoConfiguration.class)
+  static class MongoConfig {
+    @ConfigurationProperties("spring.data.mongodb")
+    static class MongoProperties {
+      private String uri;
+      public String getUri() { return uri; }
+      public void setUri(String uri) { this.uri = uri; }
+    }
+
+
+    @Bean
+    public CredentialsProvider googleCredentials() {
+      return () -> null;
+    }
+
+    @Bean
+    public GcpProjectIdProvider gcpProjectIdProvider() {
+      return () -> PROJECT_NAME;
+    }
+  }
 }
+

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertySource.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertySource.java
@@ -18,6 +18,7 @@ package com.google.cloud.spring.secretmanager;
 
 import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
+import com.google.protobuf.ByteString;
 import org.springframework.core.env.EnumerablePropertySource;
 
 /**
@@ -45,7 +46,7 @@ public class SecretManagerPropertySource extends EnumerablePropertySource<Secret
 
     if (secretIdentifier != null) {
       // Return standard String so ConfigurationProperties binder handles type conversion natively.
-      com.google.protobuf.ByteString byteString = getSource().getSecretByteString(secretIdentifier);
+      ByteString byteString = getSource().getSecretByteString(secretIdentifier);
       return byteString != null ? byteString.toStringUtf8() : null;
     } else {
       return null;

--- a/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertySource.java
+++ b/spring-cloud-gcp-secretmanager/src/main/java/com/google/cloud/spring/secretmanager/SecretManagerPropertySource.java
@@ -44,7 +44,9 @@ public class SecretManagerPropertySource extends EnumerablePropertySource<Secret
         SecretManagerPropertyUtils.getSecretVersionName(name, this.projectIdProvider);
 
     if (secretIdentifier != null) {
-      return getSource().getSecretByteString(secretIdentifier);
+      // Return standard String so ConfigurationProperties binder handles type conversion natively.
+      com.google.protobuf.ByteString byteString = getSource().getSecretByteString(secretIdentifier);
+      return byteString != null ? byteString.toStringUtf8() : null;
     } else {
       return null;
     }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/4395 ,where placeholders backed by Google Cloud Secret Manager (`${sm@my_secret}`) fail to parse into property structures like `spring.data.mongodb.uri`.

#### Problem
Spring Boot 4 scopes its `ConfigurationPropertiesBinder` atop an independent `ConversionService` that does not automatically cascade custom mappings injected during early `EnvironmentPostProcessor` cycles.

#### Solution
We adapted `SecretManagerPropertySource.java` to extract UTF-8 text dynamically upon reading. 

