### PR TITLE
ci: declare contents: read on seven CI workflows

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -17,6 +17,9 @@ on:
 env:
   EXCLUDED_MODULES: spring-cloud-spanner-spring-data-r2dbc
 
+permissions:
+  contents: read
+
 jobs:
   parallel-NativeTests:
     if: |

--- a/.github/workflows/compatibilityCheck.yaml
+++ b/.github/workflows/compatibilityCheck.yaml
@@ -15,6 +15,9 @@ on:
   schedule:
     - cron: '05 8 * * *' # 08:00 UTC every day
 
+permissions:
+  contents: read
+
 jobs:
   integrationTests:
     name: Integration Tests for Compatibility Check

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -18,6 +18,9 @@ on:
     - cron: '05 8 * * *' # 08:00 UTC every day
 
 
+permissions:
+  contents: read
+
 jobs:
   parallel-integrationTests:
     if: |

--- a/.github/workflows/linkageCheck.yaml
+++ b/.github/workflows/linkageCheck.yaml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '00 9 * * *' # 09:00 UTC every day
 
+permissions:
+  contents: read
+
 jobs:
   linkageCheck:
     if: |

--- a/.github/workflows/showcaseTests.yaml
+++ b/.github/workflows/showcaseTests.yaml
@@ -11,6 +11,9 @@ on:
       - 'main'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   showcaseTests:
 

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -12,6 +12,9 @@ on:
 env:
   # Workaround for kotlin sample multithreading issue: https://youtrack.jetbrains.com/issue/KT-43894
   MAVEN_OPTS: "-Didea.home.path=${{ vars.RUNNER_TEMP }} -Didea.ignore.disabled.plugins=true"
+permissions:
+  contents: read
+
 jobs:
   sonar:
     name: Build with Sonar

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -17,6 +17,9 @@ on:
 env:
   # Workaround for kotlin sample multithreading issue: https://youtrack.jetbrains.com/issue/KT-43894
   MAVEN_OPTS: "-Didea.home.path=${{ vars.RUNNER_TEMP }} -Didea.ignore.disabled.plugins=true"
+permissions:
+  contents: read
+
 jobs:
   unitTests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Seven read-only CI workflows currently run with no `permissions:` declared. All do checkout + maven / native-image / sonar / linkage-check / upload-artifact. None push, comment, or call write APIs.

GITHUB_TOKEN usages:

- `NativeTests`: passed to `actions/setup-java` as a `github-token` (read for releases lookups)
- `compatibilityCheck`: passed to `softprops/turnstyle` to wait for sibling workflow status (read)
- `sonar`: passed for PR-metadata lookup (read)

`contents: read` is the right minimum for all seven.

Two workflows are intentionally **not** in this PR because they need very different scopes:

- `codeql-analysis.yml` — needs `security-events: write` for SARIF upload
- `renovate.yml` — needs `contents: write` + `pull-requests: write` for branch push + PR creation

Those deserve their own focused PRs.