### PR TITLE
ci: disable multithreaded maven install to fix lock contention (NativeTests)

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -80,7 +80,6 @@ jobs:
           ./mvnw \
             --batch-mode \
             --no-transfer-progress \
-            --threads 1.5C \
             --define maven.test.skip=true \
             --define maven.javadoc.skip=true \
             install


### PR DESCRIPTION
b/512866590