### PR TITLE
ci: disable multithreaded maven install to fix lock contention (NativeTests) (#4442)

### DIFF
--- a/.github/workflows/NativeTests.yaml
+++ b/.github/workflows/NativeTests.yaml
@@ -81,7 +81,6 @@ jobs:
           ./mvnw \
             --batch-mode \
             --no-transfer-progress \
-            --threads 1.5C \
             --define maven.test.skip=true \
             --define maven.javadoc.skip=true \
             install


### PR DESCRIPTION
backport https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/4442