### PR TITLE
ci: disable multithreaded maven install to fix lock contention (#4441)

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -81,7 +81,6 @@ jobs:
           ./mvnw \
             --batch-mode \
             --no-transfer-progress \
-            --threads 1.5C \
             --define maven.test.skip=true \
             --define maven.javadoc.skip=true \
             --define org.slf4j.simpleLogger.showDateTime=true \


### PR DESCRIPTION
backport https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/4441