### PR TITLE
test: Fix flaky test readUnmatchableTypesTest due to nondeterministic results

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
@@ -269,7 +269,7 @@ class ConverterAwareMappingSpannerEntityReaderTests {
   }
 
   @Test
-  void readUnmatachableTypesTest() {
+  void readUnmatchableTypesTest() {
     Struct struct =
         Struct.newBuilder().set("fieldWithUnsupportedType").to(Value.string("key1")).build();
 
@@ -280,8 +280,7 @@ class ConverterAwareMappingSpannerEntityReaderTests {
         false
     ))
         .isInstanceOf(SpannerDataException.class)
-        .hasMessageContaining("Unable to read column from Cloud Spanner results")
-        .hasMessageEndingWith(": id");
+        .hasMessageContaining("Unable to read column from Cloud Spanner results");
   }
 
   @Test


### PR DESCRIPTION
## Description
Fixes #4186

**Problem:**
The test `readUnmatachableTypesTest()` in `ConverterAwareMappingSpannerEntityReaderTests` fails intermittently because it asserts the exact exception message ending with `: id`:

\`\`\`java
.hasMessageEndingWith(": id");
\`\`\`

The underlying `SpannerEntityReader` processes entity fields in non-deterministic order (reflection-based), so the first field that triggers the exception can vary between runs. This causes the message suffix to change, leading to flaky test failures even though the exception type and core message are correct.

**Solution:**
- Removed the brittle `.hasMessageEndingWith(": id")` assertion
- Retained the stable `.hasMessageContaining("Unable to read column from Cloud Spanner results")` check which validates the correct exception is thrown regardless of field ordering
- Fixed the typo in the test name: `readUnmatachableTypesTest` → `readUnmatchableTypesTest`

## Contribution Checklist
- [x] **Issue Linked:** This PR addresses an existing issue (#4186).
- [x] **Clear Description:** The PR description clearly states the problem and the proposed solution.
- [x] **Tests Passed:** All 19 tests in `ConverterAwareMappingSpannerEntityReaderTests` pass successfully.
- [x] **Code Formatting:** Ensured the code conforms to the Google Java Style Guide.