### PR TITLE
fix: sort column DDL strings in SpannerSchemaUtils for deterministic …

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtils.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtils.java
@@ -27,6 +27,7 @@ import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentEntity;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentProperty;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.OptionalLong;
@@ -238,14 +239,22 @@ public class SpannerSchemaUtils {
 
   private <T> void addColumnDdlStrings(
       SpannerPersistentEntity<T> spannerPersistentEntity, StringJoiner stringJoiner) {
+    List<String> columnDdls = new ArrayList<>();
+    collectColumnDdlStrings(spannerPersistentEntity, columnDdls);
+    Collections.sort(columnDdls);
+    columnDdls.forEach(stringJoiner::add);
+  }
+
+  private <T> void collectColumnDdlStrings(
+      SpannerPersistentEntity<T> spannerPersistentEntity, List<String> columnDdls) {
     spannerPersistentEntity.doWithColumnBackedProperties(
         spannerPersistentProperty -> {
           if (spannerPersistentProperty.isEmbedded()) {
-            addColumnDdlStrings(
+            collectColumnDdlStrings(
                 this.mappingContext.getPersistentEntityOrFail(spannerPersistentProperty.getType()),
-                stringJoiner);
+                columnDdls);
           } else {
-            stringJoiner.add(
+            columnDdls.add(
                 getColumnDdlString(spannerPersistentProperty, this.spannerEntityProcessor));
           }
         });

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/admin/SpannerSchemaUtilsTests.java
@@ -68,14 +68,15 @@ class SpannerSchemaUtilsTests {
   @Test
   void getCreateDdlTest() {
     String ddlResult =
-        "CREATE TABLE custom_test_table ( id STRING(MAX) , id3 INT64 , id_2 STRING(MAX) , "
-            + "bytes2 BYTES(MAX) , custom_col FLOAT64 NOT NULL , other STRING(333) , "
-            + "primitiveDoubleField FLOAT64 , bigDoubleField FLOAT64 , primitiveFloatField FLOAT32 , "
-            + "bigFloatField FLOAT32 , bigLongField INT64 , primitiveIntField INT64 , "
-            + "bigIntField INT64 , bytes BYTES(MAX) , bytesList ARRAY<BYTES(111)> , "
-            + "integerList ARRAY<INT64> , doubles ARRAY<FLOAT64> , floats ARRAY<FLOAT32> , "
+        "CREATE TABLE custom_test_table ( bigDecimalField NUMERIC , "
+            + "bigDecimals ARRAY<NUMERIC> , bigDoubleField FLOAT64 , bigFloatField FLOAT32 , "
+            + "bigIntField INT64 , bigLongField INT64 , bytes BYTES(MAX) , bytes2 BYTES(MAX) , "
+            + "bytesList ARRAY<BYTES(111)> , "
             + "commitTimestamp TIMESTAMP OPTIONS (allow_commit_timestamp=true) , "
-            + "bigDecimalField NUMERIC , bigDecimals ARRAY<NUMERIC> , jsonCol JSON ) "
+            + "custom_col FLOAT64 NOT NULL , doubles ARRAY<FLOAT64> , floats ARRAY<FLOAT32> , "
+            + "id STRING(MAX) , id3 INT64 , id_2 STRING(MAX) , integerList ARRAY<INT64> , "
+            + "jsonCol JSON , other STRING(333) , primitiveDoubleField FLOAT64 , "
+            + "primitiveFloatField FLOAT32 , primitiveIntField INT64 ) "
             + "PRIMARY KEY ( id , id_2 , id3 )";
 
     assertThat(this.spannerSchemaUtils.getCreateTableDdlString(TestEntity.class))
@@ -227,15 +228,15 @@ class SpannerSchemaUtilsTests {
         this.spannerSchemaUtils.getCreateTableDdlStringsForInterleavedHierarchy(ParentEntity.class);
     assertThat(createStrings)
         .containsExactly(
-            "CREATE TABLE parent_test_table ( id STRING(MAX) "
-                + ", id_2 STRING(MAX) , bytes2 BYTES(MAX) , "
-                + "custom_col STRING(MAX) , other STRING(MAX) ) PRIMARY KEY ( id , id_2 )",
-            "CREATE TABLE child_test_table ( id STRING(MAX) "
-                + ", id_2 STRING(MAX) , bytes2 BYTES(MAX) , "
-                + "id3 STRING(MAX) ) PRIMARY KEY ( id , id_2 , id3 ), INTERLEAVE IN PARENT "
+            "CREATE TABLE parent_test_table ( bytes2 BYTES(MAX) , "
+                + "custom_col STRING(MAX) , id STRING(MAX) , "
+                + "id_2 STRING(MAX) , other STRING(MAX) ) PRIMARY KEY ( id , id_2 )",
+            "CREATE TABLE child_test_table ( bytes2 BYTES(MAX) , "
+                + "id STRING(MAX) , id3 STRING(MAX) , "
+                + "id_2 STRING(MAX) ) PRIMARY KEY ( id , id_2 , id3 ), INTERLEAVE IN PARENT "
                 + "parent_test_table ON DELETE CASCADE",
-            "CREATE TABLE grand_child_test_table ( id STRING(MAX) , id_2 STRING(MAX) , "
-                + "id3 STRING(MAX) , id4 STRING(MAX) ) PRIMARY KEY ( id , id_2 , id3 , id4 ), "
+            "CREATE TABLE grand_child_test_table ( id STRING(MAX) , id3 STRING(MAX) , "
+                + "id4 STRING(MAX) , id_2 STRING(MAX) ) PRIMARY KEY ( id , id_2 , id3 , id4 ), "
                 + "INTERLEAVE IN PARENT child_test_table ON DELETE CASCADE");
   }
 


### PR DESCRIPTION
## Description
Fixes #4235

**Problem:**
The `addColumnDdlStrings()` method in `SpannerSchemaUtils` iterates entity properties via `doWithColumnBackedProperties()`, which relies on reflection-based property discovery. This produces nondeterministic iteration order, causing the following tests to be flaky:

\`\`\`
com.google.cloud.spring.data.spanner.core.admin.SpannerSchemaUtilsTests.getCreateDdlTest
com.google.cloud.spring.data.spanner.core.admin.SpannerSchemaUtilsTests.getCreateDdlHierarchyTest
\`\`\`

The generated DDL column ordering can vary between JVM runs, which was confirmed using the [NonDex tool](https://github.com/TestingResearchIllinois/NonDex):

\`\`\`
mvn -pl spring-cloud-gcp-data-spanner edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest="com.google.cloud.spring.data.spanner.core.admin.SpannerSchemaUtilsTests"
\`\`\`

**Solution:**
Refactored `addColumnDdlStrings()` to collect DDL strings into a list via a new helper method `collectColumnDdlStrings()`, sort them alphabetically using `Collections.sort()`, then add them to the `StringJoiner`. This guarantees deterministic DDL output regardless of reflection order. Updated the 2 affected test assertions to match the new sorted column ordering.

## Contribution Checklist
- [x] **Issue Linked:** This PR addresses an existing issue (#4235).
- [x] **Clear Description:** The PR description clearly states the problem and the proposed solution.
- [x] **Tests Passed:** All 17 tests in `SpannerSchemaUtilsTests` pass successfully.
- [x] **Code Formatting:** Ensured the code conforms to the Google Java Style Guide.