### PR TITLE
fix(spanner): support querying UUID collections against STRING columns using untyped binding

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -218,9 +218,33 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
       SpannerCustomConverter writeConverter,
       Class innerType) {
     boolean valueSet = false;
+
+    if (innerType == UUID.class) {
+      if (value != null) {
+        com.google.protobuf.ListValue.Builder listValueBuilder = com.google.protobuf.ListValue.newBuilder();
+        for (Object item : value) {
+          if (item != null) {
+            listValueBuilder.addValues(com.google.protobuf.Value.newBuilder().setStringValue(item.toString()).build());
+          } else {
+            listValueBuilder.addValues(com.google.protobuf.Value.newBuilder().setNullValue(com.google.protobuf.NullValue.NULL_VALUE).build());
+          }
+        }
+        com.google.protobuf.Value protoValue = com.google.protobuf.Value.newBuilder()
+            .setListValue(listValueBuilder.build())
+            .build();
+        valueBinder.to(Value.untyped(protoValue));
+      } else {
+        com.google.protobuf.Value nullProtoValue = com.google.protobuf.Value.newBuilder()
+            .setNullValue(com.google.protobuf.NullValue.NULL_VALUE)
+            .build();
+        valueBinder.to(Value.untyped(nullProtoValue));
+      }
+      valueSet = true;
+    }
+
     // attempt check if there is directly a write method that can accept the
     // property
-    if (iterablePropertyTypeToMethodMap.containsKey(innerType)) {
+    if (!valueSet && iterablePropertyTypeToMethodMap.containsKey(innerType)) {
       iterablePropertyTypeToMethodMap.get(innerType).accept(valueBinder, value);
       valueSet = true;
     }

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -30,6 +30,8 @@ import com.google.cloud.spring.data.spanner.core.mapping.SpannerDataException;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentEntity;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentProperty;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.NullValue;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,8 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import com.google.protobuf.ListValue;
-import com.google.protobuf.NullValue;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -226,19 +226,19 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
         ListValue.Builder listValueBuilder = ListValue.newBuilder();
         for (Object item : value) {
           if (item != null) {
-            listValueBuilder.addValues(com.google.protobuf.Value.newBuilder().setStringValue(item.toString()).build());
+            listValueBuilder.addValues(
+                com.google.protobuf.Value.newBuilder().setStringValue(item.toString()).build());
           } else {
-            listValueBuilder.addValues(com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build());
+            listValueBuilder.addValues(
+                com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build());
           }
         }
-        com.google.protobuf.Value protoValue = com.google.protobuf.Value.newBuilder()
-            .setListValue(listValueBuilder.build())
-            .build();
+        com.google.protobuf.Value protoValue =
+            com.google.protobuf.Value.newBuilder().setListValue(listValueBuilder.build()).build();
         valueBinder.to(Value.untyped(protoValue));
       } else {
-        com.google.protobuf.Value nullProtoValue = com.google.protobuf.Value.newBuilder()
-            .setNullValue(NullValue.NULL_VALUE)
-            .build();
+        com.google.protobuf.Value nullProtoValue =
+            com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
         valueBinder.to(Value.untyped(nullProtoValue));
       }
       valueSet = true;
@@ -283,14 +283,12 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 
     if (propertyType == UUID.class) {
       if (propertyValue != null) {
-        com.google.protobuf.Value protoValue = com.google.protobuf.Value.newBuilder()
-            .setStringValue(propertyValue.toString())
-            .build();
+        com.google.protobuf.Value protoValue =
+            com.google.protobuf.Value.newBuilder().setStringValue(propertyValue.toString()).build();
         valueBinder.to(Value.untyped(protoValue));
       } else {
-        com.google.protobuf.Value nullProtoValue = com.google.protobuf.Value.newBuilder()
-            .setNullValue(NullValue.NULL_VALUE)
-            .build();
+        com.google.protobuf.Value nullProtoValue =
+            com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
         valueBinder.to(Value.untyped(nullProtoValue));
       }
       valueSet = true;

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriter.java
@@ -40,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.NullValue;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -221,12 +223,12 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
 
     if (innerType == UUID.class) {
       if (value != null) {
-        com.google.protobuf.ListValue.Builder listValueBuilder = com.google.protobuf.ListValue.newBuilder();
+        ListValue.Builder listValueBuilder = ListValue.newBuilder();
         for (Object item : value) {
           if (item != null) {
             listValueBuilder.addValues(com.google.protobuf.Value.newBuilder().setStringValue(item.toString()).build());
           } else {
-            listValueBuilder.addValues(com.google.protobuf.Value.newBuilder().setNullValue(com.google.protobuf.NullValue.NULL_VALUE).build());
+            listValueBuilder.addValues(com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build());
           }
         }
         com.google.protobuf.Value protoValue = com.google.protobuf.Value.newBuilder()
@@ -235,7 +237,7 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
         valueBinder.to(Value.untyped(protoValue));
       } else {
         com.google.protobuf.Value nullProtoValue = com.google.protobuf.Value.newBuilder()
-            .setNullValue(com.google.protobuf.NullValue.NULL_VALUE)
+            .setNullValue(NullValue.NULL_VALUE)
             .build();
         valueBinder.to(Value.untyped(nullProtoValue));
       }
@@ -287,7 +289,7 @@ public class ConverterAwareMappingSpannerEntityWriter implements SpannerEntityWr
         valueBinder.to(Value.untyped(protoValue));
       } else {
         com.google.protobuf.Value nullProtoValue = com.google.protobuf.Value.newBuilder()
-            .setNullValue(com.google.protobuf.NullValue.NULL_VALUE)
+            .setNullValue(NullValue.NULL_VALUE)
             .build();
         valueBinder.to(Value.untyped(nullProtoValue));
       }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityWriterTests.java
@@ -281,7 +281,7 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     when(writeBuilder.set("uuidField")).thenReturn(uuidFieldBinder);
 
     ValueBinder<WriteBuilder> uuidListFieldBinder = mock(ValueBinder.class);
-    when(uuidListFieldBinder.toUuidArray(any())).thenReturn(null);
+    when(uuidListFieldBinder.to((Value) any())).thenReturn(null);
     when(writeBuilder.set("uuidList")).thenReturn(uuidListFieldBinder);
 
     this.spannerEntityWriter.write(t, writeBuilder::set);
@@ -323,7 +323,10 @@ class ConverterAwareMappingSpannerEntityWriterTests {
         .setStringValue(t.uuidField.toString())
         .build();
     verify(uuidFieldBinder, times(1)).to(Value.untyped(expectedProtoValue));
-    verify(uuidListFieldBinder, times(1)).toUuidArray(t.uuidList);
+    com.google.protobuf.ListValue expectedProtoListValue = com.google.protobuf.ListValue.newBuilder()
+        .addValues(com.google.protobuf.Value.newBuilder().setStringValue(t.uuidField.toString()).build())
+        .build();
+    verify(uuidListFieldBinder, times(1)).to(Value.untyped(com.google.protobuf.Value.newBuilder().setListValue(expectedProtoListValue).build()));
   }
 
   @Test
@@ -333,6 +336,7 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     t.dateField = null;
     t.doubleList = null;
     t.uuidField = null;
+    t.uuidList = null;
 
     WriteBuilder writeBuilder = mock(WriteBuilder.class);
 
@@ -348,10 +352,14 @@ class ConverterAwareMappingSpannerEntityWriterTests {
     when(uuidFieldBinder.to((Value) any())).thenReturn(null);
     when(writeBuilder.set("uuidField")).thenReturn(uuidFieldBinder);
 
+    ValueBinder<WriteBuilder> uuidListFieldBinder = mock(ValueBinder.class);
+    when(uuidListFieldBinder.to((Value) any())).thenReturn(null);
+    when(writeBuilder.set("uuidList")).thenReturn(uuidListFieldBinder);
+
     this.spannerEntityWriter.write(
         t,
         writeBuilder::set,
-        Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("dateField", "doubleList", "uuidField"))));
+        Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("dateField", "doubleList", "uuidField", "uuidList"))));
     verify(dateFieldBinder, times(1)).to((Date) isNull());
     verify(doubleListFieldBinder, times(1)).toFloat64Array((Iterable<Double>) isNull());
     
@@ -359,6 +367,7 @@ class ConverterAwareMappingSpannerEntityWriterTests {
         .setNullValue(com.google.protobuf.NullValue.NULL_VALUE)
         .build();
     verify(uuidFieldBinder, times(1)).to(Value.untyped(nullProtoValue));
+    verify(uuidListFieldBinder, times(1)).to(Value.untyped(nullProtoValue));
   }
 
   @Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
@@ -328,6 +328,45 @@ class SpannerStatementQueryTests {
     verify(this.spannerTemplate, times(1)).query((Class) any(), any(), any());
   }
 
+  @Test
+  void uuidListUntypedBindingTest() throws NoSuchMethodException {
+    when(this.queryMethod.getName()).thenReturn("findByUuidIn");
+    this.partTreeSpannerQuery = spy(createQuery());
+
+    java.util.UUID uuid1 = java.util.UUID.randomUUID();
+    java.util.UUID uuid2 = java.util.UUID.randomUUID();
+    List<java.util.UUID> uuids = Arrays.asList(uuid1, uuid2);
+    Object[] params = new Object[] {uuids};
+    
+    Method method = QueryHolder.class.getMethod("repositoryMethod9", List.class);
+    when(this.queryMethod.getQueryMethod()).thenReturn(method);
+    doReturn(new DefaultParameters(ParametersSource.of(method)))
+        .when(this.queryMethod)
+        .getParameters();
+
+    when(this.spannerTemplate.query((Class) any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              Statement statement = invocation.getArgument(1);
+              Map<String, Value> paramMap = statement.getParameters();
+
+              com.google.protobuf.ListValue expectedProtoListValue = com.google.protobuf.ListValue.newBuilder()
+                  .addValues(com.google.protobuf.Value.newBuilder().setStringValue(uuid1.toString()).build())
+                  .addValues(com.google.protobuf.Value.newBuilder().setStringValue(uuid2.toString()).build())
+                  .build();
+              assertThat(paramMap.get("tag0")).isEqualTo(Value.untyped(com.google.protobuf.Value.newBuilder().setListValue(expectedProtoListValue).build()));
+              assertThat(paramMap).hasSize(1);
+
+              return null;
+            });
+
+    doReturn(Object.class).when(this.partTreeSpannerQuery).getReturnedSimpleConvertableItemType();
+    doReturn(null).when(this.partTreeSpannerQuery).convertToSimpleReturnType(any(), any());
+
+    this.partTreeSpannerQuery.execute(params);
+    verify(this.spannerTemplate, times(1)).query((Class) any(), any(), any());
+  }
+
   private void runPageableOrSortTest(Object[] params, Method method, String expectedSql) {
     when(this.queryMethod.getName()).thenReturn("findByPriceLessThan");
     this.partTreeSpannerQuery = spy(createQuery());
@@ -572,6 +611,10 @@ class SpannerStatementQueryTests {
     }
 
     public long repositoryMethod8(java.util.UUID tag0) {
+      return 0;
+    }
+
+    public long repositoryMethod9(List<java.util.UUID> tag0) {
       return 0;
     }
   }


### PR DESCRIPTION
Binds collections/iterables of java.util.UUID parameters as untyped ListValues so that the backend can dynamically resolve the correct type when evaluated against legacy STRING(36) schema columns (e.g., in IN UNNEST(@param) queries).

This builds on the previous single-item UUID untyped binding fix to address the remaining array mapping scenario that blocked upgrades for legacy schemas.

Fixes: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/issues/4120
