### PR TITLE
feat(core): support service account impersonation in credentials

### DIFF
--- a/docs/src/main/asciidoc/core.adoc
+++ b/docs/src/main/asciidoc/core.adoc
@@ -92,6 +92,20 @@ spring.cloud.gcp.credentials.location=file:/usr/local/key.json
 Alternatively, you can set the credentials by directly specifying the `spring.cloud.gcp.credentials.encoded-key` property.
 The value should be the base64-encoded account private key in JSON format.
 
+Another alternative to managing service account keys is to use service account impersonation.
+Set `spring.cloud.gcp.credentials.impersonated-service-account` to the email of a service account, and the starter will use the Application Default Credentials to obtain access tokens on behalf of that service account.
+
+[source]
+----
+spring.cloud.gcp.credentials.impersonated-service-account=my-sa@my-project.iam.gserviceaccount.com
+----
+
+The source credentials (typically your local user credentials or the GCE/GKE workload identity) must have the `roles/iam.serviceAccountTokenCreator` role on the target service account.
+This property is useful for local development, where it lets engineers run code under a real dev service account identity without provisioning static service account keys.
+It is ignored when `spring.cloud.gcp.credentials.location` or `spring.cloud.gcp.credentials.encoded-key` is also set.
+
+NOTE: Like the other credential properties, impersonation can be overridden per service (for example, `spring.cloud.gcp.pubsub.credentials.impersonated-service-account`).
+
 If your app is running on Google App Engine or Google Compute Engine, in most cases, you should omit the `spring.cloud.gcp.credentials.location` property and, instead, let the Spring Framework on Google Cloud Starter get the correct credentials for those environments.
 On App Engine Standard, the https://cloud.google.com/appengine/docs/standard/java/appidentity/[App Identity service account credentials] are used, on App Engine Flexible, the https://cloud.google.com/appengine/docs/flexible/java/service-account[Flexible service account credential] are used and on Google Compute Engine, the https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#using_the_compute_engine_default_service_account[Compute Engine Default Service Account] is used.
 

--- a/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Credentials.java
+++ b/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Credentials.java
@@ -38,6 +38,13 @@ public class Credentials {
   /** The base64 encoded contents of an OAuth2 account private key, on the JSON format. */
   private String encodedKey;
 
+  /**
+   * Email of a service account to impersonate using the Application Default Credentials. The
+   * source credentials must have the {@code roles/iam.serviceAccountTokenCreator} role on the
+   * target service account.
+   */
+  private String impersonatedServiceAccount;
+
   public Credentials(String... defaultScopes) {
     this.scopes.addAll(Arrays.asList(defaultScopes));
   }
@@ -64,6 +71,14 @@ public class Credentials {
 
   public void setEncodedKey(String encodedKey) {
     this.encodedKey = encodedKey;
+  }
+
+  public String getImpersonatedServiceAccount() {
+    return this.impersonatedServiceAccount;
+  }
+
+  public void setImpersonatedServiceAccount(String impersonatedServiceAccount) {
+    this.impersonatedServiceAccount = impersonatedServiceAccount;
   }
 
   public boolean hasKey() {

--- a/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/DefaultCredentialsProvider.java
+++ b/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/DefaultCredentialsProvider.java
@@ -22,6 +22,7 @@ import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ImpersonatedCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auth.oauth2.UserCredentials;
 import java.io.ByteArrayInputStream;
@@ -68,6 +69,8 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
    *   <li>*.credentials.location: Credentials built from JSON content inside the file pointed to by
    *       this property,
    *   <li>*.credentials.encoded-key: Credentials built from JSON String, encoded on base64,
+   *   <li>*.credentials.impersonated-service-account: Credentials impersonating the service account by
+   *       default credentials,
    *   <li>Google Cloud Client Libraries default credentials provider.
    * </ul>
    *
@@ -81,6 +84,7 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
     List<String> scopes = resolveScopes(credentialsSupplier.getCredentials().getScopes());
     Resource providedLocation = credentialsSupplier.getCredentials().getLocation();
     String encodedKey = credentialsSupplier.getCredentials().getEncodedKey();
+    String impersonatedServiceAccount = credentialsSupplier.getCredentials().getImpersonatedServiceAccount();
 
     if (providedLocation != null) {
       this.wrappedCredentialsProvider =
@@ -92,6 +96,15 @@ public class DefaultCredentialsProvider implements CredentialsProvider {
               GoogleCredentials.fromStream(
                       new ByteArrayInputStream(Base64.getDecoder().decode(encodedKey)))
                   .createScoped(scopes));
+    } else if (StringUtils.hasText(impersonatedServiceAccount)) {
+      this.wrappedCredentialsProvider =
+          FixedCredentialsProvider.create(
+              ImpersonatedCredentials.create(
+                  GoogleCredentials.getApplicationDefault(),
+                  impersonatedServiceAccount,
+                  null,
+                  scopes,
+                  0));
     } else {
       this.wrappedCredentialsProvider =
           GoogleCredentialsProvider.newBuilder().setScopesToApply(scopes).build();

--- a/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/DefaultCredentialsProviderTests.java
+++ b/spring-cloud-gcp-core/src/test/java/com/google/cloud/spring/core/DefaultCredentialsProviderTests.java
@@ -18,10 +18,17 @@ package com.google.cloud.spring.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
 
 /** Tests for the {@link DefaultCredentialsProvider}. */
 class DefaultCredentialsProviderTests {
@@ -48,5 +55,47 @@ class DefaultCredentialsProviderTests {
         .hasSize(GcpScope.values().length + 1)
         .contains(GcpScope.PUBSUB.getUrl())
         .contains("myscope");
+  }
+
+  @Test
+  void testImpersonatedServiceAccountGetterSetter() {
+    Credentials credentials = new Credentials();
+    assertThat(credentials.getImpersonatedServiceAccount()).isNull();
+
+    credentials.setImpersonatedServiceAccount("sa@project.iam.gserviceaccount.com");
+    assertThat(credentials.getImpersonatedServiceAccount())
+        .isEqualTo("sa@project.iam.gserviceaccount.com");
+  }
+
+  @Test
+  void testEncodedKeyTakesPrecedenceOverImpersonation() throws IOException {
+    Credentials credentials = new Credentials();
+    credentials.setEncodedKey(encodedFakeKey());
+    credentials.setImpersonatedServiceAccount("sa@project.iam.gserviceaccount.com");
+
+    DefaultCredentialsProvider provider = new DefaultCredentialsProvider(() -> credentials);
+
+    assertThat(provider.getCredentials()).isInstanceOf(ServiceAccountCredentials.class);
+    assertThat(((ServiceAccountCredentials) provider.getCredentials()).getClientEmail())
+        .isEqualTo("test@fake-project.iam.gserviceaccount.com");
+  }
+
+  @Test
+  void testLocationTakesPrecedenceOverImpersonation() throws IOException {
+    Credentials credentials = new Credentials();
+    credentials.setLocation(new ClassPathResource("fake-credential-key.json"));
+    credentials.setImpersonatedServiceAccount("sa@project.iam.gserviceaccount.com");
+
+    DefaultCredentialsProvider provider = new DefaultCredentialsProvider(() -> credentials);
+
+    assertThat(provider.getCredentials()).isInstanceOf(ServiceAccountCredentials.class);
+    assertThat(((ServiceAccountCredentials) provider.getCredentials()).getClientEmail())
+        .isEqualTo("test@fake-project.iam.gserviceaccount.com");
+  }
+
+  private static String encodedFakeKey() throws IOException {
+    byte[] keyBytes =
+        Files.readAllBytes(Paths.get("src/test/resources/fake-credential-key.json"));
+    return Base64.getEncoder().encodeToString(new String(keyBytes, StandardCharsets.UTF_8).getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/spring-cloud-gcp-core/src/test/resources/fake-credential-key.json
+++ b/spring-cloud-gcp-core/src/test/resources/fake-credential-key.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "fake-project-id",
+  "private_key_id": "fake-key",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEugIBADANBgkqhkiG9w0BAQEFAASCBKQwggSgAgEAAoIBAQCh/y7v8lk1Ko79\nWVbQZCtmd0PXZr8WrUmmdEv2aaQQF/ed/KL2M/T2dbTlQ4EeOP+aK/5T8JSuxxZ5\na6e8TsovKXJz2qjeBLpzNFbx2xSyldYziC6v+bRCPKWCQLRNVdz/iYmOqjOu1/Ri\n8njOF7gG3XMQxryl9pmpJbVXj38Zw1n8mefT/g/+l6fObsVIgLs9WjGE9HDMKzx8\n9Ph7f+Ru1EuBrFOgHfKvWeIjVtQWqr3Dz+M1KyLFezYtXGB5HLg02sPJM+tMdcMj\nL9xpuodc6noBBeKvijEfTErLIaO1cJS5AgFHDyEsspaRdgXpJroM4w8ZSj3J0Wp7\ntJ7PeaG/AgMBAAECgf9ubAMSi59DHj9Zcgw7AAyVS7ZynRaj3nrVe3BMBrZOQggH\nKK3sJH5VgOZNYDYi47dW36X8kYDHoe0v1rH/KbWncBkT33g73f05ifO56Buzn27i\nsXEhgpPckno+ztwX2u9JP/cDyAByrcFnsN+nm4NVKp3EUbNFbVJQeeOiS63XYLvO\nuIUGlYJrnqa2zWp/YwhOmvZz5fNhfN/Js+V8kaA/xK/Dk0xhgvAqv73lgYZyL5pg\nlImHgHIm5alAMpchu4bInv2CjhKsgyPvHZU0Wihdm5it58hME0gN3ekD6lbdsp+1\nEwZ50JXALUPvzeMGXWorxuBUe9hpMcDmugR6rjECgYEAzpELFjiX2sNZPDX7cTM0\nYwWCdcvJUVTEapnpWuU2OhDreGMlBAWO6hkTIq6kmBZ0c30o10FNhXBrg0AyesgG\nheY6wO+v4e5hnVIdud2ih7AWDaKXVrb63Z/aF3EUhxcVk0wmnJtQ605cjMjeJOJF\nEyQCGsaiLbsEBsEKrXfLL08CgYEAyMOlz8dCNrEm16rbTE7NZpqql7IJhcAcXB5Z\nGUZicK98W4HnT6r5qPePgCjHnxjXl+/T6siH1B8CxQwtzETI8bu0Jd3ZvL7HZnIS\nHDWiGn72OJnYOvxvq1SvIqdTvlCMKqRQancp8wWP9oubzjS5ZZLGemaqvVL2Occp\nsfUZSpECgYBXPdz/2pEQHNcwXeA/VA/5DlemJpZ1GicGmtB6yjnX1lOM+dqlUy+j\n4Uk6qaXscfdm22KHXxY9mFhgC5oGTzqqDK2d1N1kv4hMqGTTni7Jve3iflwKjKdx\nONUkd2bjEzXSiyP3moVXjDX8Y82mqEXiKqAU7PWL+ONfcuJulxyicwKBgAcPoohR\nSMnlpykUsEvZxa2jKPbW4zDaFeVDh/y0lgfClEwfoIQTzl4b/ucSCBtXY1XLsJdk\nYCqcwJsvl3jEvpCJ+ocOa3cQ+rBmuK5XUJE//+bzukAw2ria7OH6Ip7h9FwXlWB5\nOnd6rZqNRHiXMCIbbHGnpL+t6E0V7Sh+J1qRAoGALRlR4TpW+UQvJIs5iBuF4/vg\n9iWLVOY8QoDYQ1k755EY53Q8tk3fO2ESUyV7A35zu/TQWm7z5PTFCl9R5dpWywMU\nTG7xr3tNVP7oDUN9ofN2ipB99EavN81k3co+nnWwhniJn0zHEpTq9IvGozwGuUjN\nIkiy17wHSSocTzvLDNk=\n-----END PRIVATE KEY-----\n",
+  "client_email": "test@fake-project.iam.gserviceaccount.com",
+  "client_id": "45678",
+  "auth_uri": "https://fake.auth.url.com/o/oauth2/auth",
+  "token_uri": "https://fake.token.url.com/token",
+  "auth_provider_x509_cert_url": "https://fake.auth.provider.cert.url.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.fake.client.cert.com/robot/v1/metadata/x509/test@fake-project.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
Adds `spring.cloud.gcp.credentials.impersonated-service-account` so applications can authenticate by impersonating a target service account via Application Default Credentials, instead of provisioning static service account key files. Cloud SQL already supports this via `spring.cloud.gcp.sql.targetPrincipal` (a JDBC-URL-level setting). This PR brings the same capability to every other GCP client through the shared core Credentials model.

Fixes #3516.