### PR TITLE
fix(storage): respect configured storage host as-is

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfiguration.java
@@ -26,8 +26,6 @@ import com.google.cloud.spring.storage.GoogleStorageProtocolResolverSettings;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -91,28 +89,8 @@ public class GcpStorageAutoConfiguration { // NOSONAR squid:S1610 must be a clas
       storageOptionsBuilder.setUniverseDomain(this.universeDomain);
     }
     if (this.host != null) {
-      storageOptionsBuilder.setHost(verifyAndFetchHost(this.host));
+      storageOptionsBuilder.setHost(this.host);
     }
     return storageOptionsBuilder.build().getService();
-  }
-
-  /**
-   * Verifies and returns host in the `https://${service}.${universeDomain}/` format, following
-   * convention in com.google.cloud.ServiceOptions#getResolvedApiaryHost().
-   *
-   * @param host host provided through `spring.cloud.gcp.storage.host` property
-   * @return host formatted as `https://${service}.${universeDomain}/`
-   */
-  private String verifyAndFetchHost(String host) {
-    URL url;
-    try {
-      url = new URL(host);
-    } catch (MalformedURLException e) {
-      throw new IllegalArgumentException(
-          "Invalid host format: "
-              + host
-              + ". Please verify that the specified host follows the 'https://${service}.${universeDomain}/' format");
-    }
-    return url.getProtocol() + "://" + url.getHost() + "/";
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/storage/GcpStorageAutoConfigurationTests.java
@@ -17,7 +17,6 @@
 package com.google.cloud.spring.autoconfigure.storage;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -106,6 +105,17 @@ class GcpStorageAutoConfigurationTests {
   }
 
   @Test
+  void testHostWithPort_respectedAsIs() {
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.storage.host=http://localhost:54321")
+        .run(
+            context -> {
+              Storage storage = context.getBean("storage", Storage.class);
+              assertThat(storage.getOptions().getHost()).isEqualTo("http://localhost:54321");
+            });
+  }
+
+  @Test
   void testUniverseDomainAndHostSet() {
     this.contextRunner
         .withPropertyValues(
@@ -115,7 +125,7 @@ class GcpStorageAutoConfigurationTests {
             context -> {
               Storage storage = context.getBean("storage", Storage.class);
               assertThat(storage.getOptions().getUniverseDomain()).isEqualTo("example.com");
-              assertThat(storage.getOptions().getHost()).isEqualTo("https://storage.example.com/");
+              assertThat(storage.getOptions().getHost()).isEqualTo("https://storage.example.com");
             });
   }
 
@@ -130,17 +140,13 @@ class GcpStorageAutoConfigurationTests {
   }
 
   @Test
-  void testInvalidHost_throwsException() {
+  void testHost_respectedAsIs() {
     this.contextRunner
         .withPropertyValues("spring.cloud.gcp.storage.host=storage.example.com")
         .run(
             context -> {
-              Exception exception =
-                  assertThrows(Exception.class, () -> context.getBean("storage", Storage.class));
-              assertThat(exception).hasRootCauseInstanceOf(IllegalArgumentException.class);
-              assertThat(exception)
-                  .hasRootCauseMessage(
-                      "Invalid host format: storage.example.com. Please verify that the specified host follows the 'https://${service}.${universeDomain}/' format");
+              Storage storage = context.getBean("storage", Storage.class);
+              assertThat(storage.getOptions().getHost()).isEqualTo("storage.example.com");
             });
   }
 


### PR DESCRIPTION
GcpStorageAutoConfiguration previously rebuilt
spring.cloud.gcp.storage.host using URL#getHost(),
which dropped the port and normalized the value.

This caused emulator endpoints such as
http://localhost:54321 to become http://localhost/.

Pass the configured host directly to StorageOptions
so user-provided endpoints are preserved. When the
property is unset, the client library continues to
use its default host.

This also removes endpoint validation and trailing
slash normalization, matching the intended behavior
of respecting user-provided host values.

Fixes #4343