### PR TITLE
Fix Spanner JSON deserialization for generic field types

### DIFF
--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructAccessor.java
@@ -174,12 +174,17 @@ public class StructAccessor {
   }
 
   <T> List<T> getListJsonValue(String colName, Class<T> colType) {
+    return getListJsonValue(colName, (java.lang.reflect.Type) colType);
+  }
+
+  @SuppressWarnings("unchecked")
+  <T> List<T> getListJsonValue(String colName, java.lang.reflect.Type colType) {
     if (this.struct.getColumnType(colName).getCode() != Code.ARRAY) {
       throw new SpannerDataException(EXCEPTION_COL_NOT_ARRAY + colName);
     }
     List<String> jsonStringList = this.struct.getJsonList(colName);
     List<T> result = new ArrayList<>();
-    jsonStringList.forEach(item -> result.add(gson.fromJson(item, colType)));
+    jsonStringList.forEach(item -> result.add((T) gson.fromJson(item, colType)));
     return result;
   }
 
@@ -224,11 +229,16 @@ public class StructAccessor {
   }
 
   <T> T getSingleJsonValue(String colName, Class<T> colType) {
+    return getSingleJsonValue(colName, (java.lang.reflect.Type) colType);
+  }
+
+  @SuppressWarnings("unchecked")
+  <T> T getSingleJsonValue(String colName, java.lang.reflect.Type colType) {
     if (this.struct.isNull(colName)) {
       return null;
     }
     String jsonString = this.struct.getJson(colName);
-    return gson.fromJson(jsonString, colType);
+    return (T) gson.fromJson(jsonString, colType);
   }
 
   // TODO: change this to private in next major release

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructPropertyValueProvider.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/convert/StructPropertyValueProvider.java
@@ -20,6 +20,7 @@ import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerDataException;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentProperty;
+import java.lang.reflect.ParameterizedType;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.mapping.model.PropertyValueProvider;
@@ -112,7 +113,7 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
     Type.Code spannerColumnType = spannerPersistentProperty.getAnnotatedColumnItemType();
     if (spannerColumnType == Type.Code.JSON) {
       Object value =
-          this.structAccessor.getSingleJsonValue(colName, spannerPersistentProperty.getType());
+          this.structAccessor.getSingleJsonValue(colName, getJsonType(spannerPersistentProperty));
       return (T) value;
     }
     Object value = this.structAccessor.getSingleValue(colName);
@@ -129,7 +130,7 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
     if (spannerColumnType == Type.Code.JSON) {
       return (List<T>)
           this.structAccessor.getListJsonValue(
-              colName, spannerPersistentProperty.getColumnInnerType());
+              colName, getJsonArrayItemType(spannerPersistentProperty));
     }
     List<?> listValue = this.structAccessor.getListValue(colName);
     return listValue.stream()
@@ -146,5 +147,33 @@ class StructPropertyValueProvider implements PropertyValueProvider<SpannerPersis
             && !this.readConverter.canConvert(sourceClass, targetType))
         ? this.entityReader.read(targetType, (Struct) sourceValue, null, this.allowMissingColumns)
         : this.readConverter.convert(sourceValue, targetType);
+  }
+
+  private java.lang.reflect.Type getJsonType(SpannerPersistentProperty spannerPersistentProperty) {
+    if (spannerPersistentProperty.getField() != null) {
+      return spannerPersistentProperty.getField().getGenericType();
+    }
+    if (spannerPersistentProperty.getGetter() != null) {
+      return spannerPersistentProperty.getGetter().getGenericReturnType();
+    }
+    return spannerPersistentProperty.getType();
+  }
+
+  private java.lang.reflect.Type getJsonArrayItemType(
+      SpannerPersistentProperty spannerPersistentProperty) {
+    java.lang.reflect.Type type = getJsonType(spannerPersistentProperty);
+    if (!(type instanceof ParameterizedType)) {
+      return spannerPersistentProperty.getColumnInnerType();
+    }
+    java.lang.reflect.Type[] typeArguments = ((ParameterizedType) type).getActualTypeArguments();
+    if (typeArguments.length != 1) {
+      throw new SpannerDataException(
+          "in field '"
+              + spannerPersistentProperty.getColumnName()
+              + "': Unsupported number of type parameters found: "
+              + typeArguments.length
+              + " Only collections of exactly 1 type parameter are supported.");
+    }
+    return typeArguments[0];
   }
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/ConverterAwareMappingSpannerEntityReaderTests.java
@@ -435,6 +435,30 @@ class ConverterAwareMappingSpannerEntityReaderTests {
   }
 
   @Test
+  void readGenericJsonFieldTest() {
+    Struct row = mock(Struct.class);
+    when(row.getString("id")).thenReturn("1234");
+    when(row.getType())
+        .thenReturn(
+            Type.struct(
+                Arrays.asList(
+                    Type.StructField.of("id", Type.string()),
+                    Type.StructField.of("params", Type.json()))));
+    when(row.getColumnType("id")).thenReturn(Type.string());
+
+    when(row.getJson("params"))
+        .thenReturn("{\"genericField\":{\"p1\":\"address line\",\"p2\":\"5\"}}");
+
+    TestEntities.TestEntityGenericJson result =
+        this.spannerEntityReader.read(TestEntities.TestEntityGenericJson.class, row);
+
+    assertThat(result.id).isEqualTo("1234");
+    assertThat(result.params.genericField).isInstanceOf(TestEntities.Params.class);
+    assertThat(result.params.genericField.p1).isEqualTo("address line");
+    assertThat(result.params.genericField.p2).isEqualTo("5");
+  }
+
+  @Test
   void readArrayJsonFieldTest() {
     Struct row = mock(Struct.class);
     when(row.getString("id")).thenReturn("1234");
@@ -464,6 +488,42 @@ class ConverterAwareMappingSpannerEntityReaderTests {
 
     assertThat(result.paramsList.get(1).p1).isEqualTo("address line 2");
     assertThat(result.paramsList.get(1).p2).isEqualTo("6");
+
+    assertThat(result.paramsList.get(2)).isNull();
+  }
+
+  @Test
+  void readGenericArrayJsonFieldTest() {
+    Struct row = mock(Struct.class);
+    when(row.getString("id")).thenReturn("1234");
+    when(row.getType())
+        .thenReturn(
+            Type.struct(
+                Arrays.asList(
+                    Type.StructField.of("id", Type.string()),
+                    Type.StructField.of("paramsList", Type.array(Type.json())))));
+    when(row.getColumnType("id")).thenReturn(Type.string());
+
+    when(row.getColumnType("paramsList")).thenReturn(Type.array(Type.json()));
+    when(row.getJsonList("paramsList"))
+        .thenReturn(
+            Arrays.asList(
+                "{\"genericField\":{\"p1\":\"address line\",\"p2\":\"5\"}}",
+                "{\"genericField\":{\"p1\":\"address line 2\",\"p2\":\"6\"}}",
+                null));
+
+    TestEntities.TestEntityGenericJsonArray result =
+        this.spannerEntityReader.read(TestEntities.TestEntityGenericJsonArray.class, row);
+
+    assertThat(result.id).isEqualTo("1234");
+
+    assertThat(result.paramsList.get(0).genericField).isInstanceOf(TestEntities.Params.class);
+    assertThat(result.paramsList.get(0).genericField.p1).isEqualTo("address line");
+    assertThat(result.paramsList.get(0).genericField.p2).isEqualTo("5");
+
+    assertThat(result.paramsList.get(1).genericField).isInstanceOf(TestEntities.Params.class);
+    assertThat(result.paramsList.get(1).genericField.p1).isEqualTo("address line 2");
+    assertThat(result.paramsList.get(1).genericField.p2).isEqualTo("6");
 
     assertThat(result.paramsList.get(2)).isNull();
   }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/convert/TestEntities.java
@@ -300,6 +300,34 @@ class TestEntities {
     }
   }
 
+  /** A test class with generic Json field. */
+  @Table(name = "generic_json_test_table")
+  static class TestEntityGenericJson {
+    @PrimaryKey String id;
+
+    @Column(spannerType = TypeCode.JSON)
+    GenericParams<Params> params;
+
+    TestEntityGenericJson(String id, GenericParams<Params> params) {
+      this.id = id;
+      this.params = params;
+    }
+  }
+
+  /** A test class with generic Json Array field. */
+  @Table(name = "generic_jsonarray_test_table")
+  static class TestEntityGenericJsonArray {
+    @PrimaryKey String id;
+
+    @Column(spannerType = TypeCode.JSON)
+    List<GenericParams<Params>> paramsList;
+
+    TestEntityGenericJsonArray(String id, List<GenericParams<Params>> paramsList) {
+      this.id = id;
+      this.paramsList = paramsList;
+    }
+  }
+
   static class Params {
     String p1;
 
@@ -308,6 +336,14 @@ class TestEntities {
     Params(String p1, String p2) {
       this.p1 = p1;
       this.p2 = p2;
+    }
+  }
+
+  static class GenericParams<T> {
+    T genericField;
+
+    GenericParams(T genericField) {
+      this.genericField = genericField;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes Spanner JSON column deserialization for generic field types.

Previously, JSON columns were deserialized with only the raw property class, so a field like `GenericType<SimpleType>` lost its parameterized type information and Gson populated nested generic values as `LinkedTreeMap`.

This change preserves the full reflective `Type` for JSON reads and passes it to Gson.

## Changes

- Use full generic type metadata when reading single JSON columns.
- Use generic item type metadata when reading ARRAY<JSON> columns.
- Add regression coverage for:
  - `GenericParams<Params>` JSON field
  - `List<GenericParams<Params>>` JSON array field

## Verification

```cmd
.\mvnw.cmd --% -pl spring-cloud-gcp-data-spanner -am -Dtest=ConverterAwareMappingSpannerEntityReaderTests -Dsurefire.failIfNoSpecifiedTests=false test
```

Fixes #4317 