### PR TITLE
fix(native): add GraalVM serialization config for JUnit UniqueId

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/native-image/com.google.cloud/spring-cloud-gcp-autoconfigure/serialization-config.json
+++ b/spring-cloud-gcp-autoconfigure/src/main/resources/META-INF/native-image/com.google.cloud/spring-cloud-gcp-autoconfigure/serialization-config.json
@@ -1,0 +1,5 @@
+[
+  {
+    "name": "org.junit.platform.engine.UniqueId$SerializedForm"
+  }
+]


### PR DESCRIPTION
This fixes UnsupportedFeatureError during native test execution when JUnit tries to serialize UniqueId, which is common in Spring Boot 4.x native test runs.

Error:
```
Error: Exception in thread "main" com.oracle.svm.core.jdk.UnsupportedFeatureError: SerializationConstructorAccessor class not found for declaringClass: org.junit.platform.engine.UniqueId$SerializedForm (targetConstructorClass: java.lang.Object). Usually adding org.junit.platform.engine.UniqueId$SerializedForm to serialization-config.json fixes the problem.
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:121)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.serialize.SerializationSupport.getSerializationConstructorAccessor(SerializationSupport.java:286)
	at java.base@25.0.2/jdk.internal.reflect.ReflectionFactory.generateConstructor(ReflectionFactory.java:2439)
	at java.base@25.0.2/jdk.internal.reflect.ReflectionFactory.newConstructorForSerialization(ReflectionFactory.java:297)
	at java.base@25.0.2/java.io.ObjectStreamClass.getSerializableConstructor(ObjectStreamClass.java:1319)
	at java.base@25.0.2/java.io.ObjectStreamClass.<init>(ObjectStreamClass.java:371)
	at java.base@25.0.2/java.io.ObjectStreamClass$Caches$1.computeValue(ObjectStreamClass.java:93)
	at java.base@25.0.2/java.io.ObjectStreamClass$Caches$1.computeValue(ObjectStreamClass.java:90)
	at java.base@25.0.2/java.io.ClassCache$1.computeValue(ClassCache.java:78)
	at java.base@25.0.2/java.io.ClassCache$1.computeValue(ClassCache.java:75)
	at java.base@25.0.2/java.lang.ClassValue.get(JavaLangSubstitutions.java:542)
	at java.base@25.0.2/java.io.ClassCache.get(ClassCache.java:89)
	at java.base@25.0.2/java.io.ObjectStreamClass.lookup(ObjectStreamClass.java:76)
	at java.base@25.0.2/java.io.ObjectStreamClass.lookup(ObjectStreamClass.java:227)
	at org.junit.platform.engine.UniqueId.<clinit>(UniqueId.java:51)
	at org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId(DiscoverySelectors.java:1199)
	at java.base@25.0.2/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214)
	at java.base@25.0.2/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1716)
	at java.base@25.0.2/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:803)
	at java.base@25.0.2/java.util.stream.ReferencePipeline$7$1FlatMap.accept(ReferencePipeline.java:293)
	at java.base@25.0.2/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214)
	at java.base@25.0.2/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:197)
	at java.base@25.0.2/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base@25.0.2/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base@25.0.2/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base@25.0.2/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base@25.0.2/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base@25.0.2/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base@25.0.2/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:723)
	at org.graalvm.junit.platform.NativeImageJUnitLauncher.getSelectors(NativeImageJUnitLauncher.java:166)
	at org.graalvm.junit.platform.NativeImageJUnitLauncher.getTestPlan(NativeImageJUnitLauncher.java:145)
	at org.graalvm.junit.platform.NativeImageJUnitLauncher.main(NativeImageJUnitLauncher.java:119)
	at java.base@25.0.2/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
```

