### PR TITLE
fix: update libraries-bom metadata URL to consolidated monorepo path

### DIFF
--- a/spring-cloud-generator/scripts/generate-steps.sh
+++ b/spring-cloud-generator/scripts/generate-steps.sh
@@ -20,7 +20,7 @@ function compute_monorepo_version() {
   libraries_bom_version=$1
   gapic_libraries_groupId='com.google.cloud'
   gapic_libraries_artifactId='gapic-libraries-bom'
-  curl -s "https://raw.githubusercontent.com/googleapis/java-cloud-bom/v$libraries_bom_version/google-cloud-bom/pom.xml" > libraries-bom-pom
+  curl -s "https://raw.githubusercontent.com/googleapis/google-cloud-java/libraries-bom/v$libraries_bom_version/java-cloud-bom/google-cloud-bom/pom.xml" > libraries-bom-pom
   monorepo_version=$(xmllint --xpath "string(//*[local-name()='dependencies']/*[local-name()='dependency'][*[local-name()='groupId']='$gapic_libraries_groupId'][*[local-name()='artifactId']='$gapic_libraries_artifactId']/*[local-name()='version'])" libraries-bom-pom)
   rm libraries-bom-pom
   echo $monorepo_version


### PR DESCRIPTION
Fixes the "Generate Spring Auto-Configurations" workflow failure by updating the metadata URL helper in `generate-steps.sh`.

*   **Root Cause**: Since `libraries-bom` version `26.85.0`, releases are hosted in the consolidated `google-cloud-java` monorepo rather than the deprecated `java-cloud-bom` repo. The script was trying to fetch the BOM POM from `java-cloud-bom` which returned 404, preventing the script from resolving the monorepo version.
*   **Fix**: Updated `compute_monorepo_version` to fetch from `raw.githubusercontent.com/googleapis/google-cloud-java/libraries-bom/v$version/java-cloud-bom/google-cloud-bom/pom.xml`.