### PR TITLE
fix: use librarian.yaml directly to resolve googleapis_commitish

### DIFF
--- a/spring-cloud-generator/scripts/generate-steps.sh
+++ b/spring-cloud-generator/scripts/generate-steps.sh
@@ -39,7 +39,7 @@ function generate_libraries_list(){
   pushd google-cloud-java || { echo "Failure: google-cloud-java folder does not exists."; exit 1; }
   git checkout "${MONOREPO_TAG}"
   # read googleapis committish used in hermetic build
-  GOOGLEAPIS_COMMITTISH=$(yq -r ".googleapis_commitish" generation_config.yaml)
+  GOOGLEAPIS_COMMITTISH=$(yq -r ".sources.googleapis.commit" librarian.yaml)
   popd || { echo "Failure in popd."; exit 1; }
 
   bash scripts/generate-library-list.sh -c $monorepo_commitish


### PR DESCRIPTION
Fixes GHA auto-configuration generation failure when running for newer releases.

*   **Root Cause**: In version `1.88.0` of `google-cloud-java` (corresponding to the target `libraries-bom` `26.85.0`), the legacy `generation_config.yaml` file has been replaced by `librarian.yaml` as part of the Librarian tool migration. The script was failing with a 404/file-not-found error because `generation_config.yaml` was missing.
*   **Fix**: Directly updated `spring-cloud-generator/scripts/generate-steps.sh` to read the `googleapis_commitish` from `.sources.googleapis.commit` in `librarian.yaml`.