### PR TITLE
fix(native): register Jackson 3 reflection config for Thymeleaf on Java 25

### DIFF
--- a/spring-cloud-gcp-core/src/main/resources/META-INF/native-image/com.google.cloud/spring-cloud-gcp-core/reflect-config.json
+++ b/spring-cloud-gcp-core/src/main/resources/META-INF/native-image/com.google.cloud/spring-cloud-gcp-core/reflect-config.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "tools.jackson.databind.json.JsonMapper",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "tools.jackson.databind.json.JsonMapper$Builder",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "tools.jackson.databind.cfg.MapperBuilder",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  }
+]

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/spring-cloud-gcp-pubsub-bus-config-sample-test/pom.xml
@@ -32,6 +32,12 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>spring-cloud-gcp-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Fixes Java 25 Native image test execution failures in sample modules using Thymeleaf.

*   **Root Cause**: The sample modules failing native tests (`kms-sample`, `vision-sample`, `secretmanager-sample`, `pubsub-bus-sample`) encounter `MissingReflectionRegistrationError` because Thymeleaf attempts to look up the Jackson 3 class `tools.jackson.databind.json.JsonMapper` and configure its builder (`JsonMapper$Builder`) reflectively. Jackson 3 is brought in by Spring Boot 4.1.0's dependencies but lacks GraalVM reflection metadata.
    During runtime execution, Thymeleaf reflectively invokes configuration methods (like `defaultDateFormat`) that are declared on `tools.jackson.databind.cfg.MapperBuilder` (the parent class of `JsonMapper$Builder`). Because this reflective invocation resolves on the declaring class `MapperBuilder`, GraalVM throws `MissingReflectionRegistrationError` unless `MapperBuilder` is also registered for reflection.
*   **Fix**: Added a GraalVM `reflect-config.json` file in the `spring-cloud-gcp-core` module that registers the Jackson 3 classes `tools.jackson.databind.json.JsonMapper`, `tools.jackson.databind.json.JsonMapper$Builder`, and `tools.jackson.databind.cfg.MapperBuilder` for reflection with all declared methods and constructors. Also added missing `spring-cloud-gcp-core` dependency in `pubsub-bus-sample-test` to ensure the configuration is present on its native image test classpath.
