### PR TITLE
fix(generator): update generate-library-list.sh to use librarian.yaml and repo-metadata.json

### DIFF
--- a/spring-cloud-generator/scripts/generate-library-list.sh
+++ b/spring-cloud-generator/scripts/generate-library-list.sh
@@ -29,54 +29,71 @@ echo "# library_name, googleapis_location, coordinates_version, monorepo_folder"
 # Note that this logic will not work for non-cloud APIs
 count=0
 
-configs=$(yq eval '.libraries[]' -o=json ./google-cloud-java/generation_config.yaml)
-# Properly format the configs as a JSON array
-# This includes adding commas between objects and wrapping everything in square brackets
-json_array="[ $(echo "$configs" | tr '\n' ' ' | sed 's/} {/}, {/g') ]"
+library_names=$(yq eval '.libraries[].name' ./google-cloud-java/librarian.yaml)
 
-# Parse each object in the JSON array
-while IFS= read -r config; do
-    # Extract library_name if present, otherwise use api_shortname
-    unique_module_name=$(echo "$config" | jq -r '.library_name // .api_shortname')
-    # Display the unique module name
-    echo "Unique Module Name: $unique_module_name"
-    distribution_name=$(echo "$config" | jq -r '.distribution_name // ""')
-    if [ -z "$distribution_name" ]; then
-      distribution_name="com.google.cloud:google-cloud-${unique_module_name}"
-    fi
-    echo "Distribution name: $distribution_name"
-    library_type=$(echo "$config" | jq -r '.library_type // "GAPIC_AUTO"') # default to GAPIC_AUTO per https://github.com/googleapis/sdk-platform-java/blob/v2.40.0/library_generation/model/library_config.py#L57
-    echo "library_type: $library_type"
-    release_level=$(echo "$config" | jq -r '.release_level // "preview"') # default to preview per https://github.com/googleapis/sdk-platform-java/blob/v2.40.0/library_generation/model/library_config.py#L58
-    echo "release_level: $release_level"
-    monorepo_folder="java/${unique_module_name}"
-    echo "monorepo folder: $monorepo_folder"
-    group_id=$(echo $distribution_name | cut -f1 -d:)
-    artifact_id=$(echo $distribution_name | cut -f2 -d:)
-    #  filter to in-scope libraries
-    if [[ $library_type != *GAPIC_AUTO* ]] ; then
-      echo "$d: non auto type: $library_type"
-      continue
-    fi
-    if [[ $group_id != "com.google.cloud" ]] ; then
-      echo "$d: group_id not in scope: $group_id"
-      continue
-    fi
-    if [[ $release_level != "stable" ]] ; then
-      echo "$d: release_level: $release_level"
-      continue
-    fi
-    # checks if library is in the manual modules exclusion list
-    if [[ $(cat ${SPRING_GENERATOR_DIR}/scripts/resources/manual_modules_exclusion_list.txt | tail -n+2 | grep $artifact_id | wc -l) -ne 0 ]] ; then
-      echo "$artifact_id is already present in manual modules."
-      continue
-    fi
-    proto_paths_stable=$(echo "$config" | yq -r '.GAPICs[] | select(.proto_path | test("/v[0-9]+$")) | .proto_path')
-    echo "proto_paths_stable : $proto_paths_stable"
-    proto_paths_latest=$(echo "$proto_paths_stable" | sort -d -r | head -n 1)
-    echo "proto_paths_latest : $proto_paths_latest"
+for name in $library_names; do
+  metadata_file="./google-cloud-java/java-${name}/.repo-metadata.json"
+  if [[ ! -f "$metadata_file" ]]; then
+    echo "Warning: metadata file missing for $name: $metadata_file"
+    continue
+  fi
+
+  config=$(cat "$metadata_file")
+  unique_module_name=$(echo "$config" | jq -r '.repo_short' | sed 's/^java-//')
+  echo "Unique Module Name: $unique_module_name"
+  
+  distribution_name=$(echo "$config" | jq -r '.distribution_name // ""')
+  if [ -z "$distribution_name" ]; then
+    distribution_name="com.google.cloud:google-cloud-${unique_module_name}"
+  fi
+  echo "Distribution name: $distribution_name"
+
+  library_type=$(echo "$config" | jq -r '.library_type // "GAPIC_AUTO"')
+  echo "library_type: $library_type"
+
+  release_level=$(echo "$config" | jq -r '.release_level // "preview"')
+  echo "release_level: $release_level"
+
+  monorepo_folder="java-${unique_module_name}"
+  echo "monorepo folder: $monorepo_folder"
+
+  group_id=$(echo $distribution_name | cut -f1 -d:)
+  artifact_id=$(echo $distribution_name | cut -f2 -d:)
+
+  # filter to in-scope libraries
+  if [[ $library_type != *GAPIC_AUTO* ]] ; then
+    echo "$name: non auto type: $library_type"
+    continue
+  fi
+  if [[ $group_id != "com.google.cloud" ]] ; then
+    echo "$name: group_id not in scope: $group_id"
+    continue
+  fi
+  if [[ $release_level != "stable" ]] ; then
+    echo "$name: release_level: $release_level"
+    continue
+  fi
+
+  # checks if library is in the manual modules exclusion list
+  if [[ $(cat ${SPRING_GENERATOR_DIR}/scripts/resources/manual_modules_exclusion_list.txt | tail -n+2 | grep $artifact_id | wc -l) -ne 0 ]] ; then
+    echo "$artifact_id is already present in manual modules."
+    continue
+  fi
+
+  # Parse proto paths from librarian.yaml
+  apis=$(yq eval '.libraries[] | select(.name == "'$name'") | .apis[].path' ./google-cloud-java/librarian.yaml)
+  proto_paths_stable=$(echo "$apis" | grep -E '/v[0-9]+$')
+  echo "proto_paths_stable : $proto_paths_stable"
+  
+  proto_paths_latest=$(echo "$proto_paths_stable" | sort -d -r | head -n 1)
+  echo "proto_paths_latest : $proto_paths_latest"
+
+  if [ -z "$proto_paths_latest" ]; then
+    echo "Warning: no stable proto paths found for $name"
+    continue
+  fi
 
   echo "$unique_module_name, $proto_paths_latest, $distribution_name, $monorepo_folder" >> $filename
   count=$((count+1))
-done < <(echo "$json_array" | jq -c '.[]')
+done
 echo "Total in-scope client libraries: $count"


### PR DESCRIPTION
Fixes the list generation failure during Auto-Configuration generation workflow after the monorepo migration to Librarian.

*   **Root Cause**: The script `spring-cloud-generator/scripts/generate-library-list.sh` was still trying to read `generation_config.yaml` from the cloned `google-cloud-java` monorepo to find active client libraries. This file was removed during the Librarian migration.
*   **Fix**: Rewrote the parsing logic in `generate-library-list.sh` to:
    1.  Parse active library names from `librarian.yaml`.
    2.  For each library, read the module's release properties (`release_level`, `library_type`, `distribution_name`) from its individual `.repo-metadata.json` file inside the monorepo.
    3.  Resolve the stable proto paths from `librarian.yaml`'s `.apis[].path` entries.