### PR TITLE
test: isolate sample databases per Java version to prevent concurrent CI flakes

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/java/com/example/MultipleDataModuleIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/java/com/example/MultipleDataModuleIntegrationTest.java
@@ -18,6 +18,10 @@ package com.example;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.google.cloud.spring.data.spanner.core.admin.SpannerDatabaseAdminTemplate;
+import com.google.cloud.spring.data.spanner.core.admin.SpannerSchemaUtils;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +38,10 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @SpringBootTest
 class MultipleDataModuleIntegrationTest {
 
+  @Autowired private SpannerDatabaseAdminTemplate spannerDatabaseAdminTemplate;
+
+  @Autowired private SpannerSchemaUtils spannerSchemaUtils;
+
   // The Spanner Repo
   @Autowired TraderRepository traderRepository;
 
@@ -43,6 +51,14 @@ class MultipleDataModuleIntegrationTest {
   @Autowired TraderService traderService;
 
   @Autowired PersonService personService;
+
+  @BeforeEach
+  void setUp() {
+    if (!this.spannerDatabaseAdminTemplate.tableExists("traders_repository")) {
+      this.spannerDatabaseAdminTemplate.executeDdlStrings(
+          List.of(this.spannerSchemaUtils.getCreateTableDdlString(Trader.class)), true);
+    }
+  }
 
   @Test
   void testMultipleModulesTogether() {

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/java/com/example/MultipleDataModuleIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/java/com/example/MultipleDataModuleIntegrationTest.java
@@ -21,8 +21,10 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import com.google.cloud.spring.data.spanner.core.admin.SpannerDatabaseAdminTemplate;
 import com.google.cloud.spring.data.spanner.core.admin.SpannerSchemaUtils;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +38,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @EnabledIfSystemProperty(named = "it.multisample", matches = "true")
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest
+@TestInstance(Lifecycle.PER_CLASS)
 class MultipleDataModuleIntegrationTest {
 
   @Autowired private SpannerDatabaseAdminTemplate spannerDatabaseAdminTemplate;
@@ -52,12 +55,10 @@ class MultipleDataModuleIntegrationTest {
 
   @Autowired PersonService personService;
 
-  @BeforeEach
-  void setUp() {
-    if (!this.spannerDatabaseAdminTemplate.tableExists("traders_repository")) {
-      this.spannerDatabaseAdminTemplate.executeDdlStrings(
-          List.of(this.spannerSchemaUtils.getCreateTableDdlString(Trader.class)), true);
-    }
+  @BeforeAll
+  void beforeAll() {
+    this.spannerDatabaseAdminTemplate.executeDdlStrings(
+        List.of(this.spannerSchemaUtils.getCreateTableDdlString(Trader.class)), true);
   }
 
   @Test

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/resources/application-test.properties
@@ -1,3 +1,4 @@
 spring.cloud.gcp.spanner.instance-id=spring-demo
 spring.cloud.gcp.spanner.database=trades
-spring.cloud.gcp.datastore.namespace=spring-demo
+spring.cloud.gcp.datastore.namespace=spring-demo-${java.specification.version}
+

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/resources/application-test.properties
@@ -1,4 +1,5 @@
 spring.cloud.gcp.spanner.instance-id=spring-demo
-spring.cloud.gcp.spanner.database=trades
+spring.cloud.gcp.spanner.database=trades_${java.specification.version}
+
 spring.cloud.gcp.datastore.namespace=spring-demo-${java.specification.version}
 

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/test/java/com/example/SpannerRepositoryMultiDatabaseIntegrationTests.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/test/java/com/example/SpannerRepositoryMultiDatabaseIntegrationTests.java
@@ -102,9 +102,12 @@ class SpannerRepositoryMultiDatabaseIntegrationTests {
 
     @Bean
     public DatabaseIdProvider databaseIdProvider(SpannerOptions spannerOptions) {
+      String javaVersion = System.getProperty("java.specification.version");
       return () ->
           DatabaseId.of(
-              spannerOptions.getProjectId(), this.instanceId, databaseFlipper ? "db1" : "db2");
+              spannerOptions.getProjectId(),
+              this.instanceId,
+              (databaseFlipper ? "db1" : "db2") + "_" + javaVersion);
     }
   }
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-repository-sample/src/test/resources/application-test.properties
@@ -1,2 +1,3 @@
 spring.cloud.gcp.spanner.instance-id=spring-demo
-spring.cloud.gcp.spanner.database=trades
+spring.cloud.gcp.spanner.database=trades_${java.specification.version}
+

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-template-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-spanner-template-sample/src/test/resources/application-test.properties
@@ -1,2 +1,3 @@
 spring.cloud.gcp.spanner.instance-id=spring-demo
-spring.cloud.gcp.spanner.database=trades
+spring.cloud.gcp.spanner.database=trades_${java.specification.version}
+

--- a/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/test/java/com/example/SpringDataR2dbcAppIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-spanner-r2dbc-samples/src/test/java/com/example/SpringDataR2dbcAppIntegrationTest.java
@@ -28,7 +28,12 @@ class SpringDataR2dbcAppIntegrationTest {
   @DynamicPropertySource
   static void registerProperties(DynamicPropertyRegistry registry) {
     registry.add("gcp.project", () -> System.getProperty("gcp.project", "spring-cloud-gcp-ci"));
-    registry.add("spanner.database", () -> System.getProperty("spanner.database", "trades"));
+    registry.add(
+        "spanner.database",
+        () ->
+            System.getProperty(
+                "spanner.database", "trades_" + System.getProperty("java.specification.version")));
+
     registry.add("spanner.instance", () -> System.getProperty("spanner.instance", "spring-demo"));
   }
 


### PR DESCRIPTION
Isolate Datastore namespaces, Spanner databases, and Cloud SQL MySQL databases per Java specification version in sample integration tests. 

This prevents parallel runs of different Java versions in GHA matrices from colliding on shared resources (which drops tables and corrupts states concurrently, causing test failures).
