### PR TITLE
test: isolate Datastore namespaces per Java version to prevent concurrent CI flakes

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/test/resources/application-test.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-datastore-sample/src/test/resources/application-test.properties
@@ -1,1 +1,2 @@
-spring.cloud.gcp.datastore.namespace=spring-demo
+spring.cloud.gcp.datastore.namespace=spring-demo-${java.specification.version}
+


### PR DESCRIPTION
Isolate Datastore namespaces per Java specification version in sample integration tests. 

This prevents parallel runs of different Java versions in GHA matrices from colliding on the same shared Datastore namespace concurrently.
