### PR TITLE
test: isolate Cloud SQL MySQL databases per Java version to prevent concurrent CI flakes

### DIFF
--- a/spring-cloud-gcp-samples/pom.xml
+++ b/spring-cloud-gcp-samples/pom.xml
@@ -239,9 +239,11 @@
 								<gcs-write-bucket>gcp-storage-bucket-sample-output</gcs-write-bucket>
 								<gcs-local-directory>/tmp/gcp_integration_tests/integration_storage_sample</gcs-local-directory>
 								<spring.cloud.gcp.sql.instance-connection-name>spring-cloud-gcp-ci:us-central1:testmysql</spring.cloud.gcp.sql.instance-connection-name>
-								<spring.cloud.gcp.sql.database-name>code_samples_test_db</spring.cloud.gcp.sql.database-name>
+								<spring.cloud.gcp.sql.database-name>code_samples_test_db_${java.specification.version}</spring.cloud.gcp.sql.database-name>
 								<spring.cloud.gcp.alloydb.instance-connection-uri>projects/spring-cloud-gcp-ci-native/locations/us-central1/clusters/testcluster/instances/testpostgres</spring.cloud.gcp.alloydb.instance-connection-uri>
 								<spring.cloud.gcp.alloydb.database-name>code_samples_test_db</spring.cloud.gcp.alloydb.database-name>
+								<spring.datasource.hikari.data-source-properties.createDatabaseIfNotExist>true</spring.datasource.hikari.data-source-properties.createDatabaseIfNotExist>
+
 							</systemPropertyVariables>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
Isolate Cloud SQL MySQL database names per Java specification version in sample integration tests, and set HikariCP property createDatabaseIfNotExist=true.

This prevents parallel runs of different Java versions in GHA matrices from dropping each other's tables and causing concurrent schema/data corruption.
