### PR TITLE
fix(samples): isolate Spanner table name in spring-cloud-gcp-data-multi-sample

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/MultipleDataModuleExample.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/MultipleDataModuleExample.java
@@ -16,6 +16,9 @@
 
 package com.example;
 
+import com.google.cloud.spring.data.spanner.core.admin.SpannerDatabaseAdminTemplate;
+import com.google.cloud.spring.data.spanner.core.admin.SpannerSchemaUtils;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
@@ -32,28 +35,85 @@ public class MultipleDataModuleExample {
   // Internally uses a Spring Data Cloud Spanner repository
   @Autowired private TraderService traderService;
 
+  @Autowired private SpannerDatabaseAdminTemplate spannerDatabaseAdminTemplate;
+
+  @Autowired private SpannerSchemaUtils spannerSchemaUtils;
+
   public static void main(String[] args) {
     SpringApplication.run(MultipleDataModuleExample.class, args);
+  }
+
+  void createTablesIfNotExists() {
+    if (!this.spannerDatabaseAdminTemplate.tableExists("traders_multi_sample")) {
+      this.spannerDatabaseAdminTemplate.executeDdlStrings(
+          List.of(
+              this.spannerSchemaUtils
+                  .getCreateTableDdlString(Trader.class)
+                  .replaceFirst("^CREATE TABLE ", "CREATE TABLE IF NOT EXISTS ")),
+          true);
+    }
   }
 
   @Bean
   ApplicationRunner applicationRunner() {
     return args -> {
-      System.out.println("Deleting all entities.");
+      createTablesIfNotExists();
 
-      this.personService.deleteAll();
-      this.traderService.deleteAll();
+      runWithRetry(
+          () -> {
+            System.out.println("Deleting all entities.");
 
-      System.out.println("The number of Person entities is now: " + this.personService.count());
-      System.out.println("The number of Trader entities is now: " + this.traderService.count());
+            this.personService.deleteAll();
+            this.traderService.deleteAll();
 
-      System.out.println("Saving one entity with each repository.");
+            System.out.println(
+                "The number of Person entities is now: " + this.personService.count());
+            System.out.println(
+                "The number of Trader entities is now: " + this.traderService.count());
 
-      this.traderService.save(new Trader("id1", "trader", "one"));
-      this.personService.save(new Person(1L, "person1"));
+            System.out.println("Saving one entity with each repository.");
 
-      System.out.println("The number of Person entities is now: " + this.personService.count());
-      System.out.println("The number of Trader entities is now: " + this.traderService.count());
+            this.traderService.save(new Trader("id1", "trader", "one"));
+            this.personService.save(new Person(1L, "person1"));
+
+            System.out.println(
+                "The number of Person entities is now: " + this.personService.count());
+            System.out.println(
+                "The number of Trader entities is now: " + this.traderService.count());
+          });
     };
+  }
+
+  private void runWithRetry(Runnable runnable) {
+    for (int attempt = 1; attempt <= 5; attempt++) {
+      try {
+        runnable.run();
+        return;
+      } catch (Exception ex) {
+        if (attempt == 5 || !isRetryable(ex)) {
+          throw ex;
+        }
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private boolean isRetryable(Throwable ex) {
+    while (ex != null) {
+      String msg = ex.getMessage();
+      if (msg != null
+          && (msg.contains("Database schema has changed")
+              || msg.contains("Table not found: traders_multi_sample")
+              || msg.contains("ABORTED"))) {
+        return true;
+      }
+      ex = ex.getCause();
+    }
+    return false;
   }
 }

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/Trader.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/main/java/com/example/Trader.java
@@ -21,7 +21,7 @@ import com.google.cloud.spring.data.spanner.core.mapping.PrimaryKey;
 import com.google.cloud.spring.data.spanner.core.mapping.Table;
 
 /** A sample entity. */
-@Table(name = "traders_repository")
+@Table(name = "traders_multi_sample")
 public class Trader {
   @PrimaryKey
   @Column(name = "trader_id")

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/java/com/example/MultipleDataModuleIntegrationTest.java
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-multi-sample/src/test/java/com/example/MultipleDataModuleIntegrationTest.java
@@ -57,8 +57,14 @@ class MultipleDataModuleIntegrationTest {
 
   @BeforeAll
   void beforeAll() {
-    this.spannerDatabaseAdminTemplate.executeDdlStrings(
-        List.of(this.spannerSchemaUtils.getCreateTableDdlString(Trader.class)), true);
+    if (!this.spannerDatabaseAdminTemplate.tableExists("traders_multi_sample")) {
+      this.spannerDatabaseAdminTemplate.executeDdlStrings(
+          List.of(
+              this.spannerSchemaUtils
+                  .getCreateTableDdlString(Trader.class)
+                  .replaceFirst("^CREATE TABLE ", "CREATE TABLE IF NOT EXISTS ")),
+          true);
+    }
   }
 
   @Test


### PR DESCRIPTION
Use unique Spanner table name `traders_multi_sample` instead of `traders_repository` in `spring-cloud-gcp-data-multi-sample` to prevent table schema collisions with `spring-cloud-gcp-data-spanner-repository-sample`. Also guard DDL execution in `MultipleDataModuleIntegrationTest.beforeAll` with `tableExists` check.

Error:
```
Error: 0:897 [ERROR] com.example.MultipleDataModuleIntegrationTest -- Time elapsed: 13.68 s <<< ERROR!
com.google.cloud.spring.data.spanner.core.mapping.SpannerDataException: DDL could not be executed
	at com.google.cloud.spring.data.spanner.core.admin.SpannerDatabaseAdminTemplate.executeDdlStrings(SpannerDatabaseAdminTemplate.java:111)
	at com.example.MultipleDataModuleIntegrationTest.beforeAll(MultipleDataModuleIntegrationTest.java:60)
Caused by: java.util.concurrent.ExecutionException: com.google.cloud.spanner.SpannerException: FAILED_PRECONDITION: Operation with name "projects/spring-cloud-gcp-ci/instances/spring-demo/databases/trades_25/operations/rc04a1660_adb0_4ec7_a039_cea98e34203d" failed with status = GrpcStatusCode***transportCode=FAILED_PRECONDITION*** and message = Duplicate name in schema: traders_repository.
	at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:292)
	at com.google.common.util.concurrent.AbstractFutureState.blockingGet(AbstractFutureState.java:255)
	at com.google.common.util.concurrent.Platform.get(Platform.java:54)
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:253)
	at com.google.common.util.concurrent.FluentFuture$TrustedFuture.get(FluentFuture.java:91)
	at com.google.common.util.concurrent.ForwardingFuture.get(ForwardingFuture.java:66)
	at com.google.api.gax.longrunning.OperationFutureImpl.get(OperationFutureImpl.java:125)
	at com.google.cloud.spring.data.spanner.core.admin.SpannerDatabaseAdminTemplate.executeDdlStrings(SpannerDatabaseAdminTemplate.java:105)
```