### PR TITLE
docs(samples): Remove usage of MySQL57Dialect from Spring Boot 3.x+

### DIFF
--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/pom.xml
@@ -31,6 +31,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
+		<!-- Required if uncommenting and using legacy community dialects (e.g. MySQL57Dialect) -->
 		<dependency>
 			<groupId>org.hibernate.orm</groupId>
 			<artifactId>hibernate-community-dialects</artifactId>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/pom.xml
@@ -31,6 +31,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.hibernate.orm</groupId>
+			<artifactId>hibernate-community-dialects</artifactId>
+		</dependency>
 
 		<!-- Cloud SQL (MySQL) Starter -->
 		<dependency>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/main/resources/application.properties
@@ -2,7 +2,12 @@ spring.cloud.gcp.sql.instance-connection-name=
 spring.cloud.gcp.sql.database-name=
 
 spring.jpa.hibernate.ddl-auto=create-drop
-spring.jpa.database-platform=org.hibernate.community.dialect.MySQL57Dialect
+
+# By default, omitting spring.jpa.database-platform allows Hibernate 6 to auto-detect the connected
+# MySQL server version via JDBC metadata and use the modern MySQL dialect with modern DDL and type mappings.
+# Uncomment the line below if connecting to a legacy MySQL 5.7 instance or retaining older Hibernate 5
+# compatibility behavior.
+#spring.jpa.database-platform=org.hibernate.community.dialect.MySQL57Dialect
 
 # Leave empty for root, uncomment and fill out if you specified a user
 #spring.datasource.username=

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/main/resources/application.properties
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-data-jpa-sample/src/main/resources/application.properties
@@ -2,6 +2,7 @@ spring.cloud.gcp.sql.instance-connection-name=
 spring.cloud.gcp.sql.database-name=
 
 spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.community.dialect.MySQL57Dialect
 
 # Leave empty for root, uncomment and fill out if you specified a user
 #spring.datasource.username=


### PR DESCRIPTION
Spring Boot 3.x+ by default uses Hibernate 3.x+ which allow for auto detecting the mysql version. This allows it to use a modern dialect and not use an potentially unsupported/ legacy dialect

Issue:
1. On MySQL in Hibernate 6, AUTO generates sequence emulation (house_seq table) rather than a simple AUTO_INCREMENT table. 
2. If an automated DDL statement fails against an external MySQL database, Hibernate does not execute and the DDL is executed against a missing table.