### PR TITLE
docs: update maintenance versions reference in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,8 +15,8 @@ Google Cloud Reference Documentation:
 // {x-version-update-start:spring-cloud-gcp:released}
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/8.0.5/reference/html/index.html[Spring Framework on Google Cloud 8.0.5 (Latest)]
 // {x-version-update-end}
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.4.8/reference/html/index.html[Spring Framework on Google Cloud 7.4.8]
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.5.8/reference/html/index.html[Spring Framework on Google Cloud 6.5.8]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.4.10/reference/html/index.html[Spring Framework on Google Cloud 7.4.10]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.5.10/reference/html/index.html[Spring Framework on Google Cloud 6.5.10]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/5.13.11/reference/html/index.html[Spring Framework on Google Cloud 5.13.11]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/4.11.3/reference/html/index.html[Spring Framework on Google Cloud 4.11.3]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/3.9.17/reference/html/index.html[Spring Framework on Google Cloud 3.9.17]


### PR DESCRIPTION
Updates version references for 7.x and 6.x branches in README.adoc to 7.4.10 and 6.5.10 respectively.