### PR TITLE
config: raise Renovate hourly and concurrent PR limits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,8 @@
 	"extends": [
 		"config:recommended"
 	],
+	"prHourlyLimit": 10,
+	"prConcurrentLimit": 20,
 	"ignorePaths": [
 		".kokoro/requirements.txt"
 	],


### PR DESCRIPTION
Raises Renovate rate limits to prHourlyLimit=10 and prConcurrentLimit=20 to prevent bottlenecks during dependency upgrades and release pipelines, while protecting CI concurrency resources.