### PR TITLE
chore(deps): group renovate dependencies to reduce rate-limits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -75,5 +75,3 @@
 		"dependencies"
 	]
 }
-
-

--- a/renovate.json
+++ b/renovate.json
@@ -17,9 +17,63 @@
 			"major": {
 				"enabled": false
 			}
+		},
+		{
+			"matchPackagePatterns": [
+				"^org\\.apache\\.maven\\.plugins:",
+				"^org\\.codehaus\\.mojo:",
+				"^com\\.coveo:fmt-maven-plugin"
+			],
+			"groupName": "Maven Plugins"
+		},
+		{
+			"matchPackagePatterns": [
+				"^org\\.graalvm\\."
+			],
+			"groupName": "GraalVM Dependencies"
+		},
+		{
+			"matchPackagePatterns": [
+				"^org\\.junit",
+				"^org\\.mockito:",
+				"^org\\.awaitility:",
+				"^org\\.hamcrest:"
+			],
+			"groupName": "Test Dependencies"
+		},
+		{
+			"matchPackagePatterns": [
+				"^org\\.springframework"
+			],
+			"groupName": "Spring Dependencies"
+		},
+		{
+			"matchPackagePatterns": [
+				"^com\\.google\\.protobuf:"
+			],
+			"groupName": "Protobuf Dependencies"
+		},
+		{
+			"matchPackagePatterns": [
+				"^io\\.grpc:"
+			],
+			"groupName": "gRPC Dependencies"
+		},
+		{
+			"matchPackagePatterns": [
+				"^com\\.google\\.cloud:",
+				"^com\\.google\\.cloud\\.sql:",
+				"^com\\.google\\.auth:",
+				"^com\\.google\\.api-common:",
+				"^com\\.google\\.api\\.grpc:",
+				"^com\\.google\\.api:"
+			],
+			"groupName": "Google Cloud Dependencies"
 		}
 	],
 	"labels": [
 		"dependencies"
 	]
 }
+
+


### PR DESCRIPTION
Groups Renovate dependencies to reduce the number of PRs and rate-limits. Fixes #4564.