### PR TITLE
feat(spanner): support select for update

### DIFF
--- a/docs/src/main/asciidoc/spanner.adoc
+++ b/docs/src/main/asciidoc/spanner.adoc
@@ -1081,6 +1081,42 @@ Parameters can also be of type `Struct` or POJOs.
 If a POJO is given as a parameter, it will be converted to a `Struct` with the same type-conversion logic as used to create write mutations.
 Comparisons using Struct parameters are limited to https://cloud.google.com/spanner/docs/data-types#limited-comparisons-for-struct[what is available with Cloud Spanner].
 
+==== Locking rows with `FOR UPDATE`
+
+For workloads with high write contention, a query can acquire exclusive locks by setting
+`forUpdate = true` on the `@Query` annotation.
+The annotation can be used with a derived query without specifying a SQL string:
+
+[source,java]
+----
+public interface TradeRepository extends SpannerRepository<Trade, Key> {
+
+	@Query(forUpdate = true)
+	Optional<Trade> findBySymbol(String symbol);
+}
+----
+
+To retrieve an entity by its ID with exclusive locks, use `findByIdForUpdate`:
+
+[source,java]
+----
+@Transactional(transactionManager = "spannerTransactionManager")
+public void updateTrade(Key tradeId) {
+	Trade trade = tradeRepository.findByIdForUpdate(tradeId).orElseThrow();
+	trade.setAction("SELL");
+	tradeRepository.save(trade);
+}
+----
+
+Both forms must be executed in a read-write transaction.
+The generated queries also apply `FOR UPDATE` when loading eager or lazy interleaved children.
+For programmatic queries with `SpannerTemplate`, set `forUpdate` on `SpannerQueryOptions`.
+
+`FOR UPDATE` can reduce transaction aborts when concurrent transactions read and update the same
+data, but conflicting transactions wait for the locks and can therefore reduce throughput.
+See https://cloud.google.com/spanner/docs/use-select-for-update[Use SELECT FOR UPDATE] for details
+and restrictions.
+
 
 ==== Query methods by convention
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerQueryOptions.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerQueryOptions.java
@@ -30,6 +30,8 @@ import org.springframework.util.Assert;
  */
 public class SpannerQueryOptions extends AbstractSpannerRequestOptions<QueryOption> {
 
+  private boolean forUpdate;
+
   /**
    * Constructor to create an instance. Use the extension-style add/set functions to add options and
    * settings.
@@ -41,6 +43,22 @@ public class SpannerQueryOptions extends AbstractSpannerRequestOptions<QueryOpti
   public SpannerQueryOptions addQueryOption(QueryOption queryOption) {
     Assert.notNull(queryOption, "Valid query option is required!");
     this.requestOptions.add(queryOption);
+    return this;
+  }
+
+  public boolean isForUpdate() {
+    return this.forUpdate;
+  }
+
+  /**
+   * Sets whether the query should acquire exclusive locks on the selected rows. Cloud Spanner only
+   * supports {@code FOR UPDATE} in read-write transactions.
+   *
+   * @param forUpdate whether {@code FOR UPDATE} is enabled
+   * @return this options instance
+   */
+  public SpannerQueryOptions setForUpdate(boolean forUpdate) {
+    this.forUpdate = forUpdate;
     return this;
   }
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerTemplate.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/core/SpannerTemplate.java
@@ -291,8 +291,10 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
     return query(
         entityClass,
         SpannerStatementQueryExecutor.buildStatementFromSqlWithArgs(
-            SpannerStatementQueryExecutor.applySortingPagingQueryOptions(
-                entityClass, options, sql, this.mappingContext, false),
+            SpannerStatementQueryExecutor.applyForUpdate(
+                SpannerStatementQueryExecutor.applySortingPagingQueryOptions(
+                    entityClass, options, sql, this.mappingContext, false),
+                options.isForUpdate()),
             null,
             null,
             null,
@@ -502,6 +504,10 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
   }
 
   public ResultSet executeQuery(Statement statement, SpannerQueryOptions options) {
+    if (options != null && options.isForUpdate() && !isReadWriteTransactionActive()) {
+      throw new SpannerDataException(
+          "FOR UPDATE queries must be executed in a read-write transaction.");
+    }
     ResultSet resultSet = performQuery(statement, options);
     if (LOGGER.isDebugEnabled()) {
       String message;
@@ -640,7 +646,8 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
         executeQuery(statement, options),
         entityClass,
         (options != null) ? options.getIncludeProperties() : null,
-        options != null && options.isAllowPartialRead());
+        options != null && options.isAllowPartialRead(),
+        options != null && options.isForUpdate());
   }
 
   private <T> List<T> mapToListAndResolveChildren(
@@ -648,20 +655,36 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
       Class<T> entityClass,
       Set<String> includeProperties,
       boolean allowMissingColumns) {
+    return mapToListAndResolveChildren(
+        resultSet, entityClass, includeProperties, allowMissingColumns, false);
+  }
+
+  private <T> List<T> mapToListAndResolveChildren(
+      ResultSet resultSet,
+      Class<T> entityClass,
+      Set<String> includeProperties,
+      boolean allowMissingColumns,
+      boolean forUpdate) {
     return resolveChildEntities(
         this.spannerEntityProcessor.mapToList(
             resultSet, entityClass, includeProperties, allowMissingColumns),
-        includeProperties);
+        includeProperties,
+        forUpdate);
   }
 
   private <T> List<T> resolveChildEntities(List<T> entities, Set<String> includeProperties) {
+    return resolveChildEntities(entities, includeProperties, false);
+  }
+
+  private <T> List<T> resolveChildEntities(
+      List<T> entities, Set<String> includeProperties, boolean forUpdate) {
     for (Object entity : entities) {
-      resolveChildEntity(entity, includeProperties);
+      resolveChildEntity(entity, includeProperties, forUpdate);
     }
     return entities;
   }
 
-  private void resolveChildEntity(Object entity, Set<String> includeProperties) {
+  private void resolveChildEntity(Object entity, Set<String> includeProperties, boolean forUpdate) {
     SpannerPersistentEntity<?> spannerPersistentEntity =
         this.mappingContext.getPersistentEntityOrFail(entity.getClass());
 
@@ -675,7 +698,7 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
           // an interleaved property can only be List
           List propertyValue = (List) accessor.getProperty(spannerPersistentProperty);
           if (propertyValue != null) {
-            resolveChildEntities(propertyValue, null);
+            resolveChildEntities(propertyValue, null, forUpdate);
             return;
           }
           Class<?> childType = spannerPersistentProperty.getColumnInnerType();
@@ -688,8 +711,9 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
                           this.spannerSchemaUtils.getKey(entity),
                           spannerPersistentProperty,
                           this.spannerEntityProcessor.getWriteConverter(),
-                          this.mappingContext),
-                      null);
+                          this.mappingContext,
+                          forUpdate),
+                      new SpannerQueryOptions().setForUpdate(forUpdate));
 
           accessor.setProperty(
               spannerPersistentProperty,
@@ -716,6 +740,10 @@ public class SpannerTemplate implements SpannerOperations, ApplicationEventPubli
       }
     }
     return null;
+  }
+
+  private boolean isReadWriteTransactionActive() {
+    return this instanceof ReadWriteTransactionSpannerTemplate || getTransactionContext() != null;
   }
 
   private <A> A doWithOrWithoutTransactionContext(

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/SpannerRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/SpannerRepository.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spring.data.spanner.repository;
 
 import com.google.cloud.spring.data.spanner.core.SpannerOperations;
+import java.util.Optional;
 import java.util.function.Function;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -58,4 +59,13 @@ public interface SpannerRepository<T, I>
    * @return the final result of the transaction.
    */
   <A> A performReadOnlyTransaction(Function<SpannerRepository<T, I>, A> operations);
+
+  /**
+   * Retrieves an entity by its id and acquires exclusive locks on the selected row and its
+   * interleaved children. This method must be called in a read-write transaction.
+   *
+   * @param id the entity id
+   * @return the entity, or empty if none was found
+   */
+  Optional<T> findByIdForUpdate(I id);
 }

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/PartTreeSpannerQuery.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/PartTreeSpannerQuery.java
@@ -65,7 +65,8 @@ public class PartTreeSpannerQuery<T> extends AbstractSpannerQuery<T> {
           paramAccessor,
           getQueryMethod().getQueryMethod().getParameters(),
           this.spannerTemplate,
-          this.spannerMappingContext);
+          this.spannerMappingContext,
+          false);
     }
     if (this.tree.isDelete()) {
       return this.spannerTemplate.performReadWriteTransaction(getDeleteFunction(parameters));
@@ -76,7 +77,8 @@ public class PartTreeSpannerQuery<T> extends AbstractSpannerQuery<T> {
         paramAccessor,
         getQueryMethod().getQueryMethod().getParameters(),
         this.spannerTemplate,
-        this.spannerMappingContext);
+        this.spannerMappingContext,
+        this.queryMethod.isForUpdate());
   }
 
   private Function<SpannerTemplate, List> getDeleteFunction(Object[] parameters) {
@@ -90,7 +92,8 @@ public class PartTreeSpannerQuery<T> extends AbstractSpannerQuery<T> {
               paramAccessor,
               getQueryMethod().getQueryMethod().getParameters(),
               transactionTemplate,
-              this.spannerMappingContext);
+              this.spannerMappingContext,
+              false);
       transactionTemplate.deleteAll(entitiesToDelete);
 
       List result = null;

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/Query.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/Query.java
@@ -53,4 +53,12 @@ public @interface Query {
    *     method is executed as a DML query.
    */
   boolean dmlStatement() default false;
+
+  /**
+   * Indicates if the query should acquire exclusive locks on the selected rows. This option is
+   * valid only for select queries executed in a read-write transaction.
+   *
+   * @return {@code true} if {@code FOR UPDATE} should be applied.
+   */
+  boolean forUpdate() default false;
 }

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryMethod.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryMethod.java
@@ -85,4 +85,9 @@ public class SpannerQueryMethod extends QueryMethod {
   Query getQueryAnnotation() {
     return AnnotatedElementUtils.findMergedAnnotation(this.queryMethod, Query.class);
   }
+
+  boolean isForUpdate() {
+    Query query = getQueryAnnotation();
+    return query != null && query.forUpdate();
+  }
 }

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryExecutor.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryExecutor.java
@@ -22,6 +22,7 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.ValueBinder;
 import com.google.cloud.spring.data.spanner.core.SpannerPageableQueryOptions;
+import com.google.cloud.spring.data.spanner.core.SpannerQueryOptions;
 import com.google.cloud.spring.data.spanner.core.SpannerTemplate;
 import com.google.cloud.spring.data.spanner.core.convert.ConversionUtils;
 import com.google.cloud.spring.data.spanner.core.convert.ConverterAwareMappingSpannerEntityWriter;
@@ -87,8 +88,26 @@ public final class SpannerStatementQueryExecutor {
       Parameter[] queryMethodParamsMetadata,
       SpannerTemplate spannerTemplate,
       SpannerMappingContext spannerMappingContext) {
+    return executeQuery(
+        type,
+        tree,
+        parameterAccessor,
+        queryMethodParamsMetadata,
+        spannerTemplate,
+        spannerMappingContext,
+        false);
+  }
+
+  public static <T> List<T> executeQuery(
+      Class<T> type,
+      PartTree tree,
+      ParameterAccessor parameterAccessor,
+      Parameter[] queryMethodParamsMetadata,
+      SpannerTemplate spannerTemplate,
+      SpannerMappingContext spannerMappingContext,
+      boolean forUpdate) {
     SqlStringAndPlaceholders sqlStringAndPlaceholders =
-        buildPartTreeSqlString(tree, spannerMappingContext, type, parameterAccessor);
+        buildPartTreeSqlString(tree, spannerMappingContext, type, parameterAccessor, forUpdate);
     Map<String, Parameter> paramMetadataMap =
         preparePartTreeSqlTagParameterMap(queryMethodParamsMetadata, sqlStringAndPlaceholders);
     Object[] params = StreamSupport.stream(parameterAccessor.spliterator(), false).toArray();
@@ -101,7 +120,7 @@ public final class SpannerStatementQueryExecutor {
             spannerTemplate.getSpannerEntityProcessor().getWriteConverter(),
             params,
             paramMetadataMap),
-        null);
+        new SpannerQueryOptions().setForUpdate(forUpdate));
   }
 
   private static Map<String, Parameter> preparePartTreeSqlTagParameterMap(
@@ -143,8 +162,28 @@ public final class SpannerStatementQueryExecutor {
       Parameter[] queryMethodParamsMetadata,
       SpannerTemplate spannerTemplate,
       SpannerMappingContext spannerMappingContext) {
+    return executeQuery(
+        rowFunc,
+        type,
+        tree,
+        parameterAccessor,
+        queryMethodParamsMetadata,
+        spannerTemplate,
+        spannerMappingContext,
+        false);
+  }
+
+  public static <A, T> List<A> executeQuery(
+      Function<Struct, A> rowFunc,
+      Class<T> type,
+      PartTree tree,
+      ParameterAccessor parameterAccessor,
+      Parameter[] queryMethodParamsMetadata,
+      SpannerTemplate spannerTemplate,
+      SpannerMappingContext spannerMappingContext,
+      boolean forUpdate) {
     SqlStringAndPlaceholders sqlStringAndPlaceholders =
-        buildPartTreeSqlString(tree, spannerMappingContext, type, parameterAccessor);
+        buildPartTreeSqlString(tree, spannerMappingContext, type, parameterAccessor, forUpdate);
     Map<String, Parameter> paramMetadataMap =
         preparePartTreeSqlTagParameterMap(queryMethodParamsMetadata, sqlStringAndPlaceholders);
     Object[] params = StreamSupport.stream(parameterAccessor.spliterator(), false).toArray();
@@ -157,7 +196,22 @@ public final class SpannerStatementQueryExecutor {
             spannerTemplate.getSpannerEntityProcessor().getWriteConverter(),
             params,
             paramMetadataMap),
-        null);
+        new SpannerQueryOptions().setForUpdate(forUpdate));
+  }
+
+  /**
+   * Appends {@code FOR UPDATE} to a select query when requested.
+   *
+   * @param sql SQL query
+   * @param forUpdate whether locking is requested
+   * @return the resulting SQL query
+   */
+  public static String applyForUpdate(String sql, boolean forUpdate) {
+    return forUpdate
+            && !sql.regionMatches(
+                true, sql.length() - "FOR UPDATE".length(), "FOR UPDATE", 0, "FOR UPDATE".length())
+        ? sql + " FOR UPDATE"
+        : sql;
   }
 
   /**
@@ -196,7 +250,9 @@ public final class SpannerStatementQueryExecutor {
         mappingContext.getPersistentEntityOrFail(entityClass);
 
     final String subquery =
-        fetchInterleaved ? getChildrenSubquery(persistentEntity, mappingContext) : "";
+        fetchInterleaved
+            ? getChildrenSubquery(persistentEntity, mappingContext, options.isForUpdate())
+            : "";
     final String alias = subquery.isEmpty() ? "" : " " + persistentEntity.tableName();
     StringBuilder sb =
         applySort(
@@ -248,12 +304,28 @@ public final class SpannerStatementQueryExecutor {
       SpannerPersistentProperty spannerPersistentProperty,
       SpannerCustomConverter writeConverter,
       SpannerMappingContext mappingContext) {
+    return getChildrenRowsQuery(
+        parentKey, spannerPersistentProperty, writeConverter, mappingContext, false);
+  }
+
+  public static Statement getChildrenRowsQuery(
+      Key parentKey,
+      SpannerPersistentProperty spannerPersistentProperty,
+      SpannerCustomConverter writeConverter,
+      SpannerMappingContext mappingContext,
+      boolean forUpdate) {
     Class<?> childType = spannerPersistentProperty.getColumnInnerType();
     SpannerPersistentEntity<?> persistentEntity =
         mappingContext.getPersistentEntityOrFail(childType);
     String whereClause = getWhere(spannerPersistentProperty, persistentEntity);
     return buildQuery(
-        KeySet.singleKey(parentKey), persistentEntity, writeConverter, mappingContext, whereClause);
+        KeySet.singleKey(parentKey),
+        persistentEntity,
+        writeConverter,
+        mappingContext,
+        whereClause,
+        null,
+        forUpdate);
   }
 
   /**
@@ -298,7 +370,8 @@ public final class SpannerStatementQueryExecutor {
       SpannerCustomConverter writeConverter,
       SpannerMappingContext mappingContext,
       String whereClause) {
-    return buildQuery(keySet, persistentEntity, writeConverter, mappingContext, whereClause, null);
+    return buildQuery(
+        keySet, persistentEntity, writeConverter, mappingContext, whereClause, null, false);
   }
 
   /**
@@ -325,6 +398,18 @@ public final class SpannerStatementQueryExecutor {
       SpannerMappingContext mappingContext,
       String whereClause,
       String index) {
+    return buildQuery(
+        keySet, persistentEntity, writeConverter, mappingContext, whereClause, index, false);
+  }
+
+  public static <T> Statement buildQuery(
+      KeySet keySet,
+      SpannerPersistentEntity<T> persistentEntity,
+      SpannerCustomConverter writeConverter,
+      SpannerMappingContext mappingContext,
+      String whereClause,
+      String index,
+      boolean forUpdate) {
     List<String> orParts = new ArrayList<>();
     List<String> tags = new ArrayList<>();
     List keyParts = new ArrayList();
@@ -349,12 +434,13 @@ public final class SpannerStatementQueryExecutor {
     String condition = combineWithAnd(keyClause, whereClause);
     String sb =
         "SELECT "
-            + getColumnsStringForSelect(persistentEntity, mappingContext, true)
+            + getColumnsStringForSelect(persistentEntity, mappingContext, true, forUpdate)
             + " FROM "
             + (!StringUtils.hasLength(index)
                 ? persistentEntity.tableName()
                 : String.format("%s@{FORCE_INDEX=%s}", persistentEntity.tableName(), index))
-            + (condition.isEmpty() ? "" : WHERE + condition);
+            + (condition.isEmpty() ? "" : WHERE + condition)
+            + (forUpdate ? " FOR UPDATE" : "");
     return buildStatementFromSqlWithArgs(sb, tags, null, writeConverter, keyParts.toArray(), null);
   }
 
@@ -363,7 +449,8 @@ public final class SpannerStatementQueryExecutor {
       SpannerPersistentEntity<P> parentPersistentEntity,
       SpannerMappingContext mappingContext,
       String columnName,
-      String whereClause) {
+      String whereClause,
+      boolean forUpdate) {
     String tableName = childPersistentEntity.tableName();
     List<SpannerPersistentProperty> parentKeyProperties =
         parentPersistentEntity.getFlattenedPrimaryKeyProperties();
@@ -386,6 +473,7 @@ public final class SpannerStatementQueryExecutor {
         + tableName
         + WHERE
         + condition
+        + (forUpdate ? " FOR UPDATE" : "")
         + ") AS "
         + columnName;
   }
@@ -495,9 +583,18 @@ public final class SpannerStatementQueryExecutor {
       SpannerPersistentEntity<?> spannerPersistentEntity,
       SpannerMappingContext mappingContext,
       boolean fetchInterleaved) {
+    return getColumnsStringForSelect(
+        spannerPersistentEntity, mappingContext, fetchInterleaved, false);
+  }
+
+  public static String getColumnsStringForSelect(
+      SpannerPersistentEntity<?> spannerPersistentEntity,
+      SpannerMappingContext mappingContext,
+      boolean fetchInterleaved,
+      boolean forUpdate) {
     final String sql = String.join(", ", spannerPersistentEntity.columns());
     return fetchInterleaved
-        ? sql + getChildrenSubquery(spannerPersistentEntity, mappingContext)
+        ? sql + getChildrenSubquery(spannerPersistentEntity, mappingContext, forUpdate)
         : sql;
   }
 
@@ -519,7 +616,9 @@ public final class SpannerStatementQueryExecutor {
   }
 
   private static String getChildrenSubquery(
-      SpannerPersistentEntity<?> spannerPersistentEntity, SpannerMappingContext mappingContext) {
+      SpannerPersistentEntity<?> spannerPersistentEntity,
+      SpannerMappingContext mappingContext,
+      boolean forUpdate) {
     StringJoiner joiner = new StringJoiner(", ", ", ", "").setEmptyValue("");
     spannerPersistentEntity.doWithInterleavedProperties(
         spannerPersistentProperty -> {
@@ -533,7 +632,8 @@ public final class SpannerStatementQueryExecutor {
                     spannerPersistentEntity,
                     mappingContext,
                     spannerPersistentProperty.getColumnName(),
-                    getWhere(spannerPersistentProperty, childPersistentEntity)));
+                    getWhere(spannerPersistentProperty, childPersistentEntity),
+                    forUpdate));
           }
         });
     return joiner.toString();
@@ -543,14 +643,15 @@ public final class SpannerStatementQueryExecutor {
       PartTree tree,
       SpannerMappingContext spannerMappingContext,
       Class type,
-      ParameterAccessor params) {
+      ParameterAccessor params,
+      boolean forUpdate) {
 
     SpannerPersistentEntity<?> persistentEntity =
         spannerMappingContext.getPersistentEntityOrFail(type);
     List<String> tags = new ArrayList<>();
     StringBuilder stringBuilder = new StringBuilder();
 
-    buildSelect(persistentEntity, tree, stringBuilder, spannerMappingContext);
+    buildSelect(persistentEntity, tree, stringBuilder, spannerMappingContext, forUpdate);
     buildFrom(persistentEntity, stringBuilder);
     buildWhere(tree, persistentEntity, tags, stringBuilder);
     applySort(
@@ -558,6 +659,9 @@ public final class SpannerStatementQueryExecutor {
         stringBuilder,
         persistentEntity);
     buildLimit(tree, stringBuilder, params.getPageable());
+    if (!(tree.isCountProjection() || tree.isExistsProjection())) {
+      stringBuilder.append(forUpdate ? " FOR UPDATE" : "");
+    }
 
     String selectSql = stringBuilder.toString();
 
@@ -575,7 +679,8 @@ public final class SpannerStatementQueryExecutor {
       SpannerPersistentEntity<?> spannerPersistentEntity,
       PartTree tree,
       StringBuilder stringBuilder,
-      SpannerMappingContext mappingContext) {
+      SpannerMappingContext mappingContext,
+      boolean forUpdate) {
     stringBuilder
         .append("SELECT ")
         .append(tree.isDistinct() ? "DISTINCT " : "")
@@ -583,7 +688,8 @@ public final class SpannerStatementQueryExecutor {
             getColumnsStringForSelect(
                 spannerPersistentEntity,
                 mappingContext,
-                !(tree.isExistsProjection() || tree.isCountProjection())))
+                !(tree.isExistsProjection() || tree.isCountProjection()),
+                forUpdate))
         .append(" ");
   }
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQuery.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/query/SqlSpannerQuery.java
@@ -196,6 +196,9 @@ public class SqlSpannerQuery<T> extends AbstractSpannerQuery<T> {
 
   @Override
   public List executeRawResult(Object[] parameters) {
+    if (this.isDml && this.queryMethod.isForUpdate()) {
+      throw new SpannerDataException("FOR UPDATE cannot be used with a DML query.");
+    }
 
     ParameterAccessor paramAccessor =
         new ParametersParameterAccessor(getQueryMethod().getParameters(), parameters);
@@ -219,6 +222,7 @@ public class SqlSpannerQuery<T> extends AbstractSpannerQuery<T> {
   private List executeReadSql(Pageable pageable, Sort sort, QueryTagValue queryTagValue) {
     SpannerPageableQueryOptions spannerQueryOptions =
         new SpannerPageableQueryOptions().setAllowPartialRead(true);
+    spannerQueryOptions.setForUpdate(this.queryMethod.isForUpdate());
 
     if (sort != null && sort.isSorted()) {
       spannerQueryOptions.setSort(sort);
@@ -239,6 +243,9 @@ public class SqlSpannerQuery<T> extends AbstractSpannerQuery<T> {
             queryTagValue.sql,
             this.spannerMappingContext,
             entity != null && entity.hasEagerlyLoadedProperties());
+    queryTagValue.sql =
+        SpannerStatementQueryExecutor.applyForUpdate(
+            queryTagValue.sql, spannerQueryOptions.isForUpdate());
 
     Statement statement = buildStatementFromQueryAndTags(queryTagValue);
 

--- a/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
+++ b/spring-cloud-gcp-data-spanner/src/main/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepository.java
@@ -20,8 +20,11 @@ import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spring.data.spanner.core.SpannerOperations;
 import com.google.cloud.spring.data.spanner.core.SpannerPageableQueryOptions;
+import com.google.cloud.spring.data.spanner.core.SpannerQueryOptions;
 import com.google.cloud.spring.data.spanner.core.SpannerTemplate;
+import com.google.cloud.spring.data.spanner.core.mapping.SpannerPersistentEntity;
 import com.google.cloud.spring.data.spanner.repository.SpannerRepository;
+import com.google.cloud.spring.data.spanner.repository.query.SpannerStatementQueryExecutor;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Function;
@@ -94,6 +97,27 @@ public class SimpleSpannerRepository<T, I> implements SpannerRepository<T, I> {
     Assert.notNull(id, NON_NULL_ID_REQUIRED);
     T result = this.spannerTemplate.read(this.entityType, toKey(id));
     return Optional.<T>ofNullable(result);
+  }
+
+  @Override
+  public Optional<T> findByIdForUpdate(I id) {
+    Assert.notNull(id, NON_NULL_ID_REQUIRED);
+    SpannerPersistentEntity<?> persistentEntity =
+        this.spannerTemplate.getMappingContext().getPersistentEntityOrFail(this.entityType);
+    return this.spannerTemplate
+        .query(
+            this.entityType,
+            SpannerStatementQueryExecutor.buildQuery(
+                KeySet.singleKey(toKey(id)),
+                persistentEntity,
+                this.spannerTemplate.getSpannerEntityProcessor().getWriteConverter(),
+                this.spannerTemplate.getMappingContext(),
+                persistentEntity.getWhere(),
+                null,
+                true),
+            new SpannerQueryOptions().setForUpdate(true))
+        .stream()
+        .findFirst();
   }
 
   @Override

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerSortPageQueryOptionsTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerSortPageQueryOptionsTests.java
@@ -55,4 +55,13 @@ class SpannerSortPageQueryOptionsTests {
     spannerQueryOptions.addQueryOption(r1).addQueryOption(r2);
     assertThat(Arrays.asList(spannerQueryOptions.getOptions())).containsExactlyInAnyOrder(r1, r2);
   }
+
+  @Test
+  void forUpdateTest() {
+    SpannerQueryOptions spannerQueryOptions = new SpannerQueryOptions();
+
+    assertThat(spannerQueryOptions.isForUpdate()).isFalse();
+    assertThat(spannerQueryOptions.setForUpdate(true)).isSameAs(spannerQueryOptions);
+    assertThat(spannerQueryOptions.isForUpdate()).isTrue();
+  }
 }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/core/SpannerTemplateTests.java
@@ -56,6 +56,7 @@ import com.google.cloud.spring.data.spanner.core.mapping.Column;
 import com.google.cloud.spring.data.spanner.core.mapping.Embedded;
 import com.google.cloud.spring.data.spanner.core.mapping.Interleaved;
 import com.google.cloud.spring.data.spanner.core.mapping.PrimaryKey;
+import com.google.cloud.spring.data.spanner.core.mapping.SpannerDataException;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.cloud.spring.data.spanner.core.mapping.Table;
 import com.google.cloud.spring.data.spanner.core.mapping.Where;
@@ -511,6 +512,18 @@ class SpannerTemplateTests {
         () -> assertThat(this.spannerTemplate.query(TestEntity.class, query, null)).isEmpty(),
         x -> {});
     verify(this.databaseClient, times(1)).singleUse();
+  }
+
+  @Test
+  void forUpdateQueryRequiresReadWriteTransactionTest() {
+    assertThatThrownBy(
+            () ->
+                this.spannerTemplate.query(
+                    TestEntity.class,
+                    Statement.of("SELECT * FROM custom_test_table FOR UPDATE"),
+                    new SpannerQueryOptions().setForUpdate(true)))
+        .isInstanceOf(SpannerDataException.class)
+        .hasMessage("FOR UPDATE queries must be executed in a read-write transaction.");
   }
 
   @Test

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerQueryLookupStrategyTests.java
@@ -93,6 +93,11 @@ class SpannerQueryLookupStrategyTests {
               public boolean dmlStatement() {
                 return false;
               }
+
+              @Override
+              public boolean forUpdate() {
+                return false;
+              }
             });
   }
 

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/query/SpannerStatementQueryTests.java
@@ -33,6 +33,7 @@ import com.google.cloud.spring.data.spanner.core.SpannerTemplate;
 import com.google.cloud.spring.data.spanner.core.convert.SpannerEntityProcessor;
 import com.google.cloud.spring.data.spanner.core.convert.SpannerWriteConverter;
 import com.google.cloud.spring.data.spanner.core.mapping.Column;
+import com.google.cloud.spring.data.spanner.core.mapping.Interleaved;
 import com.google.cloud.spring.data.spanner.core.mapping.PrimaryKey;
 import com.google.cloud.spring.data.spanner.core.mapping.SpannerMappingContext;
 import com.google.cloud.spring.data.spanner.core.mapping.Table;
@@ -294,6 +295,52 @@ class SpannerStatementQueryTests {
   }
 
   @Test
+  void forUpdateDerivedQueryTest() throws NoSuchMethodException {
+    when(this.queryMethod.getName()).thenReturn("findById");
+    when(this.queryMethod.isForUpdate()).thenReturn(true);
+    Method method = QueryHolder.class.getMethod("repositoryMethod10", String.class);
+    when(this.queryMethod.getQueryMethod()).thenReturn(method);
+    doReturn(new DefaultParameters(ParametersSource.of(method)))
+        .when(this.queryMethod)
+        .getParameters();
+    this.partTreeSpannerQuery = spy(createQuery());
+
+    when(this.spannerTemplate.query((Class) any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              Statement statement = invocation.getArgument(1);
+              assertThat(statement.getSql())
+                  .isEqualTo(
+                      "SELECT shares, trader_id, ticker, price, action, id, value, uuid "
+                          + "FROM trades WHERE ( id=@tag0 ) FOR UPDATE");
+              return Collections.emptyList();
+            });
+
+    doReturn(Object.class).when(this.partTreeSpannerQuery).getReturnedSimpleConvertableItemType();
+    doReturn(null).when(this.partTreeSpannerQuery).convertToSimpleReturnType(any(), any());
+
+    this.partTreeSpannerQuery.execute(new Object[] {"id"});
+  }
+
+  @Test
+  void forUpdateLocksEagerInterleavedChildrenTest() {
+    SpannerMappingContext mappingContext = new SpannerMappingContext();
+    Statement statement =
+        SpannerStatementQueryExecutor.buildQuery(
+            com.google.cloud.spanner.KeySet.singleKey(com.google.cloud.spanner.Key.of("parent")),
+            mappingContext.getPersistentEntityOrFail(Parent.class),
+            new SpannerWriteConverter(),
+            mappingContext,
+            null,
+            null,
+            true);
+
+    assertThat(statement.getSql())
+        .contains("FROM children WHERE children.id = parents.id FOR UPDATE")
+        .endsWith("WHERE (id = @tag0) FOR UPDATE");
+  }
+
+  @Test
   void uuidUntypedBindingTest() throws NoSuchMethodException {
     when(this.queryMethod.getName()).thenReturn("findByUuid");
     this.partTreeSpannerQuery = spy(createQuery());
@@ -552,6 +599,22 @@ class SpannerStatementQueryTests {
     java.util.UUID uuid;
   }
 
+  @Table(name = "parents")
+  private static class Parent {
+    @PrimaryKey String id;
+
+    @Interleaved List<Child> children;
+  }
+
+  @Table(name = "children")
+  private static class Child {
+    @PrimaryKey(keyOrder = 1)
+    String id;
+
+    @PrimaryKey(keyOrder = 2)
+    String childId;
+  }
+
   // The methods in this class are used to emulate repository methods
   private static class QueryHolder {
     public long repositoryMethod1(
@@ -615,6 +678,10 @@ class SpannerStatementQueryTests {
     }
 
     public long repositoryMethod9(List<java.util.UUID> tag0) {
+      return 0;
+    }
+
+    public long repositoryMethod10(String tag0) {
       return 0;
     }
   }

--- a/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepositoryTests.java
+++ b/spring-cloud-gcp-data-spanner/src/test/java/com/google/cloud/spring/data/spanner/repository/support/SimpleSpannerRepositoryTests.java
@@ -103,6 +103,16 @@ class SimpleSpannerRepositoryTests {
   }
 
   @Test
+  void findForUpdateNullIdTest() {
+    SimpleSpannerRepository spannerRepository =
+        new SimpleSpannerRepository<Object, Key>(this.template, Object.class);
+
+    assertThatThrownBy(() -> spannerRepository.findByIdForUpdate(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("A non-null ID is required.");
+  }
+
+  @Test
   void existsNullIdTest() {
 
     SimpleSpannerRepository spannerRepository =


### PR DESCRIPTION
## Problem

`SpannerRepository.findById()` uses Spanner's Read API, which cannot express a
`FOR UPDATE` clause. Custom SQL can lock the parent entity, but eagerly loaded
interleaved children are fetched through expression subqueries and are not
locked by an outer `FOR UPDATE` clause. Lazy interleaved child queries also did
not inherit locking options.

This can cause excessive transaction aborts when concurrent read-write
transactions read and update the same entity.

Fixes #3984.

## Solution

This change adds opt-in `FOR UPDATE` support for Spring Data Spanner:

- Adds `@Query(forUpdate = true)` for derived and custom repository queries.
- Adds `SpannerRepository.findByIdForUpdate(...)`.
- Adds `SpannerQueryOptions.setForUpdate(true)` for programmatic queries.
- Applies `FOR UPDATE` to generated parent queries and eager interleaved-child
  expression subqueries.
- Propagates locking to lazy interleaved-child queries.
- Rejects locking queries outside read-write transactions.
- Rejects combining `forUpdate` with DML queries.
- Documents the new APIs, transaction requirement, and contention trade-offs.

## Testing

Added unit coverage for:

- Derived-query SQL generation.
- Eager interleaved-child locking.
- Query option behavior.
- `findByIdForUpdate` validation.
- Rejection outside read-write transactions.
- Existing query and repository behavior.

Targeted test result:

- 96 tests run.
- 0 failures.
- 0 errors.

Maven compilation and validation also complete successfully.