### PR TITLE
docs: update compatibility matrix to include Spring Boot 4.1.x

### DIFF
--- a/.agents/skills/spring-cloud-gcp-release/SKILL.md
+++ b/.agents/skills/spring-cloud-gcp-release/SKILL.md
@@ -168,7 +168,7 @@ Update Spring Initializr with the new Spring Cloud GCP version:
 Update the version reference in `README.adoc`:
 *   **If releasing `main` branch**:
     1.  Update the version strings in `README.adoc` with the newly released version (ensuring **both** the version URL path and the bracketed display label text are updated).
-        *   *Compatibility Matrix Check*: If the release adds or upgrades Spring Boot / Spring Cloud version support, update the compatibility table in **both** `README.adoc` and `docs/src/main/asciidoc/getting-started.adoc` (ensuring no spaces between link text brackets, e.g. `...Release-Notes[4.0.x], ...Release-Notes[4.1.x]`).
+        *   *Compatibility Matrix Check*: To determine if the release adds or upgrades Spring Boot / Spring Cloud version support, compare the `spring-boot-dependencies.version` and `spring-cloud-dependencies.version` properties in the root `pom.xml` against the current compatibility table. If the release updates a major or minor version line (e.g. `4.0.x` to `4.1.x`), update the compatibility table in **both** `README.adoc` and `docs/src/main/asciidoc/getting-started.adoc` (ensuring no spaces between link text brackets, e.g. `...Release-Notes[4.0.x], ...Release-Notes[4.1.x]`). If only a patch version was updated (e.g. `4.0.1` to `4.0.2`), no compatibility table change is required.
     2.  Create a local branch `docs-update-readme-<TIMESTAMP>`.
     3.  Commit the change:
         ```bash
@@ -190,7 +190,7 @@ Update the version reference in `README.adoc`:
         ```
     2.  Create a local branch `docs-update-readme-<VERSION>`.
     3.  Update the version string of the released maintenance branch in `README.adoc` (e.g. update `7.4.8` to `7.4.10` in both the links list URL path and bracketed display label text).
-        *   *Compatibility Matrix Check*: If the release adds or upgrades Spring Boot / Spring Cloud version support, update the compatibility table in **both** `README.adoc` and `docs/src/main/asciidoc/getting-started.adoc`.
+        *   *Compatibility Matrix Check*: To determine if the release adds or upgrades Spring Boot / Spring Cloud version support, compare the `spring-boot-dependencies.version` and `spring-cloud-dependencies.version` properties in the root `pom.xml` against the current compatibility table. If the release updates a major or minor version line (e.g. `4.0.x` to `4.1.x`), update the compatibility table in **both** `README.adoc` and `docs/src/main/asciidoc/getting-started.adoc`. If only a patch version was updated (e.g. `4.0.1` to `4.0.2`), no compatibility table change is required.
     4.  Commit the change:
         ```bash
         git commit -m "docs: update README for release <VERSION>"

--- a/.agents/skills/spring-cloud-gcp-release/SKILL.md
+++ b/.agents/skills/spring-cloud-gcp-release/SKILL.md
@@ -167,7 +167,8 @@ Update Spring Initializr with the new Spring Cloud GCP version:
 ### Step 8: Update README.adoc
 Update the version reference in `README.adoc`:
 *   **If releasing `main` branch**:
-    1.  Update the version strings in `README.adoc` with the newly released version.
+    1.  Update the version strings in `README.adoc` with the newly released version (ensuring **both** the version URL path and the bracketed display label text are updated).
+        *   *Compatibility Matrix Check*: If the release adds or upgrades Spring Boot / Spring Cloud version support, update the compatibility table in **both** `README.adoc` and `docs/src/main/asciidoc/getting-started.adoc` (ensuring no spaces between link text brackets, e.g. `...Release-Notes[4.0.x], ...Release-Notes[4.1.x]`).
     2.  Create a local branch `docs-update-readme-<TIMESTAMP>`.
     3.  Commit the change:
         ```bash
@@ -188,7 +189,8 @@ Update the version reference in `README.adoc`:
         git pull upstream main
         ```
     2.  Create a local branch `docs-update-readme-<VERSION>`.
-    3.  Update the version string of the released maintenance branch in `README.adoc` (e.g. update `7.4.8` to `7.4.10` in the links list).
+    3.  Update the version string of the released maintenance branch in `README.adoc` (e.g. update `7.4.8` to `7.4.10` in both the links list URL path and bracketed display label text).
+        *   *Compatibility Matrix Check*: If the release adds or upgrades Spring Boot / Spring Cloud version support, update the compatibility table in **both** `README.adoc` and `docs/src/main/asciidoc/getting-started.adoc`.
     4.  Commit the change:
         ```bash
         git commit -m "docs: update README for release <VERSION>"

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ For a deep dive into the project, refer to the Spring Framework on Google Cloud 
 Google Cloud Reference Documentation:
 
 // {x-version-update-start:spring-cloud-gcp:released}
-* link:https://googlecloudplatform.github.io/spring-cloud-gcp/8.1.0/reference/html/index.html[Spring Framework on Google Cloud 8.0.5 (Latest)]
+* link:https://googlecloudplatform.github.io/spring-cloud-gcp/8.1.0/reference/html/index.html[Spring Framework on Google Cloud 8.1.0 (Latest)]
 // {x-version-update-end}
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/7.4.10/reference/html/index.html[Spring Framework on Google Cloud 7.4.10]
 * link:https://googlecloudplatform.github.io/spring-cloud-gcp/6.5.10/reference/html/index.html[Spring Framework on Google Cloud 6.5.10]
@@ -63,8 +63,8 @@ This project has dependency and transitive dependencies on Spring Projects. The 
 
 |8.x
 |https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2025.1-Release-Notes[2025.1.x] (Oakwood)
-|https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes [4.0.x]
-|https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-7.0-Release-Notes [7.0.0 or above]
+|https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes[4.0.x], https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.1-Release-Notes[4.1.x]
+|https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-7.0-Release-Notes[7.0.0 or above]
 |Yes
 
 |7.x

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -9,6 +9,7 @@ Spring Framework on Google Cloud has dependency and transitive dependencies on S
 | Spring Framework on Google Cloud | Spring Cloud | Spring Boot | Spring Framework | Supported
 
 
+|8.x |https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2025.1-Release-Notes[2025.1.x] (Oakwood)|https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes[4.0.x], https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.1-Release-Notes[4.1.x]|https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-7.0-Release-Notes[7.0.0+]|Yes
 |7.x |https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2025.0-Release-Notes[2025.0.x] (Moorgate)|https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes[3.5.x]|https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.2-Release-Notes[6.2.8+]|Yes
 |6.x |https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2024.0-Release-Notes[2024.0.x] (Moorgate)|https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Release-Notes[3.4.x]|https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.2-Release-Notes[6.2.0+]|Yes
 |5.x | https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2023.0-Release-Notes[2023.0.x] (Leyton) |https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.2-Release-Notes[3.2.x]*, https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.3-Release-Notes[3.3.x]


### PR DESCRIPTION
Updates README.adoc and getting-started.adoc to include Spring Boot 4.1.x compatibility under the 8.x release line.