### PR TITLE
test: clean up gRPC channel leaks and fix Java 8 Mockito compatibility

### DIFF
--- a/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
+++ b/spring-cloud-gcp-bigquery/src/test/java/com/google/cloud/spring/bigquery/BigQueryTemplateTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.bigquery.BigQuery;
@@ -103,7 +104,7 @@ class BigQueryTemplateTest {
     bigqueryRpcMock = mock(HttpBigQueryRpc.class);
     when(rpcFactoryMock.create(any(BigQueryOptions.class))).thenReturn(bigqueryRpcMock);
     options = createBigQueryOptionsForProject(rpcFactoryMock);
-    bigQueryWriteClientMock = mock(BigQueryWriteClient.class);
+    bigQueryWriteClientMock = mock(BigQueryWriteClient.class, withSettings().withoutAnnotations());
     bigquery = options.getService();
     bqInitSettings.put("DATASET_NAME", DATASET);
     bqInitSettings.put("JSON_WRITER_BATCH_SIZE", JSON_WRITER_BATCH_SIZE);

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/DefaultDatastoreEntityConverterTests.java
@@ -51,6 +51,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.convert.ConversionFailedException;
@@ -92,6 +93,13 @@ class DefaultDatastoreEntityConverterTests {
   void setUp() {
     this.datastore =
         HELPER.getOptions().toBuilder().setNamespace("ghijklmnop").build().getService();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (this.datastore != null) {
+      this.datastore.close();
+    }
   }
 
   @Test
@@ -966,7 +974,8 @@ class DefaultDatastoreEntityConverterTests {
     assertThatThrownBy(() -> ENTITY_CONVERTER.read(StringIdEntity.class, testEntity))
         .isInstanceOf(ConversionFailedException.class)
         .hasStackTraceContaining(
-            "The given key doesn't have a String name value but a conversion to String was attempted");
+            "The given key doesn't have a String name value but a conversion to String was"
+                + " attempted");
   }
 
   private Entity.Builder getEntityBuilder() {

--- a/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/EntityPropertyValueProviderTests.java
+++ b/spring-cloud-gcp-data-datastore/src/test/java/com/google/cloud/spring/data/datastore/core/convert/EntityPropertyValueProviderTests.java
@@ -29,6 +29,7 @@ import com.google.cloud.spring.data.datastore.core.mapping.DatastoreDataExceptio
 import com.google.cloud.spring.data.datastore.core.mapping.DatastoreMappingContext;
 import com.google.cloud.spring.data.datastore.core.mapping.DatastorePersistentEntity;
 import com.google.cloud.spring.data.datastore.core.mapping.DatastorePersistentProperty;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +53,13 @@ class EntityPropertyValueProviderTests {
   void setUp() {
     this.datastore =
         HELPER.getOptions().toBuilder().setNamespace("ghijklmnop").build().getService();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (this.datastore != null) {
+      this.datastore.close();
+    }
   }
 
   @Test

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/PubSubAdminTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/PubSubAdminTests.java
@@ -75,7 +75,10 @@ class PubSubAdminTests {
 
   @Test
   void testNewPubSubAdmin() throws IOException {
-    assertThat(new PubSubAdmin(() -> "test-project", NoCredentials::getInstance)).isNotNull();
+    try (PubSubAdmin pubSubAdmin =
+        new PubSubAdmin(() -> "test-project", NoCredentials::getInstance)) {
+      assertThat(pubSubAdmin).isNotNull();
+    }
   }
 
   @Test
@@ -318,13 +321,14 @@ class PubSubAdminTests {
 
   @Test
   void testDefaultAckDeadline() throws IOException {
-    PubSubAdmin psa = new PubSubAdmin(() -> "test-project", NoCredentials::getInstance);
-    int defaultAckDeadline = psa.getDefaultAckDeadline();
-    psa.setDefaultAckDeadline(defaultAckDeadline + 1);
-    assertThat(psa.getDefaultAckDeadline()).isEqualTo(defaultAckDeadline + 1);
+    try (PubSubAdmin psa = new PubSubAdmin(() -> "test-project", NoCredentials::getInstance)) {
+      int defaultAckDeadline = psa.getDefaultAckDeadline();
+      psa.setDefaultAckDeadline(defaultAckDeadline + 1);
+      assertThat(psa.getDefaultAckDeadline()).isEqualTo(defaultAckDeadline + 1);
 
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> psa.setDefaultAckDeadline(PubSubAdmin.MIN_ACK_DEADLINE_SECONDS - 1));
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(() -> psa.setDefaultAckDeadline(PubSubAdmin.MIN_ACK_DEADLINE_SECONDS - 1));
+    }
   }
 
   @Test

--- a/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberTemplateTests.java
+++ b/spring-cloud-gcp-pubsub/src/test/java/com/google/cloud/spring/pubsub/core/subscriber/PubSubSubscriberTemplateTests.java
@@ -22,12 +22,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.rpc.UnaryCallable;
@@ -100,7 +102,7 @@ class PubSubSubscriberTemplateTests {
   @Captor
   private ArgumentCaptor<ConvertedBasicAcknowledgeablePubsubMessage<Boolean>> convertedMessage;
 
-  @Mock private SubscriberStub subscriberStub;
+  private SubscriberStub subscriberStub;
 
   @Mock private UnaryCallable<PullRequest, PullResponse> pullCallable;
 
@@ -114,6 +116,7 @@ class PubSubSubscriberTemplateTests {
 
   @BeforeEach
   void setUp() throws ExecutionException, InterruptedException {
+    this.subscriberStub = mock(SubscriberStub.class, withSettings().withoutAnnotations());
     reset(this.subscriberFactory);
     reset(this.subscriberStub);
     reset(this.subscriber);


### PR DESCRIPTION
- Close Datastore instances in DefaultDatastoreEntityConverterTests and EntityPropertyValueProviderTests via @AfterEach teardown to prevent ManagedChannel leaks.
- Close PubSubAdmin in try-with-resources blocks in PubSubAdminTests to clean up TopicAdminClient and SubscriptionAdminClient gRPC channels.
- Configure withoutAnnotations() for BigQueryWriteClient and SubscriberStub mocks to resolve Java 8 Mockito ArrayStoreException caused by JSpecify annotations targeting ElementType.MODULE.