### PR TITLE
deps: bump libraries-bom to 26.87.0 and fix preview starter annotations

### DIFF
--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -34,11 +34,13 @@
 	</distributionManagement>
 
 	<properties>
-		<gcp-libraries-bom.version>26.76.0</gcp-libraries-bom.version>
+		<gcp-libraries-bom.version>26.87.0</gcp-libraries-bom.version>
 		<cloud-sql-socket-factory.version>1.23.1</cloud-sql-socket-factory.version>
 		<r2dbc-postgres-driver.version>1.0.7.RELEASE</r2dbc-postgres-driver.version>
 		<cloud-spanner-r2dbc.version>1.3.0</cloud-spanner-r2dbc.version>
 		<alloydb-jdbc-connector.version>1.2.0</alloydb-jdbc-connector.version>
+		<!-- Manually manage version since it was removed from libraries-bom after 26.86.0 -->
+		<google-cloud-datacatalog.version>1.101.0</google-cloud-datacatalog.version>
 	</properties>
 
 	<dependencyManagement>
@@ -304,6 +306,16 @@
 				<groupId>io.opentelemetry</groupId>
 				<artifactId>opentelemetry-api</artifactId>
 				<version>1.47.0</version>
+			</dependency>
+			<dependency>
+				<groupId>javax.annotation</groupId>
+				<artifactId>javax.annotation-api</artifactId>
+				<version>1.3.2</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.cloud</groupId>
+				<artifactId>google-cloud-datacatalog</artifactId>
+				<version>${google-cloud-datacatalog.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -41,6 +41,8 @@
 		<alloydb-jdbc-connector.version>1.2.0</alloydb-jdbc-connector.version>
 		<!-- Manually manage version since it was removed from libraries-bom after 26.86.0 -->
 		<google-cloud-datacatalog.version>1.101.0</google-cloud-datacatalog.version>
+		<!-- Pin dataplex on 5.x LTS to preserve ContentServiceClient compatibility -->
+		<google-cloud-dataplex.version>1.83.0</google-cloud-dataplex.version>
 	</properties>
 
 	<dependencyManagement>
@@ -316,6 +318,21 @@
 				<groupId>com.google.cloud</groupId>
 				<artifactId>google-cloud-datacatalog</artifactId>
 				<version>${google-cloud-datacatalog.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.cloud</groupId>
+				<artifactId>google-cloud-dataplex</artifactId>
+				<version>${google-cloud-dataplex.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.api.grpc</groupId>
+				<artifactId>grpc-google-cloud-dataplex-v1</artifactId>
+				<version>${google-cloud-dataplex.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.api.grpc</groupId>
+				<artifactId>proto-google-cloud-dataplex-v1</artifactId>
+				<version>${google-cloud-dataplex.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-gcp-starters/pom.xml
+++ b/spring-cloud-gcp-starters/pom.xml
@@ -19,6 +19,12 @@
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+		</dependency>
+	</dependencies>
 	<modules>
 		<module>spring-cloud-gcp-starter</module>
 		<module>spring-cloud-gcp-starter-bus-pubsub</module>


### PR DESCRIPTION
### Description

This PR resolves compilation failures with `@javax.annotation.Generated` and decommissioned GAPIC classes in preview starters when bumping `com.google.cloud:libraries-bom` past `26.76.0` (to `26.87.0`).

- Bump `com.google.cloud:libraries-bom` to `26.87.0` in `spring-cloud-gcp-dependencies/pom.xml`.
- Manage `javax.annotation:javax.annotation-api:1.3.2` under `dependencyManagement` in `spring-cloud-gcp-dependencies/pom.xml`.
- Add `javax.annotation:javax.annotation-api` as a shared dependency in `spring-cloud-gcp-starters/pom.xml` so that all preview starters inherit it at compile time (consistent with `6.x`, `7.x`, and `main`).
- Add manual version management for `com.google.cloud:google-cloud-datacatalog:1.101.0` in `spring-cloud-gcp-dependencies/pom.xml` (removed from upstream BOM in `26.87.0`).
- Pin `com.google.cloud:google-cloud-dataplex` (and its grpc/proto artifacts) to `1.83.0` in `spring-cloud-gcp-dependencies/pom.xml` under `dependencyManagement` to preserve backwards compatibility with `ContentServiceClient` on this LTS maintenance branch.