### PR TITLE
refactor: extract Firestore emulator credentials to separate emulator package

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/emulator/FirestoreEmulatorCredentials.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/emulator/FirestoreEmulatorCredentials.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spring.autoconfigure.emulator;
+
+import com.google.auth.Credentials;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Custom credentials provider used when connecting to a local Firestore emulator.
+ */
+public class FirestoreEmulatorCredentials extends Credentials {
+
+  private final Map<String, List<String>> headerMap;
+
+  /**
+   * Constructs emulator credentials targeting the specified root resource path.
+   *
+   * @param rootPath the Firestore root database path
+   */
+  public FirestoreEmulatorCredentials(String rootPath) {
+    this.headerMap = new HashMap<>();
+    this.headerMap.put("Authorization", Collections.singletonList("Bearer owner"));
+    this.headerMap.put(
+        "google-cloud-resource-prefix",
+        Collections.singletonList(rootPath.substring(0, rootPath.lastIndexOf("/documents"))));
+  }
+
+  @Override
+  public String getAuthenticationType() {
+    return null;
+  }
+
+  @Override
+  public Map<String, List<String>> getRequestMetadata(URI uri) {
+    return this.headerMap;
+  }
+
+  @Override
+  public boolean hasRequestMetadata() {
+    return true;
+  }
+
+  @Override
+  public boolean hasRequestMetadataOnly() {
+    return true;
+  }
+
+  @Override
+  public void refresh() {
+    // no-op
+  }
+}

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/FirestoreRepositoriesAutoConfigureRegistrar.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/FirestoreRepositoriesAutoConfigureRegistrar.java
@@ -20,8 +20,6 @@ import com.google.cloud.spring.data.firestore.repository.config.EnableReactiveFi
 import com.google.cloud.spring.data.firestore.repository.config.FirestoreRepositoryConfigurationExtension;
 import java.lang.annotation.Annotation;
 import org.springframework.boot.autoconfigure.data.AbstractRepositoryConfigurationSourceSupport;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.data.repository.config.RepositoryConfigurationExtension;
 
 /**
@@ -47,10 +45,6 @@ public class FirestoreRepositoriesAutoConfigureRegistrar
     return new FirestoreRepositoryConfigurationExtension();
   }
 
-  @EnableReactiveFirestoreRepositories(
-      excludeFilters =
-          @ComponentScan.Filter(
-              type = FilterType.REGEX,
-              pattern = ".*GcpFirestoreEmulatorAutoConfiguration.*"))
+  @EnableReactiveFirestoreRepositories
   private static class EnableFirestoreRepositoriesConfiguration {}
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/firestore/GcpFirestoreEmulatorAutoConfiguration.java
@@ -19,6 +19,7 @@ package com.google.cloud.spring.autoconfigure.firestore;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.auth.Credentials;
 import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.spring.autoconfigure.emulator.FirestoreEmulatorCredentials;
 import com.google.cloud.spring.autoconfigure.firestore.GcpFirestoreAutoConfiguration.FirestoreReactiveAutoConfiguration;
 import com.google.cloud.spring.data.firestore.FirestoreTemplate;
 import com.google.cloud.spring.data.firestore.mapping.FirestoreClassMapper;
@@ -27,11 +28,6 @@ import com.google.firestore.v1.FirestoreGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.auth.MoreCallCredentials;
-import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -77,37 +73,7 @@ public class GcpFirestoreEmulatorAutoConfiguration {
   }
 
   private Credentials emulatorCredentials() {
-    final Map<String, List<String>> headerMap = new HashMap<>();
-    headerMap.put("Authorization", Collections.singletonList("Bearer owner"));
-    headerMap.put("google-cloud-resource-prefix", Collections.singletonList(
-        rootPath.substring(0, rootPath.lastIndexOf("/documents"))));
-
-    return new Credentials() {
-      @Override
-      public String getAuthenticationType() {
-        return null;
-      }
-
-      @Override
-      public Map<String, List<String>> getRequestMetadata(URI uri) {
-        return headerMap;
-      }
-
-      @Override
-      public boolean hasRequestMetadata() {
-        return true;
-      }
-
-      @Override
-      public boolean hasRequestMetadataOnly() {
-        return true;
-      }
-
-      @Override
-      public void refresh() {
-        // no-op
-      }
-    };
+    return new FirestoreEmulatorCredentials(this.rootPath);
   }
 
   /** Reactive Firestore autoconfiguration to enable emulator use. */


### PR DESCRIPTION
### Summary

Refactors the Firestore emulator credentials implementation in `GcpFirestoreEmulatorAutoConfiguration`:
- Moves the custom `Credentials` implementation from an anonymous inner class in `com.google.cloud.spring.autoconfigure.firestore` into `com.google.cloud.spring.autoconfigure.emulator.FirestoreEmulatorCredentials`.
- Removes the regex `excludeFilters` previously added to `FirestoreRepositoriesAutoConfigureRegistrar`.

### Rationale
In Java 8 runtimes, Spring Data's repository component scanning inspects all classes in the auto-configuration package. An anonymous inner class extending `com.google.auth.Credentials` (which now carries JSpecify 1.0.0 annotations targeting Java 9 `ElementType.MODULE`) triggered an `ArrayStoreException` on Java 8. Moving this internal credentials class to a dedicated `emulator` package prevents Spring Data from scanning it as a repository candidate without requiring any regex filters or test package modifications.

### Compatibility
Zero breaking impact. The previous class was a `private` anonymous inner class; its return type, public API, and header injection behavior (`Authorization` and `google-cloud-resource-prefix`) remain identical.