### PR TITLE
fix(deps): update spring-boot-dependencies to v4.1.1 [security]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
 		<project.parent.version>${project.version}</project.parent.version>
 		<!-- Dependency versions -->
 		<spring-cloud-dependencies.version>2025.1.2</spring-cloud-dependencies.version>
-		<spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
+		<spring-boot-dependencies.version>4.1.1</spring-boot-dependencies.version>
 		<spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
 		<zipkin-gcp.version>2.3.0</zipkin-gcp.version>
 		<java-cfenv.version>2.5.0</java-cfenv.version>
-		<micrometer-tracing.version>1.4.3</micrometer-tracing.version>
+		<micrometer-tracing.version>1.7.1</micrometer-tracing.version>
 
 		<!-- Plugin versions -->
 		<maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/spring-cloud-gcp-dependencies/pom.xml
+++ b/spring-cloud-gcp-dependencies/pom.xml
@@ -41,7 +41,7 @@
 		<cloud-spanner-r2dbc.version>1.3.0</cloud-spanner-r2dbc.version>
 		<alloydb-jdbc-connector.version>1.2.0</alloydb-jdbc-connector.version>
 		<jakarta-annotation-api.version>2.1.1</jakarta-annotation-api.version>
-		<spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
+		<spring-boot-dependencies.version>4.1.1</spring-boot-dependencies.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
## Description
Upgrades `spring-boot-dependencies` from `4.1.0` to `4.1.1` and aligns `micrometer-tracing.version` to `1.7.1`.

This update resolves 43 security vulnerabilities announced on August 20, 2026, across the Spring ecosystem:
* **Spring Security** (7 CVEs, including Critical `CVE-2026-59270` and High `CVE-2026-41707`, `CVE-2026-47841`, `CVE-2026-47877`)
* **Spring Framework** (17 CVEs, upgraded from `7.0.8` to `7.0.9`)
* **Spring Integration** (14 CVEs, upgraded from `7.1.0` to `7.1.1`)
* **Reactor Core** (2 CVEs, upgraded from `3.8.6` to `3.8.7`)
* **Micrometer & Micrometer Tracing** (3 CVEs, upgraded to `1.17.1` and `1.7.1`)

## Changes
* `pom.xml`: Bumped `spring-boot-dependencies.version` to `4.1.1` and `micrometer-tracing.version` to `1.7.1`.
* `spring-cloud-gcp-dependencies/pom.xml`: Bumped `spring-boot-dependencies.version` to `4.1.1`.

## Verification
* Full compilation of core and starter modules passed.
* Unit tests in `spring-cloud-gcp-security-iap` and `spring-cloud-gcp-security-firebase` passed against Spring Security `7.1.1`.
* Unit tests in `spring-cloud-gcp-pubsub` and `spring-cloud-gcp-storage` passed against Spring Framework `7.0.9` and Spring Integration `7.1.1`.
* `mvn checkstyle:check` passed with 0 violations.