### PR TITLE
fix(deps): update spring-cloud-dependencies to v2025.1.3 [security]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 	<properties>
 		<project.parent.version>${project.version}</project.parent.version>
 		<!-- Dependency versions -->
-		<spring-cloud-dependencies.version>2025.1.2</spring-cloud-dependencies.version>
+		<spring-cloud-dependencies.version>2025.1.3</spring-cloud-dependencies.version>
 		<spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
 		<spring-cloud-gcp-dependencies.version>${project.parent.version}</spring-cloud-gcp-dependencies.version>
 		<zipkin-gcp.version>2.3.0</zipkin-gcp.version>

--- a/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
+++ b/spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2025.1.2</version>
+                <version>2025.1.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Description
Upgrades `spring-cloud-dependencies` from `2025.1.2` to `2025.1.3`.

This update resolves the remaining 10 vulnerabilities announced on August 20, 2026, across the Spring Cloud ecosystem:
* **Spring Cloud Commons** (1 High CVE: `CVE-2026-59284`, upgraded from `5.0.2` to `5.0.3`)
* **Spring Cloud Stream** (5 CVEs, upgraded from `5.0.2` to `5.0.3`)
* **Spring Cloud Config** (4 CVEs in sample apps, upgraded from `5.0.4` to `5.0.5`)

## Changes
* `pom.xml`: Bumped `spring-cloud-dependencies.version` to `2025.1.3`.
* `spring-cloud-gcp-samples/spring-cloud-gcp-pubsub-bus-config-sample/pom.xml`: Bumped `spring-cloud-dependencies` version to `2025.1.3`.

## Verification
* Full compilation of `spring-cloud-gcp-pubsub-stream-binder`, `starter-secretmanager`, and sample modules passed.
* Unit tests in `spring-cloud-gcp-pubsub-stream-binder` passed (`14 tests run, 0 failures, 0 errors`).
* `mvn checkstyle:check` passed with 0 violations.