### PR TITLE
feat(datastore): add use-http property to configure HTTP transport

### DIFF
--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -22,6 +22,7 @@ import com.google.cloud.NoCredentials;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.DatastoreReaderWriter;
+import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
 import com.google.cloud.spring.core.DefaultCredentialsProvider;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
@@ -76,6 +77,8 @@ public class GcpDatastoreAutoConfiguration {
 
   private final String host;
 
+  private final boolean useHttp;
+
   GcpDatastoreAutoConfiguration(
       GcpDatastoreProperties gcpDatastoreProperties,
       GcpProjectIdProvider projectIdProvider,
@@ -107,6 +110,7 @@ public class GcpDatastoreAutoConfiguration {
     }
 
     this.host = hostToConnect;
+    this.useHttp = gcpDatastoreProperties.isUseHttp();
   }
 
   @Bean
@@ -193,6 +197,9 @@ public class GcpDatastoreAutoConfiguration {
             .setProjectId(this.projectId)
             .setHeaderProvider(new UserAgentHeaderProvider(this.getClass()))
             .setCredentials(this.credentials);
+    if (this.useHttp) {
+      builder.setTransportOptions(HttpTransportOptions.newBuilder().build());
+    }
     if (namespace != null) {
       builder.setNamespace(namespace);
     }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfiguration.java
@@ -77,7 +77,7 @@ public class GcpDatastoreAutoConfiguration {
 
   private final String host;
 
-  private final boolean useHttp;
+  private final boolean useHttpJson;
 
   GcpDatastoreAutoConfiguration(
       GcpDatastoreProperties gcpDatastoreProperties,
@@ -110,7 +110,7 @@ public class GcpDatastoreAutoConfiguration {
     }
 
     this.host = hostToConnect;
-    this.useHttp = gcpDatastoreProperties.isUseHttp();
+    this.useHttpJson = gcpDatastoreProperties.isUseHttpJson();
   }
 
   @Bean
@@ -197,7 +197,7 @@ public class GcpDatastoreAutoConfiguration {
             .setProjectId(this.projectId)
             .setHeaderProvider(new UserAgentHeaderProvider(this.getClass()))
             .setCredentials(this.credentials);
-    if (this.useHttp) {
+    if (this.useHttpJson) {
       builder.setTransportOptions(HttpTransportOptions.newBuilder().build());
     }
     if (namespace != null) {

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreProperties.java
@@ -49,6 +49,9 @@ public class GcpDatastoreProperties implements CredentialsSupplier {
   /** Whether skip the insertion if the value is null */
   private boolean skipNullValue;
 
+  /** Whether to use HTTP transport instead of gRPC for Cloud Datastore. */
+  private boolean useHttp;
+
   @Override
   public Credentials getCredentials() {
     return this.credentials;
@@ -96,5 +99,13 @@ public class GcpDatastoreProperties implements CredentialsSupplier {
 
   public void setSkipNullValue(boolean skipNullValue) {
     this.skipNullValue = skipNullValue;
+  }
+
+  public boolean isUseHttp() {
+    return useHttp;
+  }
+
+  public void setUseHttp(boolean useHttp) {
+    this.useHttp = useHttp;
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreProperties.java
+++ b/spring-cloud-gcp-autoconfigure/src/main/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreProperties.java
@@ -49,8 +49,8 @@ public class GcpDatastoreProperties implements CredentialsSupplier {
   /** Whether skip the insertion if the value is null */
   private boolean skipNullValue;
 
-  /** Whether to use HTTP transport instead of gRPC for Cloud Datastore. */
-  private boolean useHttp;
+  /** Whether to use HTTP/JSON transport instead of gRPC for Cloud Datastore. */
+  private boolean useHttpJson;
 
   @Override
   public Credentials getCredentials() {
@@ -101,11 +101,21 @@ public class GcpDatastoreProperties implements CredentialsSupplier {
     this.skipNullValue = skipNullValue;
   }
 
-  public boolean isUseHttp() {
-    return useHttp;
+  /**
+   * Returns whether to use HTTP/JSON transport instead of gRPC for Cloud Datastore.
+   *
+   * @return {@code true} if HTTP/JSON transport is enabled; {@code false} otherwise.
+   */
+  public boolean isUseHttpJson() {
+    return useHttpJson;
   }
 
-  public void setUseHttp(boolean useHttp) {
-    this.useHttp = useHttp;
+  /**
+   * Sets whether to use HTTP/JSON transport instead of gRPC for Cloud Datastore.
+   *
+   * @param useHttpJson {@code true} to use HTTP/JSON transport; {@code false} to use gRPC.
+   */
+  public void setUseHttpJson(boolean useHttpJson) {
+    this.useHttpJson = useHttpJson;
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
@@ -26,11 +26,13 @@ import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration;
 import com.google.cloud.spring.autoconfigure.datastore.health.DatastoreHealthIndicator;
 import com.google.cloud.spring.autoconfigure.datastore.health.DatastoreHealthIndicatorAutoConfiguration;
 import com.google.cloud.spring.core.GcpProjectIdProvider;
 import com.google.cloud.spring.data.datastore.core.DatastoreOperations;
+import com.google.cloud.spring.data.datastore.core.DatastoreTemplate;
 import com.google.cloud.spring.data.datastore.core.DatastoreTransactionManager;
 import com.google.cloud.spring.data.datastore.core.mapping.DatastoreMappingContext;
 import java.util.function.Supplier;
@@ -122,6 +124,75 @@ class GcpDatastoreAutoConfigurationTests {
           assertThat(datastoreOptions.getNamespace()).isEqualTo("testNamespace");
           assertThat(datastoreOptions.getHost()).isEqualTo("localhost:8081");
         });
+  }
+
+  @Test
+  void testDatastoreHttpTransportOption() {
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.datastore.use-http=true")
+        .run(
+            context -> {
+              DatastoreOptions datastoreOptions = getDatastoreBean(context).getOptions();
+              assertThat(datastoreOptions.getTransportOptions())
+                  .isInstanceOf(HttpTransportOptions.class);
+            });
+  }
+
+  @Test
+  void testDatastoreDefaultTransportOption() {
+    this.contextRunner.run(
+        context -> {
+          DatastoreOptions datastoreOptions = getDatastoreBean(context).getOptions();
+          assertThat(datastoreOptions.getTransportOptions())
+              .isNotInstanceOf(HttpTransportOptions.class);
+        });
+  }
+
+  @Test
+  void testDatastoreHttpTransportOptionWithExplicitFalse() {
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.datastore.use-http=false")
+        .run(
+            context -> {
+              DatastoreOptions datastoreOptions = getDatastoreBean(context).getOptions();
+              assertThat(datastoreOptions.getTransportOptions())
+                  .isNotInstanceOf(HttpTransportOptions.class);
+            });
+  }
+
+  @Test
+  void testDatastoreHttpTransportWithNamespaceProvider() {
+    ApplicationContextRunner runner =
+        new ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    GcpDatastoreAutoConfiguration.class, GcpContextAutoConfiguration.class))
+            .withUserConfiguration(TestConfigurationWithNamespaceProviderOnly.class)
+            .withPropertyValues(
+                "spring.cloud.gcp.datastore.project-id=test-project",
+                "spring.cloud.gcp.datastore.host=localhost:8081",
+                "spring.cloud.gcp.datastore.use-http=true",
+                "management.health.datastore.enabled=false");
+
+    runner.run(
+        context -> {
+          DatastoreProvider provider = context.getBean(DatastoreProvider.class);
+          assertThat(provider).isNotNull();
+          Datastore client = provider.get();
+          assertThat(client.getOptions().getTransportOptions())
+              .isInstanceOf(HttpTransportOptions.class);
+          assertThat(client.getOptions().getNamespace()).isEqualTo("dynamic-namespace");
+        });
+  }
+
+  @Test
+  void testDatastoreTemplateWithHttpTransport() {
+    this.contextRunner
+        .withPropertyValues("spring.cloud.gcp.datastore.use-http=true")
+        .run(
+            context -> {
+              assertThat(context.getBean(DatastoreTemplate.class)).isNotNull();
+            });
   }
 
   @Test
@@ -260,6 +331,21 @@ class GcpDatastoreAutoConfigurationTests {
     @Bean
     public DatastoreNamespaceProvider datastoreNamespaceProvider() {
       return () -> "blah";
+    }
+  }
+
+  /** Spring Boot config for tests with only DatastoreNamespaceProvider. */
+  @Configuration
+  static class TestConfigurationWithNamespaceProviderOnly {
+
+    @Bean
+    public CredentialsProvider credentialsProvider() {
+      return () -> NoCredentials.getInstance();
+    }
+
+    @Bean
+    public DatastoreNamespaceProvider datastoreNamespaceProvider() {
+      return () -> "dynamic-namespace";
     }
   }
 }

--- a/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
+++ b/spring-cloud-gcp-autoconfigure/src/test/java/com/google/cloud/spring/autoconfigure/datastore/GcpDatastoreAutoConfigurationTests.java
@@ -127,9 +127,9 @@ class GcpDatastoreAutoConfigurationTests {
   }
 
   @Test
-  void testDatastoreHttpTransportOption() {
+  void testDatastoreHttpJsonTransportOption() {
     this.contextRunner
-        .withPropertyValues("spring.cloud.gcp.datastore.use-http=true")
+        .withPropertyValues("spring.cloud.gcp.datastore.use-http-json=true")
         .run(
             context -> {
               DatastoreOptions datastoreOptions = getDatastoreBean(context).getOptions();
@@ -149,9 +149,9 @@ class GcpDatastoreAutoConfigurationTests {
   }
 
   @Test
-  void testDatastoreHttpTransportOptionWithExplicitFalse() {
+  void testDatastoreHttpJsonTransportOptionWithExplicitFalse() {
     this.contextRunner
-        .withPropertyValues("spring.cloud.gcp.datastore.use-http=false")
+        .withPropertyValues("spring.cloud.gcp.datastore.use-http-json=false")
         .run(
             context -> {
               DatastoreOptions datastoreOptions = getDatastoreBean(context).getOptions();
@@ -161,7 +161,7 @@ class GcpDatastoreAutoConfigurationTests {
   }
 
   @Test
-  void testDatastoreHttpTransportWithNamespaceProvider() {
+  void testDatastoreHttpJsonTransportWithNamespaceProvider() {
     ApplicationContextRunner runner =
         new ApplicationContextRunner()
             .withConfiguration(
@@ -171,7 +171,7 @@ class GcpDatastoreAutoConfigurationTests {
             .withPropertyValues(
                 "spring.cloud.gcp.datastore.project-id=test-project",
                 "spring.cloud.gcp.datastore.host=localhost:8081",
-                "spring.cloud.gcp.datastore.use-http=true",
+                "spring.cloud.gcp.datastore.use-http-json=true",
                 "management.health.datastore.enabled=false");
 
     runner.run(
@@ -186,9 +186,9 @@ class GcpDatastoreAutoConfigurationTests {
   }
 
   @Test
-  void testDatastoreTemplateWithHttpTransport() {
+  void testDatastoreTemplateWithHttpJsonTransport() {
     this.contextRunner
-        .withPropertyValues("spring.cloud.gcp.datastore.use-http=true")
+        .withPropertyValues("spring.cloud.gcp.datastore.use-http-json=true")
         .run(
             context -> {
               assertThat(context.getBean(DatastoreTemplate.class)).isNotNull();


### PR DESCRIPTION
## Description
In multi-tenant applications with dynamic namespaces, creating multiple Datastore client instances over gRPC can lead to high resource and thread consumption. This change introduces the \`spring.cloud.gcp.datastore.use-http\` configuration property, allowing applications to use HTTP transport to reduce overhead.

Relates to #4597

b/549105996