### PR TITLE
build: prevent javadoc aggregate execution from running on sub-modules (#4624)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -798,6 +798,7 @@
 							</execution>
 							<execution>
 								<id>aggregate</id>
+								<inherited>false</inherited>
 								<goals>
 									<goal>aggregate-no-fork</goal>
 								</goals>


### PR DESCRIPTION
backport https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/4624